### PR TITLE
Fix issue #180: Prevents recursive parsing of $ref references.

### DIFF
--- a/src/main/java/com/networknt/schema/JsonSchemaRef.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaRef.java
@@ -1,0 +1,40 @@
+package com.networknt.schema;
+
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Use this object instead a JsonSchema for references.
+ *
+ * This reference may be empty (if the reference is being parsed) or with data (after the reference has been parsed),
+ * helping to prevent recursive reference to cause an infinite loop.
+ */
+
+public class JsonSchemaRef {
+
+    private JsonSchema schema;
+    private ValidationContext validationContext;
+    private String refValue;
+
+    public JsonSchemaRef(ValidationContext validationContext, String refValue) {
+        this.validationContext = validationContext;
+        this.refValue = refValue;
+    }
+
+    public JsonSchemaRef(JsonSchema schema) {
+        this.schema = schema;
+    }
+
+    public void set(JsonSchema schema) {
+        this.schema = schema;
+    }
+
+    public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
+        return schema.validate(node, rootNode, at);
+    }
+
+    public JsonSchema getSchema() {
+        return schema;
+    }
+}

--- a/src/main/java/com/networknt/schema/ValidationContext.java
+++ b/src/main/java/com/networknt/schema/ValidationContext.java
@@ -16,6 +16,9 @@
 
 package com.networknt.schema;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.uri.URIFactory;
 
@@ -24,7 +27,8 @@ public class ValidationContext {
     private final JsonMetaSchema metaSchema;
     private final JsonSchemaFactory jsonSchemaFactory;
     private SchemaValidatorsConfig config;
-    
+    private final Map<String, JsonSchemaRef> refParsingInProgress = new HashMap<>();
+
     public ValidationContext(URIFactory uriFactory, JsonMetaSchema metaSchema, JsonSchemaFactory jsonSchemaFactory) {
         if (uriFactory == null) {
             throw new IllegalArgumentException("URIFactory must not be null");
@@ -39,16 +43,16 @@ public class ValidationContext {
         this.metaSchema = metaSchema;
         this.jsonSchemaFactory = jsonSchemaFactory;
     }
-    
+
     public JsonValidator newValidator(String schemaPath, String keyword /* keyword */, JsonNode schemaNode,
                                       JsonSchema parentSchema) {
         return metaSchema.newValidator(this, schemaPath, keyword, schemaNode, parentSchema);
     }
-    
+
     public URIFactory getURIFactory() {
         return this.uriFactory;
     }
-    
+
     public JsonSchemaFactory getJsonSchemaFactory() {
         return jsonSchemaFactory;
     }
@@ -60,4 +64,13 @@ public class ValidationContext {
     public void setConfig(SchemaValidatorsConfig config) {
         this.config = config;
     }
+
+    public void setReferenceParsingInProgress(String refValue, JsonSchemaRef ref) {
+        refParsingInProgress.put(refValue, ref);
+    }
+
+    public JsonSchemaRef getReferenceParsingInProgress(String refValue) {
+        return refParsingInProgress.get(refValue);
+    }
+
 }


### PR DESCRIPTION
Prevents recursive parsing of json schema when conditions like told in json-schema specification, point 8.3.1:

https://json-schema.org/latest/json-schema-core.html#rfc.section.8.3.1

"A schema MUST NOT be run into an infinite loop against a schema. For example, if two schemas "#alice" and "#bob" both have an "allOf" property that refers to the other, a naive validator might get stuck in an infinite recursive loop trying to validate the instance. Schemas SHOULD NOT make use of infinite recursive nesting like this; the behavior is undefined. "