### PR TITLE
Only apply pattern validation on strings

### DIFF
--- a/src/main/java/com/networknt/schema/PatternValidator.java
+++ b/src/main/java/com/networknt/schema/PatternValidator.java
@@ -48,7 +48,7 @@ public class PatternValidator extends BaseJsonValidator implements JsonValidator
         debug(logger, node, rootNode, at);
 
         JsonType nodeType = TypeFactory.getValueNodeType(node);
-        if (nodeType != JsonType.STRING && nodeType != JsonType.NUMBER && nodeType != JsonType.INTEGER) {
+        if (nodeType != JsonType.STRING) {
             return Collections.emptySet();
         }
 


### PR DESCRIPTION
Currently, `pattern` is applied to strings, numbers, and integers. According to the [spec](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.3.3),

> A string instance is considered valid if the regular expression matches the instance successfully. 

I think that means patterns are ignored for non-strings.