### PR TITLE
Fix multipleOf validator 

### DIFF
--- a/src/main/java/com/networknt/schema/MultipleOfValidator.java
+++ b/src/main/java/com/networknt/schema/MultipleOfValidator.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Set;
 
@@ -44,8 +45,10 @@ public class MultipleOfValidator extends BaseJsonValidator implements JsonValida
         if (node.isNumber()) {
             double nodeValue = node.doubleValue();
             if (divisor != 0) {
-                long multiples = Math.round(nodeValue / divisor);
-                if (Math.abs(multiples * divisor - nodeValue) > 1e-12) {
+                // convert to BigDecimal since double type is not accurate enough to do the division and multiple
+                BigDecimal accurateDividend = new BigDecimal(String.valueOf(nodeValue));
+                BigDecimal accurateDivisor = new BigDecimal(String.valueOf(divisor));
+                if (accurateDividend.divideAndRemainder(accurateDivisor)[1].doubleValue() > 1e-12) {
                     return Collections.singleton(buildValidationMessage(at, "" + divisor));
                 }
             }

--- a/src/main/java/com/networknt/schema/MultipleOfValidator.java
+++ b/src/main/java/com/networknt/schema/MultipleOfValidator.java
@@ -48,7 +48,7 @@ public class MultipleOfValidator extends BaseJsonValidator implements JsonValida
                 // convert to BigDecimal since double type is not accurate enough to do the division and multiple
                 BigDecimal accurateDividend = new BigDecimal(String.valueOf(nodeValue));
                 BigDecimal accurateDivisor = new BigDecimal(String.valueOf(divisor));
-                if (accurateDividend.divideAndRemainder(accurateDivisor)[1].doubleValue() > 1e-12) {
+                if (Math.abs(accurateDividend.divideAndRemainder(accurateDivisor)[1].doubleValue()) > 1e-12) {
                     return Collections.singleton(buildValidationMessage(at, "" + divisor));
                 }
             }

--- a/src/test/resources/tests/multipleOf.json
+++ b/src/test/resources/tests/multipleOf.json
@@ -80,8 +80,13 @@
             },
             {
                 "description": "9313.8 is a multiple of 0.01",
-                "data": 9313.888,
+                "data": -9313.8861,
                 "valid": false
+            },
+            {
+                "description": "9313.8 is a multiple of 0.01",
+                "data": -9313.8,
+                "valid": true
             }
         ]
     }

--- a/src/test/resources/tests/multipleOf.json
+++ b/src/test/resources/tests/multipleOf.json
@@ -56,5 +56,33 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "by small number",
+        "schema": {
+            "multipleOf": 0.01
+        },
+        "tests": [
+            {
+                "description": "9313.7 is a multiple of 0.01",
+                "data": 9313.7,
+                "valid": true
+            },
+            {
+                "description": "9313.9 is a multiple of 0.01",
+                "data": 9313.9,
+                "valid": true
+            },
+            {
+                "description": "9313.8 is a multiple of 0.01",
+                "data": 9313.8,
+                "valid": true
+            },
+            {
+                "description": "9313.8 is a multiple of 0.01",
+                "data": 9313.888,
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Related issue: https://github.com/networknt/json-schema-validator/pull/139

Since the division and multiple of double type do not have the enough accuracy. Convert dividend and divisor into BigDecimal to do the validation would be more reliable.