### PR TITLE
feat: Use URL mappings for $ref and other URLs

### DIFF
--- a/src/main/java/com/networknt/schema/BaseJsonValidator.java
+++ b/src/main/java/com/networknt/schema/BaseJsonValidator.java
@@ -83,7 +83,7 @@ public abstract class BaseJsonValidator implements JsonValidator {
             }
             else {
                 URL url = URLFactory.toURL(node.textValue());
-                return validationContext.getJsonSchemaFactory().getSchema(url);
+                return validationContext.getJsonSchemaFactory().getSchema(url, validationContext.getConfig());
             }
         } catch (MalformedURLException e) {
             return null;

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -62,7 +62,7 @@ public class RefValidator extends BaseJsonValidator implements JsonValidator {
             
             try {
                 URL url = URLFactory.toURL(schemaUrl);
-                parentSchema = validationContext.getJsonSchemaFactory().getSchema(url);
+                parentSchema = validationContext.getJsonSchemaFactory().getSchema(url, validationContext.getConfig());
             } catch (MalformedURLException e) {
                 InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(schemaUrl);
                 parentSchema = validationContext.getJsonSchemaFactory().getSchema(is);

--- a/src/test/java/com/networknt/schema/UrlMappingTest.java
+++ b/src/test/java/com/networknt/schema/UrlMappingTest.java
@@ -130,6 +130,17 @@ public class UrlMappingTest {
         assertEquals(0, schema.validate(mapper.createObjectNode()).size());
     }
 
+    @Test
+    public void testMappingsForRef() throws IOException {
+        JsonSchemaFactory instance = JsonSchemaFactory.getInstance();
+        URL mappings = URLFactory.toURL("resource:tests/url_mapping/schema-with-ref-mapping.json");
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.setUrlMappings(getUrlMappingsFromUrl(mappings));
+        JsonSchema schema = instance.getSchema(URLFactory.toURL("resource:tests/url_mapping/schema-with-ref.json"),
+                config);
+        assertEquals(0, schema.validate(mapper.readTree(mappings)).size());
+    }
+
     private Map<URL, URL> getUrlMappingsFromUrl(URL url) throws MalformedURLException, IOException {
         HashMap<URL, URL> map = new HashMap<URL, URL>();
         for (JsonNode mapping : mapper.readTree(url)) {

--- a/src/test/java/com/networknt/schema/UrlMappingTest.java
+++ b/src/test/java/com/networknt/schema/UrlMappingTest.java
@@ -138,7 +138,7 @@ public class UrlMappingTest {
         config.setUrlMappings(getUrlMappingsFromUrl(mappings));
         JsonSchema schema = instance.getSchema(URLFactory.toURL("resource:tests/url_mapping/schema-with-ref.json"),
                 config);
-        assertEquals(0, schema.validate(mapper.readTree(mappings)).size());
+        assertEquals(0, schema.validate(mapper.readTree("[]")).size());
     }
 
     private Map<URL, URL> getUrlMappingsFromUrl(URL url) throws MalformedURLException, IOException {

--- a/src/test/resources/tests/url_mapping/schema-with-ref-mapping.json
+++ b/src/test/resources/tests/url_mapping/schema-with-ref-mapping.json
@@ -1,0 +1,10 @@
+[
+    {
+        "publicURL": "http://json-schema.org/draft-04/schema#",
+        "localURL": "resource:/draftv4.schema.json"
+    },
+    {
+        "publicURL": "http://example.com/invalid/schema/url",
+        "localURL": "resource:/tests/url_mapping/example-schema.json"
+    }
+]

--- a/src/test/resources/tests/url_mapping/schema-with-ref.json
+++ b/src/test/resources/tests/url_mapping/schema-with-ref.json
@@ -1,21 +1,10 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "json-object-with-schema",
-    "type": "object",
-    "description": "A JSON object and the schema to evaluate it against",
+    "type": "array",
     "properties": {
-        "for": {
-            "type": "object",
-            "description": "The object to evaluate"
-        },
         "schema": {
-            "$ref": "http://example.com/invalid/schema/url",
-            "description": "The Schema to evaluate the object against (using invalid URL to force failure if mapping is not correct)"
+            "$ref": "http://example.com/invalid/schema/url"
         }
-    },
-    "additionalProperties": false,
-    "required": [
-        "for",
-        "schema"
-    ]
+    }
 }

--- a/src/test/resources/tests/url_mapping/schema-with-ref.json
+++ b/src/test/resources/tests/url_mapping/schema-with-ref.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "json-object-with-schema",
+    "type": "object",
+    "description": "A JSON object and the schema to evaluate it against",
+    "properties": {
+        "for": {
+            "type": "object",
+            "description": "The object to evaluate"
+        },
+        "schema": {
+            "$ref": "http://example.com/invalid/schema/url",
+            "description": "The Schema to evaluate the object against (using invalid URL to force failure if mapping is not correct)"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "for",
+        "schema"
+    ]
+}


### PR DESCRIPTION
With this change, I think that anywhere a URL is used in a schema, it can be mapped to a local or alternate URL to be retrieved from.

Fixes #134