### PR TITLE
fixes #171 validation of quoted numerics added

### DIFF
--- a/src/test/java/com/networknt/schema/MaximumValidatorPerfTest.java
+++ b/src/test/java/com/networknt/schema/MaximumValidatorPerfTest.java
@@ -1,22 +1,29 @@
 package com.networknt.schema;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.DecimalNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertTrue;
+
 @Ignore
 public class MaximumValidatorPerfTest {
     MaximumValidatorTest test = new MaximumValidatorTest();
 
     @Test
     public void testTime() throws InvocationTargetException, IllegalAccessException {
-        test.setUp();
         String[] testMethodsToBeExecuted = {"testMaximumDoubleValue"};
         List<Method> testMethods = getTestMethods(testMethodsToBeExecuted);
         long start = System.currentTimeMillis();


### PR DESCRIPTION
Proposed solution to issue raised in #171

## Testing

Organized tests into sections (positive and negative) tests for `number`, `integer`, and `integer` with exclusive type of behavior.

Each collection of inputs is augmented with it's corresponding quoted counter part. 

Quoting thresholds does not seem necessary as they can be parsed into numbers at schema creation time.