### PR TITLE
Use LinkedHashSets for ValidationMessages

### DIFF
--- a/src/main/java/com/networknt/schema/AdditionalPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/AdditionalPropertiesValidator.java
@@ -66,7 +66,7 @@ public class AdditionalPropertiesValidator extends BaseJsonValidator implements 
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         if (logger.isDebugEnabled()) debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
+        Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
         if (!node.isObject()) {
             // ignore no object
             return errors;
@@ -97,7 +97,7 @@ public class AdditionalPropertiesValidator extends BaseJsonValidator implements 
                 }
             }
         }
-        return errors;
+        return Collections.unmodifiableSet(errors);
     }
 
 }

--- a/src/main/java/com/networknt/schema/AllOfValidator.java
+++ b/src/main/java/com/networknt/schema/AllOfValidator.java
@@ -22,7 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -43,13 +44,13 @@ public class AllOfValidator extends BaseJsonValidator implements JsonValidator {
         debug(logger, node, rootNode, at);
 
         int size = schemas.size();
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
+        Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
 
         for (int i = 0; i < size; i++) {
             errors.addAll(schemas.get(i).validate(node, rootNode, at));
         }
 
-        return errors;
+        return Collections.unmodifiableSet(errors);
     }
 
 }

--- a/src/main/java/com/networknt/schema/AnyOfValidator.java
+++ b/src/main/java/com/networknt/schema/AnyOfValidator.java
@@ -22,7 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -43,7 +44,7 @@ public class AnyOfValidator extends BaseJsonValidator implements JsonValidator {
         debug(logger, node, rootNode, at);
 
         int size = schemas.size();
-        Set<ValidationMessage> allErrors = new HashSet<ValidationMessage>();
+        Set<ValidationMessage> allErrors = new LinkedHashSet<ValidationMessage>();
 
         for (int i = 0; i < size; i++) {
             Set<ValidationMessage> errors = schemas.get(i).validate(node, rootNode, at);
@@ -53,7 +54,7 @@ public class AnyOfValidator extends BaseJsonValidator implements JsonValidator {
             allErrors.addAll(errors);
         }
 
-        return allErrors;
+        return Collections.unmodifiableSet(allErrors);
     }
 
 }

--- a/src/main/java/com/networknt/schema/DependenciesValidator.java
+++ b/src/main/java/com/networknt/schema/DependenciesValidator.java
@@ -55,7 +55,7 @@ public class DependenciesValidator extends BaseJsonValidator implements JsonVali
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
+        Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
 
         for (Iterator<String> it = node.fieldNames(); it.hasNext(); ) {
             String pname = it.next();
@@ -73,7 +73,7 @@ public class DependenciesValidator extends BaseJsonValidator implements JsonVali
             }
         }
 
-        return errors;
+        return Collections.unmodifiableSet(errors);
     }
 
 }

--- a/src/main/java/com/networknt/schema/EnumValidator.java
+++ b/src/main/java/com/networknt/schema/EnumValidator.java
@@ -22,7 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -57,13 +58,13 @@ public class EnumValidator extends BaseJsonValidator implements JsonValidator {
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
+        Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
 
         if (!nodes.contains(node)) {
             errors.add(buildValidationMessage(at, error));
         }
 
-        return errors;
+        return Collections.unmodifiableSet(errors);
     }
 
 }

--- a/src/main/java/com/networknt/schema/FormatValidator.java
+++ b/src/main/java/com/networknt/schema/FormatValidator.java
@@ -21,8 +21,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -74,7 +75,7 @@ public class FormatValidator extends BaseJsonValidator implements JsonValidator 
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
+        Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
 
         JsonType nodeType = TypeFactory.getValueNodeType(node);
         if (nodeType != JsonType.STRING) {
@@ -93,7 +94,7 @@ public class FormatValidator extends BaseJsonValidator implements JsonValidator 
             }
         }
 
-        return errors;
+        return Collections.unmodifiableSet(errors);
     }
 
 }

--- a/src/main/java/com/networknt/schema/ItemsValidator.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator.java
@@ -22,7 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -61,7 +62,7 @@ public class ItemsValidator extends BaseJsonValidator implements JsonValidator {
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
+        Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
 
         if (!node.isArray()) {
             // ignores non-arrays
@@ -93,7 +94,7 @@ public class ItemsValidator extends BaseJsonValidator implements JsonValidator {
 
             i++;
         }
-        return errors;
+        return Collections.unmodifiableSet(errors);
     }
 
 }

