### PR TITLE
Expose URI Factory

### DIFF
--- a/src/main/java/com/networknt/schema/JsonSchemaFactory.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaFactory.java
@@ -245,6 +245,14 @@ public class JsonSchemaFactory {
         }
         return jsonMetaSchema;
     }
+    
+    /**
+     * @return A shared {@link URI} factory that is used for creating the URI references in schemas.
+     */
+    public URIFactory getUriFactory()
+    {
+    	return this.uriFactory;
+    }
 	
     public JsonSchema getSchema(final String schema, final SchemaValidatorsConfig config) {
         try {


### PR DESCRIPTION
This just has to do with a minor limitation that I've encountered. 

The JsonSchemaFactory allows URIFactories to be given for various URI schemes. The JsonSchemaFactory then builds up a URISchemeFactory that delegates creation to URIFactories based on the needed scheme. This was something that I previously added in to allow custom URI support and all that good stuff. 

The problem is that the users of this library will also need to create URIs. The JsonSchemaFactory accepts URIs for the location of the schema to use. So the user essentially needs to have their own URI creation utility and then we'll also use a separate one under the hood. This doesn't work out very well, because the user won't be able to use our custom classpath URI factory/fetcher.

If we simply just provide access to the URIFactory that the JsonSchemaFactory is using, then the user would be able to create the same URI objects as this library. In the case of my application (I'm a user), my schema URIs are represented as strings until the point where I need to load up a JsonSchema. At that point, it would be really convenient to grab the JsonSchemaFactory's URIFactory and then get my schema URI ready for the JsonSchemaFactory#getSchema.

This pull request is mainly just a suggestion. I don't mind if it gets rejected.