### PR TITLE
References that cannot be resolved should be treated as an error

### DIFF
--- a/src/main/java/com/networknt/schema/JsonSchemaException.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaException.java
@@ -16,11 +16,16 @@
 
 package com.networknt.schema;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class JsonSchemaException extends RuntimeException {
     private static final long serialVersionUID = -7805792737596582110L;
+    private ValidationMessage validationMessage;
 
     public JsonSchemaException(ValidationMessage validationMessage) {
         super(validationMessage.getMessage());
+        this.validationMessage = validationMessage;
     }
     
     public JsonSchemaException(String message) {
@@ -31,4 +36,10 @@ public class JsonSchemaException extends RuntimeException {
         super(throwable);
     }
 
+    public Set<ValidationMessage> getValidationMessages() {
+        if (validationMessage == null) {
+            return Collections.emptySet();
+        }
+        return Collections.singleton(validationMessage);
+    }
 }

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -16,16 +16,18 @@
 
 package com.networknt.schema;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.networknt.schema.url.URLFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.networknt.schema.url.URLFactory;
 
 public class RefValidator extends BaseJsonValidator implements JsonValidator {
     private static final Logger logger = LoggerFactory.getLogger(RefValidator.class);
@@ -71,6 +73,9 @@ public class RefValidator extends BaseJsonValidator implements JsonValidator {
             if (node != null) {
                 schema = new JsonSchema(validationContext, refValue, node, parentSchema);
             }
+        }
+        if (schema == null) {
+            throw new JsonSchemaException(ValidationMessage.of(ValidatorTypeCode.REF.getValue(), CustomErrorMessageType.of("internal.unresolvedRef", new MessageFormat("{0}: Reference {1} cannot be resolved")), schemaPath, refValue));
         }
     }
     


### PR DESCRIPTION
Documents were validated even if "$ref" pointed to a non-existing schema. 

The json schema spec does not explicitely  state how to treat this case, but I would like to argue that a non-existing referenced schema should be treated as an error.