### PR TITLE
Don't leave out 50% of your audience who still use older java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,8 @@
     </distributionManagement>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>1.6</java.version>
+        <java.testversion>1.7</java.testversion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.jackson>2.8.7</version.jackson>
         <version.slf4j>1.7.25</version.slf4j>
@@ -206,6 +207,19 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>process-test-sources</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <source>${java.testversion}</source>
+                            <target>${java.testversion}</target>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
Only few lines in OneOfValidator.java use constructs specific to java 1.7 and 1.8. I rewrote them with older syntax.

Unfortunately, the dependencies of junit tests of this project are compiled for java 1.7, so for the tests to work out of the box in Eclipse I had to mention both versions in maven-compiler-plugin config. Eclipse picks the latest one for the project execution env.

We, personally, use java 1.7 in our project and we need this library.
