### PR TITLE
Optimization for OneOf

### DIFF
--- a/src/main/java/com/networknt/schema/OneOfValidator.java
+++ b/src/main/java/com/networknt/schema/OneOfValidator.java
@@ -16,28 +16,113 @@
 
 package com.networknt.schema;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class OneOfValidator extends BaseJsonValidator implements JsonValidator {
     private static final Logger logger = LoggerFactory.getLogger(RequiredValidator.class);
 
-    private List<JsonSchema> schemas = new ArrayList<JsonSchema>();
+    private List<ShortcutValidator> schemas = new ArrayList<ShortcutValidator>();
+
+    private static class ShortcutValidator {
+        private final JsonSchema schema;
+        private final Map<String, String> constants;
+
+        ShortcutValidator(JsonNode schemaNode, JsonSchema parentSchema,
+                ValidationContext validationContext, JsonSchema schema) {
+            JsonNode refNode = schemaNode.get(ValidatorTypeCode.REF.getValue());
+            JsonSchema resolvedRefSchema = refNode != null && refNode.isTextual() ? RefValidator.getRefSchema(parentSchema, validationContext,refNode.textValue()) : null;
+            this.constants = extractConstants(schemaNode, resolvedRefSchema);
+            this.schema = schema;
+        }
+
+        private Map<String, String> extractConstants(JsonNode schemaNode, JsonSchema resolvedRefSchema) {
+            Map<String, String> refMap = resolvedRefSchema != null ?  extractConstants(resolvedRefSchema.getSchemaNode()) : Collections.<String,String>emptyMap();
+            Map<String, String> schemaMap = extractConstants(schemaNode);
+            if (refMap.isEmpty() ) {
+                return schemaMap;
+            }
+            if (schemaMap.isEmpty()) {
+                return refMap;
+            }
+            Map<String, String> joined = new HashMap<String, String>();
+            joined.putAll(schemaMap);
+            joined.putAll(refMap);
+            return joined;
+        }
+        
+        private Map<String, String> extractConstants(JsonNode schemaNode) {
+            Map<String, String> result = new HashMap<String, String>();
+            if (!schemaNode.isObject()) {
+                return result;
+            }
+            
+            JsonNode propertiesNode  = schemaNode.get("properties");
+            if (propertiesNode == null || !propertiesNode.isObject()) {
+                return result;
+            }
+            Iterator<String> fit = propertiesNode.fieldNames();
+            while (fit.hasNext()) {
+                String fieldName = fit.next();
+                JsonNode jsonNode = propertiesNode.get(fieldName);
+                String constantFieldValue = getConstantFieldValue(jsonNode);
+                if (constantFieldValue != null && !constantFieldValue.isEmpty()) {
+                    result.put(fieldName, constantFieldValue);
+                }
+            }
+            return result; 
+        }
+        private String getConstantFieldValue(JsonNode jsonNode) {
+            if (jsonNode == null || !jsonNode.isObject() || !jsonNode.has("enum")) {
+                return null;
+            }
+            JsonNode enumNode = jsonNode.get("enum");
+            if (enumNode == null || !enumNode.isArray() ) {
+                return null;
+            }
+            if (enumNode.size() != 1) {
+                return null;
+            }
+            JsonNode valueNode = enumNode.get(0);
+            if (valueNode == null || !valueNode.isTextual()) {
+                return null;
+            }
+            return valueNode.textValue();
+        }
+        
+        public boolean allConstantsMatch(JsonNode node) {
+            for (Map.Entry<String, String> e: constants.entrySet()) {
+                JsonNode valueNode = node.get(e.getKey());
+                if (valueNode != null && valueNode.isTextual()) {
+                    boolean match = e.getValue().equals(valueNode.textValue());
+                    if (!match) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+    }
 
     public OneOfValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaPath, schemaNode, parentSchema, ValidatorTypeCode.ONE_OF, validationContext);
         int size = schemaNode.size();
         for (int i = 0; i < size; i++) {
-            schemas.add(new JsonSchema(validationContext, getValidatorType().getValue(), schemaNode.get(i), parentSchema));
+            JsonNode childNode = schemaNode.get(i);
+            JsonSchema childSchema = new JsonSchema(validationContext, getValidatorType().getValue(), childNode, parentSchema);
+            schemas.add(new ShortcutValidator(childNode, parentSchema, validationContext, childSchema));
         }
 
         parseErrorCode(getValidatorType().getErrorCodeKey());
@@ -49,7 +134,13 @@ public class OneOfValidator extends BaseJsonValidator implements JsonValidator {
         int numberOfValidSchema = 0;
         Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
         
-        for (JsonSchema schema : schemas) {
+        for (ShortcutValidator validator : schemas) {
+            if (!validator.allConstantsMatch(node)) {
+                // take a shortcut: if there is any constant that does not match,
+                // we can bail out
+                continue;
+            }
+            JsonSchema schema = validator.schema;
         	Set<ValidationMessage> schemaErrors = schema.validate(node, rootNode, at);
             if (schemaErrors.isEmpty()) {
                 numberOfValidSchema++;
@@ -69,6 +160,10 @@ public class OneOfValidator extends BaseJsonValidator implements JsonValidator {
                 
                 if (ValidatorTypeCode.ADDITIONAL_PROPERTIES.getValue().equals(msg.getType())) {
                     it.remove();
+                }
+                if (errors.isEmpty()) {
+                    // ensure there is always an error reported if number of valid schemas is 0
+                    errors.add(buildValidationMessage(at, ""));
                 }
             }
         }

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.Set;
 
@@ -32,14 +33,21 @@ public class RefValidator extends BaseJsonValidator implements JsonValidator {
 
     protected JsonSchema schema;
     
-    private final String REF_DOMAIN = "/";
-    private final String REF_CURRENT = "#";
-    private final String REF_RELATIVE = "../";
+    private static final String REF_DOMAIN = "/";
+    private static final String REF_CURRENT = "#";
+    private static final String REF_RELATIVE = "../";
 
     public RefValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
 
         super(schemaPath, schemaNode, parentSchema, ValidatorTypeCode.REF, validationContext);
         String refValue = schemaNode.asText();
+        schema = getRefSchema(parentSchema, validationContext, refValue);
+        if (schema == null) {
+            throw new JsonSchemaException(ValidationMessage.of(ValidatorTypeCode.REF.getValue(), CustomErrorMessageType.of("internal.unresolvedRef", new MessageFormat("{0}: Reference {1} cannot be resolved")), schemaPath, refValue));
+        }
+    }
+
+    static JsonSchema getRefSchema(JsonSchema parentSchema, ValidationContext validationContext, String refValue) {
         if (!refValue.startsWith(REF_CURRENT)) {
             // handle remote ref
             String schemaUrl = refValue;
@@ -59,26 +67,27 @@ public class RefValidator extends BaseJsonValidator implements JsonValidator {
                 parentSchema = validationContext.getJsonSchemaFactory().getSchema(is);
             }
             if (index < 0) {
-                schema = parentSchema.findAncestor();
+                return parentSchema.findAncestor();
             } else {
                 refValue = refValue.substring(index);
             }
         }
         if (refValue.equals(REF_CURRENT)) {
-            schema = parentSchema.findAncestor();
+            return parentSchema.findAncestor();
         } else {
             JsonNode node = parentSchema.getRefSchemaNode(refValue);
             if (node != null) {
-                schema = new JsonSchema(validationContext, refValue, node, parentSchema);
+                return new JsonSchema(validationContext, refValue, node, parentSchema);
             }
         }
+        return null;
     }
     
-    private boolean isRelativePath(String schemaUrl) {
+    private static boolean isRelativePath(String schemaUrl) {
     	return !schemaUrl.startsWith("http");
     }
     
-    private String obtainAbsolutePath(JsonSchema parentSchema, String schemaUrl) {
+    private static String obtainAbsolutePath(JsonSchema parentSchema, String schemaUrl) {
     	String baseSchemaUrl = parentSchema.findAncestor().getSchemaNode().get("id").textValue();
 		int index = baseSchemaUrl.lastIndexOf("/");
 		baseSchemaUrl = baseSchemaUrl.substring(0, index);


### PR DESCRIPTION
An often-used pattern in conjunction with oneOf is to use a single value
enum as a constant where each oneOf alternative typically has a different
constant.

If the corresponding property is set in the json node (and thus is
textual) we can skip all alternatives that have a different constant
value defined for that property since they will definitely not match.

For schemas with many alternatives and a lot of items that need to run
through those alternatives, I found this to speedup validation
considerably (30% faster in my case).

Please note that this commit contains the semantics from PR "unresolved-refs-are-errors" as well - if you object to that one, I can adjust this PR. 