### PR TITLE
Switch to targeting Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.networknt</groupId>
     <artifactId>json-schema-validator</artifactId>
-    <version>0.1.4</version>
+    <version>0.1.5-SNAPSHOT</version>
     <description>A json schema validator that supports draft v4</description>
     <url>https://github.com/networknt/json-schema-validator</url>
     <name>JsonSchemaValidator</name>
@@ -63,7 +63,7 @@
     </distributionManagement>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>1.7</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.jackson>2.8.2</version.jackson>
         <version.slf4j>1.7.21</version.slf4j>


### PR DESCRIPTION
As silly as this may sound, I've still got to compile against Java 7 for Jenkins plugins, at least for a while longer. I'd *really* like to use this library in a key Jenkins plugin, but can't unless it's compiled against Java 7. I tried this locally and everything worked fine. Thanks!

(Oh, and I also bumped the version to 0.1.5-SNAPSHOT)