### PR TITLE
#173 - Do not ignore other errors in case of anyOf validator

### DIFF
--- a/src/main/java/com/networknt/schema/AnyOfValidator.java
+++ b/src/main/java/com/networknt/schema/AnyOfValidator.java
@@ -45,7 +45,6 @@ public class AnyOfValidator extends BaseJsonValidator implements JsonValidator {
 
         Set<ValidationMessage> allErrors = new LinkedHashSet<ValidationMessage>();
         String typeValidatorName = "anyOf/type";
-        List<String> expectedTypeList = new ArrayList<String>();
 
         for (JsonSchema schema : schemas) {
             if (schema.validators.containsKey(typeValidatorName)) {
@@ -53,7 +52,7 @@ public class AnyOfValidator extends BaseJsonValidator implements JsonValidator {
                 //If schema has type validator and node type doesn't match with schemaType then ignore it
                 //For union type, it is must to call TypeValidator
                 if (typeValidator.getSchemaType() != JsonType.UNION && !typeValidator.equalsToSchemaType(node)) {
-                    expectedTypeList.add(typeValidator.getSchemaType().toString());
+                    allErrors.add(buildValidationMessage(at, typeValidator.getSchemaType().toString()));
                     continue;
                 }
             }
@@ -62,9 +61,6 @@ public class AnyOfValidator extends BaseJsonValidator implements JsonValidator {
                 return errors;
             }
             allErrors.addAll(errors);
-        }
-        if (!expectedTypeList.isEmpty()) {
-            return Collections.singleton(buildValidationMessage(at, expectedTypeList.toArray(new String[expectedTypeList.size()])));
         }
         return Collections.unmodifiableSet(allErrors);
     }

--- a/src/test/java/com/networknt/schema/JsonSchemaTest.java
+++ b/src/test/java/com/networknt/schema/JsonSchemaTest.java
@@ -95,16 +95,25 @@ public class JsonSchemaTest {
 
                     if (test.get("valid").asBoolean()) {
                         if (!errors.isEmpty()) {
-                            System.out.println("---- test case filed ----");
+                            System.out.println("---- test case failed ----");
                             System.out.println("schema: " + schema.toString());
                             System.out.println("data: " + test.get("data"));
                         }
                         Assert.assertEquals(0, errors.size());
                     } else {
                         if (errors.isEmpty()) {
-                            System.out.println("---- test case filed ----");
+                            System.out.println("---- test case failed ----");
                             System.out.println("schema: " + schema);
                             System.out.println("data: " + test.get("data"));
+                        } else {
+                            JsonNode errorCount = test.get("errorCount");
+                            if (errorCount != null && errorCount.isInt() && errors.size() != errorCount.asInt()) {
+                                System.out.println("---- test case failed ----");
+                                System.out.println("schema: " + schema);
+                                System.out.println("data: " + test.get("data"));
+                                System.out.println("errors: " + errors);
+                                Assert.assertEquals("expected error count", errorCount.asInt(), errors.size());
+                            }
                         }
                         Assert.assertEquals(false, errors.isEmpty());
                     }

--- a/src/test/resources/tests/anyOf.json
+++ b/src/test/resources/tests/anyOf.json
@@ -94,5 +94,110 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "all errors are listed",
+        "schema": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "test": {
+                            "type": "string",
+                            "enum": [ "A", "B" ]
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "neither anyOf valid",
+                "data": {
+                    "test": "C"
+                },
+                "valid": false,
+                "errorCount": 2
+            },
+            {
+                "description": "first anyOf valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid",
+                "data": {
+                    "test": "A"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "all errors are listed",
+        "schema": {
+            "type": "array",
+            "items": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "test": {
+                                "type": "string",
+                                "enum": [ "A", "B" ]
+                            }
+                        }
+                    },
+                    {
+                    "type": "null"
+                    }
+                ]
+            }
+        },
+        "tests": [
+            {
+                "description": "neither anyOf valid",
+                "data": [{
+                    "test": "C"
+                }],
+                "valid": false,
+                "errorCount": 2
+            },
+            {
+                "description": "first anyOf valid",
+                "data": [null],
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid",
+                "data": [{
+                    "test": "A"
+                }],
+                "valid": true
+            },
+            {
+                "description": "mixed anyOf valid",
+                "data": [{
+                    "test": "A"
+                }, null, {
+                    "test": 2
+                }],
+                "valid": false,
+                "errorCount": 3
+            },
+            {
+                "description": "mixed anyOf valid",
+                "data": [{
+                    "test": "A"
+                }, null, {
+                    "test": 2
+                }, 2],
+                "valid": false,
+                "errorCount": 5
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Fixes issue #173
Also added a way to validate the error count in test cases using the optional int field `"errorCount"`