### PR TITLE
Resolve sub schema node only if really needed

### DIFF
--- a/src/main/java/com/networknt/schema/BaseJsonValidator.java
+++ b/src/main/java/com/networknt/schema/BaseJsonValidator.java
@@ -29,23 +29,24 @@ public abstract class BaseJsonValidator implements JsonValidator {
     private String schemaPath;
     private JsonNode schemaNode;
     private JsonSchema parentSchema;
-    private JsonSchema subSchema;
+    private boolean suppressSubSchemaRetrieval;
     private ValidatorTypeCode validatorType;
     private ErrorMessageType errorMessageType;
 
+    
     public BaseJsonValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema,
                              ValidatorTypeCode validatorType, ValidationContext validationContext) {
-    	this(schemaPath, schemaNode, parentSchema, validatorType, obainSubSchemaNode(schemaNode, validationContext) );
+    	this(schemaPath, schemaNode, parentSchema, validatorType, false );
     }
 
     public BaseJsonValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema,
-                             ValidatorTypeCode validatorType, JsonSchema subSchema) {
+                             ValidatorTypeCode validatorType, boolean suppressSubSchemaRetrieval) {
         this.errorMessageType = validatorType;
         this.schemaPath = schemaPath;
         this.schemaNode = schemaNode;
         this.parentSchema = parentSchema;
         this.validatorType = validatorType;
-        this.subSchema = subSchema;
+        this.suppressSubSchemaRetrieval = suppressSubSchemaRetrieval;
     }
 
     protected String getSchemaPath() {
@@ -60,15 +61,12 @@ public abstract class BaseJsonValidator implements JsonValidator {
         return parentSchema;
     }
     
-    protected JsonSchema getSubSchema() {
-        return subSchema;
+    protected JsonSchema fetchSubSchemaNode(ValidationContext validationContext) {
+        return suppressSubSchemaRetrieval ? null : obtainSubSchemaNode(schemaNode, validationContext);
     }
 
-    protected boolean hasSubSchema() {
-        return subSchema != null;
-    }
     
-    protected static JsonSchema obainSubSchemaNode(JsonNode schemaNode, ValidationContext validationContext){
+    private static JsonSchema obtainSubSchemaNode(JsonNode schemaNode, ValidationContext validationContext){
         JsonNode node = schemaNode.get("id");
         if(node == null) return null;
     	if(node.equals(schemaNode.get("$schema"))) return null;

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -46,18 +46,18 @@ public class JsonSchema extends BaseJsonValidator {
 
     JsonSchema(ValidationContext validationContext,  String schemaPath, JsonNode schemaNode,
                JsonSchema parent) {
-        this(validationContext,  schemaPath, schemaNode, parent, obainSubSchemaNode(schemaNode, validationContext));
+        this(validationContext,  schemaPath, schemaNode, parent, false);
     }
 
     JsonSchema(ValidationContext validatorFactory,  String schemaPath, JsonNode schemaNode,
-               JsonSchema parent, JsonSchema subSchema) {
-        super(schemaPath, schemaNode, parent, null, subSchema);
+               JsonSchema parent, boolean suppressSubSchemaRetrieval) {
+        super(schemaPath, schemaNode, parent, null, suppressSubSchemaRetrieval);
         this.validationContext = validatorFactory;
         this.validators = Collections.unmodifiableMap(this.read(schemaNode));
     }
 
-    public JsonSchema(ValidationContext validationContext,  JsonNode schemaNode, JsonSchema subSchema) {
-        this(validationContext, "#", schemaNode, null, subSchema);
+    public JsonSchema(ValidationContext validationContext,  JsonNode schemaNode, boolean suppressSubSchemaRetrieval) {
+        this(validationContext, "#", schemaNode, null, suppressSubSchemaRetrieval);
     }
 
     /**
@@ -84,8 +84,11 @@ public class JsonSchema extends BaseJsonValidator {
                 } else {
                     node = node.get(key);
                 }
-                if (node == null && schema.hasSubSchema()){
-                    node = schema.getSubSchema().getRefSchemaNode(ref);
+                if (node == null){
+                    JsonSchema subSchema = schema.fetchSubSchemaNode(validationContext);
+                    if (subSchema != null) {
+                        node = subSchema.getRefSchemaNode(ref);
+                    }
                 }
                 if (node == null){
                     break;

--- a/src/main/java/com/networknt/schema/JsonSchemaFactory.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaFactory.java
@@ -189,7 +189,7 @@ public class JsonSchemaFactory {
 
                 if (idMatchesSourceUrl(jsonMetaSchema, schemaNode, schemaURL)) {
                     
-                    return new JsonSchema(new ValidationContext(jsonMetaSchema, this), schemaNode, null);
+                    return new JsonSchema(new ValidationContext(jsonMetaSchema, this), schemaNode, true /*retrieved via id, resolving will not change anything*/);
                 }
 
                 return newJsonSchema(schemaNode);


### PR DESCRIPTION
When JsonSchemaFactory.getSchema is called with anything else than a URL, a specified ID property used to lead to the URI being resolved even if it was not necessary (because there was no ref that cannot be satisfied with the current schema). If the validation code is called to verify a Schema before it is accepted as the "official" schema for a given URI, it will fail because the resolved URI either does not exist yet or contains an older version.  Thus I changed the implementation to resolve the sub schema node lazily.