--- a/src/main/java/com/networknt/schema/MaxItemsValidator.java
+++ b/src/main/java/com/networknt/schema/MaxItemsValidator.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 public class MaxItemsValidator extends BaseJsonValidator implements JsonValidator {
@@ -41,15 +41,13 @@ public class MaxItemsValidator extends BaseJsonValidator implements JsonValidato
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
-
         if (node.isArray()) {
             if (node.size() > max) {
-                errors.add(buildValidationMessage(at, "" + max));
+                return Collections.singleton(buildValidationMessage(at, "" + max));
             }
         }
 
-        return errors;
+        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/MaxLengthValidator.java
+++ b/src/main/java/com/networknt/schema/MaxLengthValidator.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 public class MaxLengthValidator extends BaseJsonValidator implements JsonValidator {
@@ -43,15 +43,14 @@ public class MaxLengthValidator extends BaseJsonValidator implements JsonValidat
         debug(logger, node, rootNode, at);
 
         JsonType nodeType = TypeFactory.getValueNodeType(node);
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
         if (nodeType != JsonType.STRING) {
             // ignore no-string typs
-            return errors;
+            return Collections.emptySet();
         }
         if (node.textValue().codePointCount(0, node.textValue().length()) > maxLength) {
-            errors.add(buildValidationMessage(at, "" + maxLength));
+            return Collections.singleton(buildValidationMessage(at, "" + maxLength));
         }
-        return errors;
+        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/MaxPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/MaxPropertiesValidator.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 public class MaxPropertiesValidator extends BaseJsonValidator implements JsonValidator {
@@ -42,15 +42,13 @@ public class MaxPropertiesValidator extends BaseJsonValidator implements JsonVal
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
-
         if (node.isObject()) {
             if (node.size() > max) {
-                errors.add(buildValidationMessage(at, "" + max));
+                return Collections.singleton(buildValidationMessage(at, "" + max));
             }
         }
 
-        return errors;
+        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/MaximumValidator.java
+++ b/src/main/java/com/networknt/schema/MaximumValidator.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 public class MaximumValidator extends BaseJsonValidator implements JsonValidator {
@@ -51,18 +51,16 @@ public class MaximumValidator extends BaseJsonValidator implements JsonValidator
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
-
         if (!node.isNumber()) {
             // maximum only applies to numbers
-            return errors;
+            return Collections.emptySet();
         }
 
         double value = node.doubleValue();
         if (greaterThan(value, maximum) || (excludeEqual && equals(value, maximum))) {
-            errors.add(buildValidationMessage(at, "" + maximum));
+            return Collections.singleton(buildValidationMessage(at, "" + maximum));
         }
-        return errors;
+        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/MinItemsValidator.java
+++ b/src/main/java/com/networknt/schema/MinItemsValidator.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 public class MinItemsValidator extends BaseJsonValidator implements JsonValidator {
@@ -41,15 +41,13 @@ public class MinItemsValidator extends BaseJsonValidator implements JsonValidato
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
-
         if (node.isArray()) {
             if (node.size() < min) {
-                errors.add(buildValidationMessage(at, "" + min));
+                return Collections.singleton(buildValidationMessage(at, "" + min));
             }
         }
 
-        return errors;
+        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/MinLengthValidator.java
+++ b/src/main/java/com/networknt/schema/MinLengthValidator.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 public class MinLengthValidator extends BaseJsonValidator implements JsonValidator {
@@ -43,16 +43,15 @@ public class MinLengthValidator extends BaseJsonValidator implements JsonValidat
         debug(logger, node, rootNode, at);
 
         JsonType nodeType = TypeFactory.getValueNodeType(node);
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
         if (nodeType != JsonType.STRING) {
             // ignore non-string types
-            return errors;
+            return Collections.emptySet();
         }
 
         if (node.textValue().codePointCount(0, node.textValue().length()) < minLength) {
-            errors.add(buildValidationMessage(at, "" + minLength));
+            return Collections.singleton(buildValidationMessage(at, "" + minLength));
         }
-        return errors;
+        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/MinPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/MinPropertiesValidator.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 public class MinPropertiesValidator extends BaseJsonValidator implements JsonValidator {
@@ -42,15 +42,13 @@ public class MinPropertiesValidator extends BaseJsonValidator implements JsonVal
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
-
         if (node.isObject()) {
             if (node.size() < min) {
-                errors.add(buildValidationMessage(at, "" + min));
+                return Collections.singleton(buildValidationMessage(at, "" + min));
             }
         }
 
-        return errors;
+        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/MinimumValidator.java
+++ b/src/main/java/com/networknt/schema/MinimumValidator.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 public class MinimumValidator extends BaseJsonValidator implements JsonValidator {
@@ -50,18 +50,16 @@ public class MinimumValidator extends BaseJsonValidator implements JsonValidator
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
-
         if (!node.isNumber()) {
             // minimum only applies to numbers
-            return errors;
+            return Collections.emptySet();
         }
 
         double value = node.doubleValue();
         if (lessThan(value, minimum) || (excluded && equals(value, minimum))) {
-            errors.add(buildValidationMessage(at, "" + minimum));
+            return Collections.singleton(buildValidationMessage(at, "" + minimum));
         }
-        return errors;
+        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/MultipleOfValidator.java
+++ b/src/main/java/com/networknt/schema/MultipleOfValidator.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 public class MultipleOfValidator extends BaseJsonValidator implements JsonValidator {
@@ -42,19 +42,17 @@ public class MultipleOfValidator extends BaseJsonValidator implements JsonValida
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
-
         if (node.isNumber()) {
             double nodeValue = node.doubleValue();
             if (divisor != 0) {
                 long multiples = Math.round(nodeValue / divisor);
                 if (Math.abs(multiples * divisor - nodeValue) > 1e-12) {
-                    errors.add(buildValidationMessage(at, "" + divisor));
+                    return Collections.singleton(buildValidationMessage(at, "" + divisor));
                 }
             }
         }
 
-        return errors;
+        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/NotAllowedValidator.java
+++ b/src/main/java/com/networknt/schema/NotAllowedValidator.java
@@ -22,7 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -47,7 +48,7 @@ public class NotAllowedValidator extends BaseJsonValidator implements JsonValida
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
+        Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
 
         for (String fieldName : fieldNames) {
             JsonNode propertyNode = node.get(fieldName);
@@ -57,7 +58,7 @@ public class NotAllowedValidator extends BaseJsonValidator implements JsonValida
             }
         }
 
-        return errors;
+        return Collections.unmodifiableSet(errors);
     }
 
 }

--- a/src/main/java/com/networknt/schema/NotValidator.java
+++ b/src/main/java/com/networknt/schema/NotValidator.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 public class NotValidator extends BaseJsonValidator implements JsonValidator {
@@ -39,12 +39,11 @@ public class NotValidator extends BaseJsonValidator implements JsonValidator {
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> notValidationError = new HashSet<ValidationMessage>();
         Set<ValidationMessage> errors = schema.validate(node, rootNode, at);
         if (errors.isEmpty()) {
-            notValidationError.add(buildValidationMessage(at, schema.toString()));
+            return Collections.singleton(buildValidationMessage(at, schema.toString()));
         }
-        return notValidationError;
+        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/OneOfValidator.java
+++ b/src/main/java/com/networknt/schema/OneOfValidator.java
@@ -23,8 +23,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -47,13 +48,13 @@ public class OneOfValidator extends BaseJsonValidator implements JsonValidator {
         debug(logger, node, rootNode, at);
 
         int numberOfValidSchema = 0;
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
+        Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
         
         for (JsonSchema schema : schemas) {
         	Set<ValidationMessage> schemaErrors = schema.validate(node, rootNode, at);
             if (schemaErrors.isEmpty()) {
                 numberOfValidSchema++;
-                errors = new HashSet<ValidationMessage>();
+                errors = new LinkedHashSet<ValidationMessage>();
             }
             if(numberOfValidSchema == 0){
         		errors.addAll(schemaErrors);
@@ -74,11 +75,10 @@ public class OneOfValidator extends BaseJsonValidator implements JsonValidator {
             }
         }
         if (numberOfValidSchema > 1) {
-        	errors = new HashSet<ValidationMessage>();
-        	errors.add(buildValidationMessage(at, ""));
+            errors = Collections.singleton(buildValidationMessage(at, ""));
         }
         
-        return errors;
+        return Collections.unmodifiableSet(errors);
     }
 
 }

--- a/src/main/java/com/networknt/schema/PatternValidator.java
+++ b/src/main/java/com/networknt/schema/PatternValidator.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -48,25 +49,23 @@ public class PatternValidator extends BaseJsonValidator implements JsonValidator
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
-
         JsonType nodeType = TypeFactory.getValueNodeType(node);
         if (nodeType != JsonType.STRING && nodeType != JsonType.NUMBER && nodeType != JsonType.INTEGER) {
-            return errors;
+            return Collections.emptySet();
         }
 
         if (p != null) {
             try {
                 Matcher m = p.matcher(node.asText());
                 if (!m.find()) {
-                    errors.add(buildValidationMessage(at, pattern));
+                    return Collections.singleton(buildValidationMessage(at, pattern));
                 }
             } catch (PatternSyntaxException pse) {
                 logger.error("Failed to apply pattern on " + at + ": Invalid syntax [" + pattern + "]", pse);
             }
         }
 
-        return errors;
+        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/PropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/PropertiesValidator.java
@@ -40,7 +40,7 @@ public class PropertiesValidator extends BaseJsonValidator implements JsonValida
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
+        Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
 
         for (String key : schemas.keySet()) {
             JsonSchema propertySchema = schemas.get(key);
@@ -51,7 +51,7 @@ public class PropertiesValidator extends BaseJsonValidator implements JsonValida
             }
         }
 
-        return errors;
+        return Collections.unmodifiableSet(errors);
     }
 
 }

--- a/src/main/java/com/networknt/schema/ReadOnlyValidator.java
+++ b/src/main/java/com/networknt/schema/ReadOnlyValidator.java
@@ -22,7 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -46,7 +47,7 @@ public class ReadOnlyValidator extends BaseJsonValidator implements JsonValidato
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
+        Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
 
         for (String fieldName : fieldNames) {
             JsonNode propertyNode = node.get(fieldName);
@@ -64,7 +65,7 @@ public class ReadOnlyValidator extends BaseJsonValidator implements JsonValidato
             }
         }
 
-        return errors;
+        return Collections.unmodifiableSet(errors);
     }
 
     private JsonNode getNode(String datapath, JsonNode data) {

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 public class RefValidator extends BaseJsonValidator implements JsonValidator {
@@ -113,7 +113,7 @@ public class RefValidator extends BaseJsonValidator implements JsonValidator {
         if (schema != null) {
             return schema.validate(node, rootNode, at);
         } else {
-            return new HashSet<ValidationMessage>();
+            return Collections.emptySet();
         }
     }
 

--- a/src/main/java/com/networknt/schema/RequiredValidator.java
+++ b/src/main/java/com/networknt/schema/RequiredValidator.java
@@ -22,7 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -47,7 +48,7 @@ public class RequiredValidator extends BaseJsonValidator implements JsonValidato
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
+        Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
 
         for (String fieldName : fieldNames) {
             JsonNode propertyNode = node.get(fieldName);
@@ -57,7 +58,7 @@ public class RequiredValidator extends BaseJsonValidator implements JsonValidato
             }
         }
 
-        return errors;
+        return Collections.unmodifiableSet(errors);
     }
 
 }

--- a/src/main/java/com/networknt/schema/TypeValidator.java
+++ b/src/main/java/com/networknt/schema/TypeValidator.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 public class TypeValidator extends BaseJsonValidator implements JsonValidator {
@@ -44,27 +44,24 @@ public class TypeValidator extends BaseJsonValidator implements JsonValidator {
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
-
         if (schemaType == JsonType.UNION) {
-            errors.addAll(unionTypeValidator.validate(node, rootNode, at));
-            return errors;
+            return unionTypeValidator.validate(node, rootNode, at);
         }
 
         JsonType nodeType = TypeFactory.getValueNodeType(node);
         if (nodeType != schemaType) {
             if (schemaType == JsonType.ANY) {
-                return errors;
+                return Collections.emptySet();
             }
 
             if (schemaType == JsonType.NUMBER && nodeType == JsonType.INTEGER) {
-                return errors;
+                return Collections.emptySet();
             }
 
-            errors.add(buildValidationMessage(at, nodeType.toString(), schemaType.toString()));
+           return Collections.singleton(buildValidationMessage(at, nodeType.toString(), schemaType.toString()));
         }
 
-        return errors;
+        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/UniqueItemsValidator.java
+++ b/src/main/java/com/networknt/schema/UniqueItemsValidator.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -41,8 +42,6 @@ public class UniqueItemsValidator extends BaseJsonValidator implements JsonValid
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new HashSet<ValidationMessage>();
-
         if (unique) {
             Set<JsonNode> set = new HashSet<JsonNode>();
             for (JsonNode n : node) {
@@ -50,11 +49,11 @@ public class UniqueItemsValidator extends BaseJsonValidator implements JsonValid
             }
 
             if (set.size() < node.size()) {
-                errors.add(buildValidationMessage(at));
+                return Collections.singleton(buildValidationMessage(at));
             }
         }
 
-        return errors;
+        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/ValidationMessage.java
+++ b/src/main/java/com/networknt/schema/ValidationMessage.java
@@ -45,11 +45,11 @@ public class ValidationMessage {
         this.path = path;
     }
 
-    String[] getArguments() {
+    public String[] getArguments() {
         return arguments;
     }
 
-    public void setArguments(String[] arguments) {
+    void setArguments(String[] arguments) {
         this.arguments = arguments;
     }
 


### PR DESCRIPTION
For things that might be read by humans, maintaining order can be
valuable. This change uses LinkedHashSet rather than HashSet to
maintain the iteration order of error in the order they're encountered.

Additionally, there are a few optimzations in validators:
- Using singletonSet and emptySet rather than a *HashSet when
  appropriate
- Map iteration optimization
- StringBuilder optimization