### PR TITLE
Dont Merge: Reproducing issue in multipleOf

### DIFF
--- a/src/test/resources/tests/multipleOf.json
+++ b/src/test/resources/tests/multipleOf.json
@@ -62,17 +62,17 @@
         "schema": {"multipleOf": 0.01},
         "tests": [
             {
-                "description": "9313.7 is not multiple of 0.01",
+                "description": "9313.7 is a multiple of 0.01",
                 "data": 9313.7,
                 "valid": true
             },
             {
-                "description": "9313.9 is not multiple of 0.01",
+                "description": "9313.9 is a multiple of 0.01",
                 "data": 9313.9,
                 "valid": true
             },
             {
-                "description": "9313.8 is multiple of 0.01",
+                "description": "9313.8 is a multiple of 0.01",
                 "data": 9313.8,
                 "valid": true
             }

--- a/src/test/resources/tests/multipleOf.json
+++ b/src/test/resources/tests/multipleOf.json
@@ -56,5 +56,26 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "by small number",
+        "schema": {"multipleOf": 0.01},
+        "tests": [
+            {
+                "description": "9313.7 is not multiple of 0.01",
+                "data": 9313.7,
+                "valid": true
+            },
+            {
+                "description": "9313.9 is not multiple of 0.01",
+                "data": 9313.9,
+                "valid": true
+            },
+            {
+                "description": "9313.8 is multiple of 0.01",
+                "data": 9313.8,
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
These two cases pass:
```json
            {
                "description": "9313.7 is a multiple of 0.01",
                "data": 9313.7,
                "valid": true
            },
            {
                "description": "9313.9 is a multiple of 0.01",
                "data": 9313.9,
                "valid": true
            },
```
And this one fails:
```json
            {
                "description": "9313.8 is a multiple of 0.01",
                "data": 9313.8,
                "valid": true
            }
```
