### PR TITLE
Insights into performance gains of tuning min/max validators

### DIFF
--- a/src/test/java/com/networknt/schema/ThresholdMixinPerfTest.java
+++ b/src/test/java/com/networknt/schema/ThresholdMixinPerfTest.java
@@ -1,0 +1,244 @@
+package com.networknt.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.DecimalNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.math.BigDecimal;
+
+@Ignore
+public class ThresholdMixinPerfTest {
+
+//    private final double threshold = Double.MAX_VALUE - 1;
+    private final double threshold = 1797693.134E+5D;
+    private final DoubleNode maximumDouble   = new DoubleNode(threshold);
+    private final DecimalNode maximumDecimal = new DecimalNode(BigDecimal.valueOf(threshold));
+
+    private final double value = threshold+1;
+    private final DoubleNode valueDouble = new DoubleNode(value);
+    private final DecimalNode valueDecimal = new DecimalNode(new BigDecimal(value));
+    private final TextNode valueTextual = new TextNode(String.valueOf(value));
+
+    private final String maximumText = maximumDouble.asText();
+    private final BigDecimal max = new BigDecimal(maximumText);
+
+    private final int executeTimes = 200000;
+    private final boolean excludeEqual = false;
+
+    @Test
+    public void testDoubleVsBigDecimalOnCompareTimeViaMixins() throws InvocationTargetException, IllegalAccessException {
+
+        double baseTime = getAvgTimeViaMixin(asDouble, valueDouble, executeTimes);
+        System.out.println(String.format("Base execution time (comparing two DoubleNodes) %f ns \n", baseTime));
+
+        double currentAvgTimeOnDouble = getAvgTimeViaMixin(currentImplementationDouble, valueDouble, executeTimes);
+        System.out.println(String.format("Current double on double execution time %f ns, %f times slower", currentAvgTimeOnDouble, (currentAvgTimeOnDouble/baseTime)));
+
+        double currentAvgTimeOnDecimal = getAvgTimeViaMixin(currentImplementationDouble, valueDecimal, executeTimes);
+        System.out.println(String.format("Current double on decimal execution time %f ns, %f times slower", currentAvgTimeOnDecimal, (currentAvgTimeOnDecimal/baseTime)));
+
+        double currentAvgTimeOnText = getAvgTimeViaMixin(currentImplementationDouble, valueTextual, executeTimes);
+        System.out.println(String.format("Current double on text execution time %f ns, %f times slower", currentAvgTimeOnText, (currentAvgTimeOnText/baseTime)));
+
+        double currentAvgTimeDecimalOnDouble = getAvgTimeViaMixin(currentImplementationDecimal, valueDouble, executeTimes);
+        System.out.println(String.format("Current decimal on double execution time %f ns, %f times slower", currentAvgTimeDecimalOnDouble, (currentAvgTimeDecimalOnDouble/baseTime)));
+
+        double currentAvgTimeDecimalOnDecimal = getAvgTimeViaMixin(currentImplementationDecimal, valueDecimal, executeTimes);
+        System.out.println(String.format("Current decimal on decimal execution time %f ns, %f times slower", currentAvgTimeDecimalOnDecimal, (currentAvgTimeDecimalOnDecimal/baseTime)));
+
+        double currentAvgTimeDecimalOnText = getAvgTimeViaMixin(currentImplementationDecimal, valueTextual, executeTimes);
+        System.out.println(String.format("Current decimal on text execution time %f ns, %f times slower", currentAvgTimeDecimalOnText, (currentAvgTimeDecimalOnText/baseTime)));
+
+        System.out.println(String.format("Cumulative average: %f\n\n", (currentAvgTimeOnDouble+currentAvgTimeOnDecimal+currentAvgTimeOnText+currentAvgTimeDecimalOnDouble+currentAvgTimeDecimalOnDecimal+currentAvgTimeDecimalOnText)/6.0d));
+
+        double allInOneDoubleOnDouble = getAvgTimeViaMixin(allInOneDouble, valueDouble, executeTimes);
+        System.out.println(String.format("AllInOne double on double execution time  %f ns, %f times slower", allInOneDoubleOnDouble, (allInOneDoubleOnDouble/baseTime)));
+
+        double allInOneDoubleOnDecimal = getAvgTimeViaMixin(allInOneDouble, valueDecimal, executeTimes);
+        System.out.println(String.format("AllInOne double on decimal execution time %f ns, %f times slower", allInOneDoubleOnDecimal, (allInOneDoubleOnDecimal/baseTime)));
+
+        double allInOneDoubleOnText = getAvgTimeViaMixin(allInOneDouble, valueTextual, executeTimes);
+        System.out.println(String.format("AllInOne double on text execution time %f ns, %f times slower", allInOneDoubleOnText, (allInOneDoubleOnText/baseTime)));
+
+        double allInOneDecimalOnDouble = getAvgTimeViaMixin(allInOneDecimal, valueDouble, executeTimes);
+        System.out.println(String.format("AllInOne decimal on double execution time %f ns, %f times slower", allInOneDecimalOnDouble, (allInOneDecimalOnDouble/baseTime)));
+
+        double allInOneDecimalOnDecimal = getAvgTimeViaMixin(allInOneDecimal, valueDecimal, executeTimes);
+        System.out.println(String.format("AllInOne decimal on decimal execution time %f ns, %f times slower", allInOneDecimalOnDecimal, (allInOneDecimalOnDecimal/baseTime)));
+
+        double allInOneDecimalOnText = getAvgTimeViaMixin(allInOneDecimal, valueTextual, executeTimes);
+        System.out.println(String.format("AllInOne decimal on text execution time %f ns, %f times slower", allInOneDecimalOnText, (allInOneDecimalOnText/baseTime)));
+
+        System.out.println(String.format("Cumulative average: %f\n\n", (allInOneDoubleOnDouble+allInOneDoubleOnDecimal+allInOneDoubleOnText+allInOneDecimalOnDouble+allInOneDecimalOnDecimal+allInOneDecimalOnText)/6.0d));
+
+        double typedThresholdOnDouble = getAvgTimeViaMixin(typedThreshold, valueDouble, executeTimes);
+        System.out.println(String.format("Typed threshold execution time %f ns, %f times slower", typedThresholdOnDouble, (typedThresholdOnDouble/baseTime)));
+
+        double typedThresholdOnDecimal = getAvgTimeViaMixin(typedThreshold, valueDecimal, executeTimes);
+        System.out.println(String.format("Typed threshold execution time %f ns, %f times slower", typedThresholdOnDecimal, (typedThresholdOnDecimal/baseTime)));
+
+        double typedThresholdOnText = getAvgTimeViaMixin(typedThreshold, valueTextual, executeTimes);
+        System.out.println(String.format("Typed threshold execution time %f ns, %f times slower", typedThresholdOnText, (typedThresholdOnText/baseTime)));
+
+        System.out.println(String.format("Cumulative average: %f\n\n", (typedThresholdOnDouble+typedThresholdOnDecimal+typedThresholdOnText)/3.0d));
+    }
+
+    ThresholdMixin allInOneDouble = new AllInOneThreshold(maximumDouble, false);
+    ThresholdMixin allInOneDecimal = new AllInOneThreshold(maximumDecimal, false);
+
+    public static class AllInOneThreshold implements ThresholdMixin {
+
+        private final BigDecimal bigDecimalMax;
+        JsonNode maximum;
+        private boolean excludeEqual;
+
+        AllInOneThreshold(JsonNode maximum, boolean exludeEqual){
+            this.maximum = maximum;
+            this.excludeEqual = exludeEqual;
+            this.bigDecimalMax = new BigDecimal(maximum.asText());
+        }
+
+        @Override
+        public boolean crossesThreshold(JsonNode node) {
+            if (maximum.isDouble() && maximum.doubleValue() == Double.POSITIVE_INFINITY) {
+                return false;
+            }
+            if (maximum.isDouble() && maximum.doubleValue() == Double.NEGATIVE_INFINITY) {
+                return true;
+            }
+            if (maximum.isDouble() && node.isDouble()) {
+                double lm = maximum.doubleValue();
+                double val = node.doubleValue();
+                return lm < val || (excludeEqual && lm == val);
+            }
+
+            if (maximum.isFloatingPointNumber() && node.isFloatingPointNumber()) {
+                BigDecimal value = node.decimalValue();
+                int compare = value.compareTo(bigDecimalMax);
+                return compare > 0 || (excludeEqual && compare == 0);
+            }
+
+            BigDecimal value = new BigDecimal(node.asText());
+            int compare = value.compareTo(bigDecimalMax);
+            return compare > 0 || (excludeEqual && compare == 0);
+        }
+
+        @Override
+        public String thresholdValue() {
+            return maximum.asText();
+        }
+    };
+
+    ThresholdMixin asDouble = new ThresholdMixin() {
+        @Override
+        public boolean crossesThreshold(JsonNode node) {
+            double lm = maximumDouble.doubleValue();
+            double val = node.doubleValue();
+            return lm < val || (excludeEqual && lm == val);
+        }
+
+        @Override
+        public String thresholdValue() {
+            return maximumText;
+        }
+    };
+
+    ThresholdMixin typedThreshold = new ThresholdMixin() {
+        @Override
+        public boolean crossesThreshold(JsonNode node) {
+            if (node.isDouble()) {
+                double lm = maximumDouble.doubleValue();
+                double val = node.doubleValue();
+                return lm < val || (excludeEqual && lm == val);
+            }
+
+            if (node.isBigDecimal()) {
+                BigDecimal value = node.decimalValue();
+                int compare = value.compareTo(max);
+                return compare > 0 || (excludeEqual && compare == 0);
+            }
+
+            BigDecimal value = new BigDecimal(node.asText());
+            int compare = value.compareTo(max);
+            return compare > 0 || (excludeEqual && compare == 0);
+        }
+
+        @Override
+        public String thresholdValue() {
+            return maximumText;
+        }
+    };
+
+    ThresholdMixin currentImplementationDouble = new ThresholdMixin() {
+        @Override
+        public boolean crossesThreshold(JsonNode node) {
+            if (maximumDouble.isDouble() && maximumDouble.doubleValue() == Double.POSITIVE_INFINITY) {
+                return false;
+            }
+            if (maximumDouble.isDouble() && maximumDouble.doubleValue() == Double.NEGATIVE_INFINITY) {
+                return true;
+            }
+            if (node.isDouble() && node.doubleValue() == Double.NEGATIVE_INFINITY) {
+                return false;
+            }
+            if (node.isDouble() && node.doubleValue() == Double.POSITIVE_INFINITY) {
+                return true;
+            }
+            final BigDecimal max = new BigDecimal(maximumText);
+            BigDecimal value = new BigDecimal(node.asText());
+            int compare = value.compareTo(max);
+            return compare > 0 || (excludeEqual && compare == 0);
+        }
+
+        @Override
+        public String thresholdValue() {
+            return maximumText;
+        }
+    };
+
+
+    ThresholdMixin currentImplementationDecimal = new ThresholdMixin() {
+        @Override
+        public boolean crossesThreshold(JsonNode node) {
+            if (maximumDecimal.isDouble() && maximumDecimal.doubleValue() == Double.POSITIVE_INFINITY) {
+                return false;
+            }
+            if (maximumDecimal.isDouble() && maximumDecimal.doubleValue() == Double.NEGATIVE_INFINITY) {
+                return true;
+            }
+            if (node.isDouble() && node.doubleValue() == Double.NEGATIVE_INFINITY) {
+                return false;
+            }
+            if (node.isDouble() && node.doubleValue() == Double.POSITIVE_INFINITY) {
+                return true;
+            }
+            final BigDecimal max = new BigDecimal(maximumText);
+            BigDecimal value = new BigDecimal(node.asText());
+            int compare = value.compareTo(max);
+            return compare > 0 || (excludeEqual && compare == 0);
+        }
+
+        @Override
+        public String thresholdValue() {
+            return maximumText;
+        }
+    };
+
+    private double getAvgTimeViaMixin(ThresholdMixin mixin, JsonNode value, int iterations) {
+        boolean excludeEqual = false;
+        long totalTime = 0;
+        for(int i = 0; i < iterations; i++) {
+            long start = System.nanoTime();
+            try {
+                mixin.crossesThreshold(value);
+            } finally {
+                totalTime += System.nanoTime() - start;
+            }
+        }
+        return totalTime / (iterations * 1.0D);
+    }
+}


