### PR TITLE
Only apply required validator to objects

### DIFF
--- a/src/main/java/com/networknt/schema/RequiredValidator.java
+++ b/src/main/java/com/networknt/schema/RequiredValidator.java
@@ -35,9 +35,8 @@ public class RequiredValidator extends BaseJsonValidator implements JsonValidato
 
         super(schemaPath, schemaNode, parentSchema, ValidatorTypeCode.REQUIRED, validationContext);
         if (schemaNode.isArray()) {
-            int size = schemaNode.size();
-            for (int i = 0; i < size; i++) {
-                fieldNames.add(schemaNode.get(i).asText());
+            for (JsonNode fieldNme : schemaNode) {
+                fieldNames.add(fieldNme.asText());
             }
         }
 
@@ -46,6 +45,10 @@ public class RequiredValidator extends BaseJsonValidator implements JsonValidato
 
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
+
+        if (!node.isObject()) {
+            return Collections.emptySet();
+        }
 
         Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
 

--- a/src/test/resources/tests/required.json
+++ b/src/test/resources/tests/required.json
@@ -35,5 +35,18 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "required validation on non-object",
+        "schema": {
+            "required": ["foo"]
+        },
+        "tests": [
+            {
+                "description": "required not applied on null",
+                "data": null,
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
The spec for `require` say

>  An object instance is valid against this keyword if every item in the array is the name of a property in the instance.

`require` shouldn't be applied to non-objects.