### PR TITLE
Fixed validation for path parameters and query parameters

### DIFF
--- a/src/main/java/com/networknt/schema/EnumValidator.java
+++ b/src/main/java/com/networknt/schema/EnumValidator.java
@@ -65,11 +65,24 @@ public class EnumValidator extends BaseJsonValidator implements JsonValidator {
 
         Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
 
-        if (!nodes.contains(node)) {
+        if (!nodes.contains(node) && !isTypeLooseEqual(node)) {
             errors.add(buildValidationMessage(at, error));
         }
 
         return Collections.unmodifiableSet(errors);
+    }
+
+    private boolean isTypeLooseEqual(JsonNode node) {
+        if (config.isTypeLoose() && TypeFactory.getValueNodeType(node) == JsonType.STRING) {
+            String nodeText = node.textValue();
+            for (JsonNode n : nodes) {
+                String value = n.asText();
+                if (value != null && value.equals(nodeText)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
 }

--- a/src/main/java/com/networknt/schema/EnumValidator.java
+++ b/src/main/java/com/networknt/schema/EnumValidator.java
@@ -65,15 +65,19 @@ public class EnumValidator extends BaseJsonValidator implements JsonValidator {
 
         Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
 
-        if (!nodes.contains(node) && !isTypeLooseEqual(node)) {
+        if (!nodes.contains(node) && !(config.isTypeLoose() && isTypeLooseContainsInEnum(node))) {
             errors.add(buildValidationMessage(at, error));
         }
 
         return Collections.unmodifiableSet(errors);
     }
 
-    private boolean isTypeLooseEqual(JsonNode node) {
-        if (config.isTypeLoose() && TypeFactory.getValueNodeType(node) == JsonType.STRING) {
+    /**
+     * Check whether enum contains the value of the JsonNode if the typeLoose is enabled.
+     * @param node JsonNode to check
+     */
+    private boolean isTypeLooseContainsInEnum(JsonNode node) {
+        if (TypeFactory.getValueNodeType(node) == JsonType.STRING) {
             String nodeText = node.textValue();
             for (JsonNode n : nodes) {
                 String value = n.asText();

--- a/src/main/java/com/networknt/schema/MaximumValidator.java
+++ b/src/main/java/com/networknt/schema/MaximumValidator.java
@@ -50,14 +50,16 @@ public class MaximumValidator extends BaseJsonValidator implements JsonValidator
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        if (!node.isNumber()) {
+        if (!node.isNumber() && !(config.isTypeLoose()
+                && TypeFactory.getValueNodeType(node) == JsonType.STRING
+                && TypeValidator.isNumeric(node.textValue()))) {
             // maximum only applies to numbers
             return Collections.emptySet();
         }
 
         String fieldType = this.getNodeFieldType();
 
-        double value = node.doubleValue();
+        double value = node.asDouble();
         if (greaterThan(value, maximum) || (excludeEqual && equals(value, maximum))) {
             if (JsonType.INTEGER.toString().equals(fieldType)) {
                 return Collections.singleton(buildValidationMessage(at, "" + (int)maximum));

--- a/src/main/java/com/networknt/schema/MaximumValidator.java
+++ b/src/main/java/com/networknt/schema/MaximumValidator.java
@@ -50,9 +50,7 @@ public class MaximumValidator extends BaseJsonValidator implements JsonValidator
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        if (!node.isNumber() && !(config.isTypeLoose()
-                && TypeFactory.getValueNodeType(node) == JsonType.STRING
-                && TypeValidator.isNumeric(node.textValue()))) {
+        if (!TypeValidator.isNumber(node, config.isTypeLoose())) {
             // maximum only applies to numbers
             return Collections.emptySet();
         }

--- a/src/main/java/com/networknt/schema/MinimumValidator.java
+++ b/src/main/java/com/networknt/schema/MinimumValidator.java
@@ -49,13 +49,15 @@ public class MinimumValidator extends BaseJsonValidator implements JsonValidator
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        if (!node.isNumber()) {
+        if (!node.isNumber() && !(config.isTypeLoose()
+                && TypeFactory.getValueNodeType(node) == JsonType.STRING
+                && TypeValidator.isNumeric(node.textValue()))) {
             // minimum only applies to numbers
             return Collections.emptySet();
         }
         String fieldType = this.getNodeFieldType();
 
-        double value = node.doubleValue();
+        double value = node.asDouble();
         if (lessThan(value, minimum) || (excluded && equals(value, minimum))) {
             if (JsonType.INTEGER.toString().equals(fieldType)) {
                 return Collections.singleton(buildValidationMessage(at, "" + (int) minimum));

--- a/src/main/java/com/networknt/schema/MinimumValidator.java
+++ b/src/main/java/com/networknt/schema/MinimumValidator.java
@@ -49,9 +49,7 @@ public class MinimumValidator extends BaseJsonValidator implements JsonValidator
     public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        if (!node.isNumber() && !(config.isTypeLoose()
-                && TypeFactory.getValueNodeType(node) == JsonType.STRING
-                && TypeValidator.isNumeric(node.textValue()))) {
+        if (!TypeValidator.isNumber(node, config.isTypeLoose())) {
             // minimum only applies to numbers
             return Collections.emptySet();
         }

--- a/src/main/java/com/networknt/schema/TypeValidator.java
+++ b/src/main/java/com/networknt/schema/TypeValidator.java
@@ -147,4 +147,21 @@ public class TypeValidator extends BaseJsonValidator implements JsonValidator {
         }
         return true;
     }
+
+    /**
+     * Check if the type of the JsonNode's value is number based on the
+     * status of typeLoose flag.
+     * @param node the JsonNode to check
+     * @param isTypeLoose The flag to show whether typeLoose is enabled
+     */
+    public static boolean isNumber(JsonNode node, boolean isTypeLoose) {
+        if (node.isNumber()) {
+            return true;
+        } else if (isTypeLoose) {
+            if (TypeFactory.getValueNodeType(node) == JsonType.STRING) {
+                return isNumeric(node.textValue());
+            }
+        }
+        return false;
+    }
 }

--- a/src/test/java/com/networknt/schema/JsonSchemaTest.java
+++ b/src/test/java/com/networknt/schema/JsonSchemaTest.java
@@ -74,11 +74,17 @@ public class JsonSchemaTest {
         for (int j = 0; j < testCases.size(); j++) {
             try {
                 JsonNode testCase = testCases.get(j);
-                JsonSchema schema = validatorFactory.getSchema(testCase.get("schema"));
+                SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+
                 ArrayNode testNodes = (ArrayNode) testCase.get("tests");
                 for (int i = 0; i < testNodes.size(); i++) {
                     JsonNode test = testNodes.get(i);
                     JsonNode node = test.get("data");
+                    JsonNode typeLooseNode = test.get("isTypeLoose");
+                    // Configure the schemaValidator to set typeLoose's value based on the test file,
+                    // if test file do not contains typeLoose flag, use default value: true.
+                    config.setTypeLoose((typeLooseNode == null) ? true : typeLooseNode.asBoolean());
+                    JsonSchema schema = validatorFactory.getSchema(testCase.get("schema"), config);
                     List<ValidationMessage> errors = new ArrayList<ValidationMessage>();
 
                     errors.addAll(schema.validate(node));

--- a/src/test/resources/tests/enum.json
+++ b/src/test/resources/tests/enum.json
@@ -47,7 +47,13 @@
                 "valid": false
             },
             {
-                "description": "objects are deep compared",
+                "description": "one of the enum is valid",
+                "data": "true",
+                "isTypeLoose": true,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
                 "data": "true",
                 "isTypeLoose": false,
                 "valid": false

--- a/src/test/resources/tests/enum.json
+++ b/src/test/resources/tests/enum.json
@@ -9,6 +9,18 @@
                 "valid": true
             },
             {
+                "description": "one of the enum is valid",
+                "isTypeLoose": true,
+                "data": "1",
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "isTypeLoose": false,
+                "data": "1",
+                "valid": false
+            },
+            {
                 "description": "something else is invalid",
                 "data": 4,
                 "valid": false
@@ -32,6 +44,12 @@
             {
                 "description": "objects are deep compared",
                 "data": {"foo": false},
+                "valid": false
+            },
+            {
+                "description": "objects are deep compared",
+                "data": "true",
+                "isTypeLoose": false,
                 "valid": false
             }
         ]

--- a/src/test/resources/tests/maximum.json
+++ b/src/test/resources/tests/maximum.json
@@ -9,6 +9,11 @@
                 "valid": true
             },
             {
+                "description": "below the maximum is valid",
+                "data": "2.6",
+                "valid": true
+            },
+            {
                 "description": "above the maximum is invalid",
                 "data": 3.5,
                 "valid": false

--- a/src/test/resources/tests/minimum.json
+++ b/src/test/resources/tests/minimum.json
@@ -9,6 +9,11 @@
                 "valid": true
             },
             {
+                "description": "above the minimum is valid",
+                "data": "2.6",
+                "valid": true
+            },
+            {
                 "description": "below the minimum is invalid",
                 "data": 0.6,
                 "valid": false


### PR DESCRIPTION
@NicholasAzar @stevehu Since the RequestValidator is built on json-schema-validator. There is another PR related to this issue can be found in networknt/light-rest-4j repo. These changes in different repo contributions to the same issue.

RFC which specifies the details of fix can be found here: https://github.com/networknt/light-rfcs/blob/master/light-rest-4j/0001-openapi-validator-bug-fix.md