### PR DESCRIPTION
## Context

While there is a wide range of tradeoffs between code readability/maintainability and performance it would be interesting to look at how much speed is given up with different levels of readability.

This PR offers a simple test-case-like setup that allows do have some ball-park numbers to make discussion more concrete. Also by no means is this test suite complete or precise.

## Methodology

### Base case
Since there was no isolated environment to do the benchmarking on, I opted for benchmarking with respect to some "base" cases. Base cases were chosen as comparing two `DoubleNode` and comparing two `LongNode`. 

### Average time
Time is measured as difference between start and end of `ThresholdMixin` execution, and averaged over number of executions. Then average time for a particular case is compared to average time of a corresponding base case

### Cases
Each combination of threshold and value is measured separately. Measurement for each combination is treated equally, which might not be true for a particular production setup, i.e. if numbers in schema/payload were always generated without quotes and for values within 64-bit range cases with `double`/`double` and `integer`/`integer` comparison would account for majority of use-cases.

### Test values
Same numbers were used across multiple tests. Numbers were set to be within 64bit range. See [Insights](#insights) section for more.

## Considered cases

Which cases should we consider when talking about performance/readability spectrum? Before going into case let us describe some questions each of the cases would have to answer to be functionally correct:

* What json schma `"type"` was provided ? 
  Generally two are assumed: `"integer"` and `"number"`

* What threshold value was provided? 
  Here we can talk of CPU-word long case (aka `long`/`double`) and a number that are outside CPU-word length (aka `BigInteger`/`BigDecimal`).
  Case of quoted numeric value can easily be assumed as one of the above two cases, as threshold assignment happens at schema creation and does not generally affect the validation runtime.

* What value node was provided for comparison?
   There seems to be 5 major categories, 4 similar to ones in threshold aspect plus a quoted value. Since string parsing now contributes to validation runtime we need to include this separately.

### case 1: blind type coercing

Essentially it would functionally correct to coerce any threshold to a `BigDecimal` do the very same thing to comparison value and then compare two `BigDecimal` values. Very readable, simple and clean. `ThresholdMixin` is not really a necessity here. even less code! Performance comparable (might even slightly improve) compared to current setup.

### case 2: special treatment for `"integer"` type, current setup

Assume that `"number"` type comparison is performed similarly to blind coercing and give special treatment to `"integer"`. This already brings in `ThresholdMixin` into picture and given that threshold value can still be expressed as a floating point calls for a several sub-cases. Readability degraded. Same performance. Mixin could be refactored into it's own class, making code slightly less cluttered.

### case 3: special treatment for value types

Here each `"integer"` and `"number"` each get their own mixin. At runtime mixin differentiates between values under/above 64-bit. Major speedup ~2x performance gain. Readability degraded similar to current case.

### case 4: Special treatment to `"types"` and threshold values

Here a dedicated mixin is created based on combination of expected type *and* actual value provided for `minimum`/`maximum`. Number of mixins grows up to 4-6 (depending on implementation), runtime code for each mixin still needs to differentiate between different value types. Readability is greatly reduced. Performance gain ~30% over the special treatment for each of value types case

## Insights

After some examination it looks like most of performance penalty is payed when a `double`/`long` value is serialized to string and then de-serialized back into some sort of numeric representation. Similar to this snippet

```java
BigDecimal value = new BigDecimal(node.asText());
```

Both "big" number and textual values seem to perform better for such code. Also performance gains become more apparent as size of the value grows. Likely because bigger values usually take more symbols in a serialized form which then means a longer input for de-serializing the value.

## Personal note

Not sure what is the major use case for light-4j frameworks. From where I am coming it looks like overwhelming majority of inputs is quoted numerics (`long`/`double` values serialized with quotes around them), with a minor share of values under 32-bits that come in unquoted form. 

## Reference

Sample result from my laptop (3.1 GHz Intel Core i7)

Base execution time (comparing two DoubleNodes) 36-59 ns
Base execution time (comparing two LongeNodes) 36-59 ns 

```
||                         ||  value 64bit || value over 64bit || quoted value ||
| case 1 (float inputs)     | 176 ns        | 109 ns            | 192 ns        |
| case 1 (intg inputs       | 194.58 ns     | 536 ns            | 93.7 ns       |
| case 2 (float inputs)     | 357.8 ns      | 253.6 ns          | 179 ns        |
| case 3 (float inputs)     | 44 ns         | 50 ns             | 107 ns        | 
| case 3 (big float inputs) | 201.6 ns      | 47.66 ns          | 105 ns        | 
| case 4                    | 39.95 ns      | 62 ns             | 107 ns        |
```

or in terms of base performance
```
||                         || value 64bit || value over 64bit || quoted value ||
| case 1 (float inputs)     | x2.96        | x1.8              | x3.2          |
| case 1 (intg inputs       | x4.97        | x13.7             | x2.4 .        |
| case 2 (float inputs)     | x9.2         | x6.54             | x4.6          |
| case 3 (float inputs)     | x1.2         | x1.4              | x2.9          | 
| case 3 (big float inputs) | x5.5         | x1.3              | x2.9          | 
| case 4                    | x1.05        | x1.6              | x2.8          |
```
