### PR TITLE
Fixing ref validation with same name but different files

### DIFF
--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -45,6 +45,8 @@ public class RefValidator extends BaseJsonValidator implements JsonValidator {
     }
 
     static JsonSchemaRef getRefSchema(JsonSchema parentSchema, ValidationContext validationContext, String refValue) {
+        final String refValueOriginal = refValue;
+
         if (!refValue.startsWith(REF_CURRENT)) {
             // This will be the uri extracted from the refValue (this may be a relative or absolute uri).
             final String refUri;
@@ -76,10 +78,10 @@ public class RefValidator extends BaseJsonValidator implements JsonValidator {
         } else {
             JsonNode node = parentSchema.getRefSchemaNode(refValue);
             if (node != null) {
-                JsonSchemaRef ref = validationContext.getReferenceParsingInProgress(refValue);
+                JsonSchemaRef ref = validationContext.getReferenceParsingInProgress(refValueOriginal);
                 if (ref == null) {
                     ref = new JsonSchemaRef(validationContext, refValue);
-                    validationContext.setReferenceParsingInProgress(refValue, ref);
+                    validationContext.setReferenceParsingInProgress(refValueOriginal, ref);
                     JsonSchema ret = new JsonSchema(validationContext, refValue, parentSchema.getCurrentUri(), node, parentSchema);
                     ref.set(ret);
                 }

--- a/src/test/resources/tests/ref.json
+++ b/src/test/resources/tests/ref.json
@@ -96,6 +96,29 @@
         ]
     },
     {
+        "description": "nested refs with duplicate ref values for different files",
+        "schema": {
+            "definitions": {
+                "a": {"$ref": "subSchemas.json#/definitions/a"},
+                "b": {"$ref": "#/definitions/a"},
+                "c": {"$ref": "#/definitions/b"}
+            },
+            "$ref": "#/definitions/c"
+        },
+        "tests": [
+            {
+                "description": "nested ref valid",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "nested ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "remote ref, containing refs itself",
         "schema": {"$ref": "http://json-schema.org/draft-04/schema#"},
         "tests": [

--- a/src/test/resources/tests/subSchemas.json
+++ b/src/test/resources/tests/subSchemas.json
@@ -4,5 +4,8 @@
 	},
 	"refToInteger" : {
 		"$ref" : "#/integer"
+	},
+	"definitions" : {
+		"a" : { "type": "integer" }
 	}
 }


### PR DESCRIPTION
Avoid java.lang.StackOverFlowError.
related issue https://github.com/networknt/json-schema-validator/issues/208