### PR TITLE
Match subsequence instead of entire input sequence.

### DIFF
--- a/src/main/java/com/networknt/schema/PatternValidator.java
+++ b/src/main/java/com/networknt/schema/PatternValidator.java
@@ -58,7 +58,7 @@ public class PatternValidator extends BaseJsonValidator implements JsonValidator
         if (p != null) {
             try {
                 Matcher m = p.matcher(node.asText());
-                if (!m.matches()) {
+                if (!m.find()) {
                     errors.add(buildValidationMessage(at, pattern));
                 }
             } catch (PatternSyntaxException pse) {

--- a/src/test/resources/tests/pattern.json
+++ b/src/test/resources/tests/pattern.json
@@ -19,5 +19,16 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "pattern is not anchored",
+        "schema": {"pattern": "a+"},
+        "tests": [
+            {
+                "description": "matches a substring",
+                "data": "xxaayy",
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Closes #6. There is the larger issue that json schema regular expressions need to use ECMA 262 regular expressions instead of Java regular expressions. I can open a separate ticket for that. I think other people are solving it by using the Rhino JS engine for Java 7 or the Nashorn JS engine for Java 8.