### PR TITLE
Replaced 'new URL' with a call to a new URLFactory 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.networknt</groupId>
     <artifactId>json-schema-validator</artifactId>
-    <version>0.1.10</version>
+    <version>0.1.10-escenic</version>
     <description>A json schema validator that supports draft v4</description>
     <url>https://github.com/networknt/json-schema-validator</url>
     <name>JsonSchemaValidator</name>

--- a/src/main/java/com/networknt/schema/BaseJsonValidator.java
+++ b/src/main/java/com/networknt/schema/BaseJsonValidator.java
@@ -17,6 +17,7 @@
 package com.networknt.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.networknt.schema.url.URLFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
@@ -77,8 +78,14 @@ public abstract class BaseJsonValidator implements JsonValidator {
 
         try {
             JsonSchemaFactory factory = new JsonSchemaFactory();
-            URL url = new URL(node.textValue());
-            return factory.getSchema(url);
+            String text = node.textValue();
+            if (text == null) {
+                return null;
+            }
+            else {
+                URL url = URLFactory.toURL(node.textValue());
+                return factory.getSchema(url);
+            }
         } catch (MalformedURLException e) {
             return null;
         }

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -18,6 +18,7 @@ package com.networknt.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.url.URLFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +54,7 @@ public class RefValidator extends BaseJsonValidator implements JsonValidator {
             
             JsonSchemaFactory factory = new JsonSchemaFactory(mapper);
             try {
-                URL url = new URL(schemaUrl);
+                URL url = URLFactory.toURL(schemaUrl);
                 parentSchema = factory.getSchema(url);
             } catch (MalformedURLException e) {
                 InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(schemaUrl);
@@ -89,7 +90,7 @@ public class RefValidator extends BaseJsonValidator implements JsonValidator {
 		if(schemaRef.startsWith(REF_DOMAIN)){
 			// from domain add ref
 			try {
-				URL url = new URL(baseSchemaUrl);
+				URL url = URLFactory.toURL(baseSchemaUrl);
 				baseSchemaUrl = url.getProtocol()+"//"+url.getHost();
 			} catch (MalformedURLException e) {
 				e.printStackTrace();

--- a/src/main/java/com/networknt/schema/url/ClasspathURLStreamHandler.java
+++ b/src/main/java/com/networknt/schema/url/ClasspathURLStreamHandler.java
@@ -1,0 +1,85 @@
+package com.networknt.schema.url;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+
+/**
+ * An {@link URLStreamHandler} capable of loading resources from the classpath.
+ *
+ * @author <a href="mailto:kenneth.waldenstroem@gmail.com">Kenneth Waldenstrom</a>
+ */
+class ClasspathURLStreamHandler extends URLStreamHandler {
+  private final static String CLASSPATH_PREFIX = "classpath:";
+  private final static String RESOURCE_PREFIX = "resource:";
+
+  boolean supports(final String pURL) {
+    return pURL.startsWith(CLASSPATH_PREFIX) || pURL.startsWith(RESOURCE_PREFIX);
+  }
+
+  @Override
+  protected URLConnection openConnection(final URL pURL) throws IOException {
+    return new ClassPathURLConnection(pURL);
+  }
+
+  class ClassPathURLConnection extends URLConnection {
+
+    private Class<?> mHost = null;
+
+    protected ClassPathURLConnection(URL pURL) {
+      super(pURL);
+    }
+
+    @Override
+    public final void connect() throws IOException {
+      String className = url.getHost();
+      try {
+        if (className != null && className.length() > 0) {
+          mHost = Class.forName(className);
+        }
+        connected = true;
+      }
+      catch (ClassNotFoundException e) {
+        throw new IOException("Class not found: " + e.toString());
+      }
+    }
+
+    @Override
+    public final InputStream getInputStream() throws IOException {
+      if (!connected) {
+        connect();
+      }
+      return getResourceAsStream(url);
+    }
+
+    private InputStream getResourceAsStream(URL pURL) throws IOException {
+      String path = pURL.getPath();
+
+      if (path.startsWith("/")) {
+        path = path.substring(1);
+      }
+
+      InputStream stream;
+      if (mHost != null) {
+        stream = mHost.getClassLoader().getResourceAsStream(path);
+      }
+      else {
+        stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
+        if (stream == null) {
+          stream = getClass().getClassLoader().getResourceAsStream(path);
+        }
+        if (stream == null) {
+          stream = ClassLoader.getSystemResourceAsStream(path);
+        }
+      }
+      if (stream == null) {
+        throw new IOException("Resource " + path + " not found in classpath.");
+      }
+      return stream;
+    }
+  }
+
+
+}

--- a/src/main/java/com/networknt/schema/url/URLFactory.java
+++ b/src/main/java/com/networknt/schema/url/URLFactory.java
@@ -1,0 +1,28 @@
+package com.networknt.schema.url;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * A factory for creating {@link URL}'s. This factory creates {@link URL}'s that in additional to the standard {@link URL}'s
+ * capability of loading resources using http, https, file, etc. also makes it possible to load resources from
+ * the applications classpath. To load a resource from classpath, the url must be prefixed either with <i>classpath:</i>
+ * or <i>resource:</i>
+ *
+ * To ensure that we support classpath resources, this class should be used instead of <code>new URL(pURL)</code>
+ *
+ * @author <a href="mailto:kenneth.waldenstroem@gmail.com">Kenneth Waldenstrom</a>
+ */
+public class URLFactory {
+  private static final ClasspathURLStreamHandler sClasspathURLStreamHandler = new ClasspathURLStreamHandler();
+
+  /**
+   * Creates an {@link URL} based on the provided string
+   * @param pURL the url
+   * @return a {@link URL}
+   * @throws MalformedURLException if the url is not a proper URL
+   */
+  public static URL toURL(final String pURL) throws MalformedURLException {
+    return new URL(null, pURL, sClasspathURLStreamHandler.supports(pURL) ? sClasspathURLStreamHandler : null);
+  }
+}


### PR DESCRIPTION
The original implementation supports schema's to be accessible either in http, http, file, etc.. This pull request adds the possibility to also refer to schema's present in the applications classpath. 
