### PR TITLE
Fix for oneOf when not all properties are matched

### DIFF
--- a/src/test/resources/draft2019-09/oneOf.json
+++ b/src/test/resources/draft2019-09/oneOf.json
@@ -115,8 +115,7 @@
             "oneOf": [
                 {
                     "properties": {
-                        "bar": {"type": "integer"},
-                        "baz": {"type": "integer"}
+                        "bar": {"type": "integer"}
                     },
                     "required": ["bar"]
                 },
@@ -200,6 +199,48 @@
             {
                 "description": "both valid - invalid",
                 "data": {"foo": 1, "bar": 2, "baz" : 3},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with missing optional property",
+        "schema": {
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": true,
+                        "baz": true
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": true
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": {"bar": 8},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": {"foo": "foo"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": {"foo": "foo", "bar": 8},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": {"baz": "quux"},
                 "valid": false
             }
         ]

--- a/src/test/resources/draft2019-09/oneOf.json
+++ b/src/test/resources/draft2019-09/oneOf.json
@@ -115,7 +115,8 @@
             "oneOf": [
                 {
                     "properties": {
-                        "bar": {"type": "integer"}
+                        "bar": {"type": "integer"},
+                        "baz": {"type": "integer"}
                     },
                     "required": ["bar"]
                 },

--- a/src/test/resources/draft4/oneOf.json
+++ b/src/test/resources/draft4/oneOf.json
@@ -128,6 +128,9 @@
             "oneOf": [
                 {
                     "type": "object",
+                    "required": [
+                        "id"
+                    ],
                     "properties": {
                         "color": {
                           "type": "string"
@@ -175,6 +178,13 @@
                     "type": "INVALID_TYPE"
                 },
                 "valid": false
+            },
+            {
+                "description": "first oneOf missing property but still valid",
+                "data": {
+                    "id": "abc"
+                },
+                "valid": true
             }
         ]
     },

--- a/src/test/resources/draft6/oneOf.json
+++ b/src/test/resources/draft6/oneOf.json
@@ -115,8 +115,7 @@
             "oneOf": [
                 {
                     "properties": {
-                        "bar": {"type": "integer"},
-                        "baz": {"type": "integer"}
+                        "bar": {"type": "integer"}
                     },
                     "required": ["bar"]
                 },
@@ -200,6 +199,48 @@
             {
                 "description": "both valid - invalid",
                 "data": {"foo": 1, "bar": 2, "baz" : 3},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with missing optional property",
+        "schema": {
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": true,
+                        "baz": true
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": true
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": {"bar": 8},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": {"foo": "foo"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": {"foo": "foo", "bar": 8},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": {"baz": "quux"},
                 "valid": false
             }
         ]

--- a/src/test/resources/draft6/oneOf.json
+++ b/src/test/resources/draft6/oneOf.json
@@ -115,7 +115,8 @@
             "oneOf": [
                 {
                     "properties": {
-                        "bar": {"type": "integer"}
+                        "bar": {"type": "integer"},
+                        "baz": {"type": "integer"}
                     },
                     "required": ["bar"]
                 },

--- a/src/test/resources/draft7/oneOf.json
+++ b/src/test/resources/draft7/oneOf.json
@@ -115,8 +115,7 @@
             "oneOf": [
                 {
                     "properties": {
-                        "bar": {"type": "integer"},
-                        "baz": {"type": "integer"}
+                        "bar": {"type": "integer"}
                     },
                     "required": ["bar"]
                 },
@@ -200,6 +199,48 @@
             {
                 "description": "both valid - invalid",
                 "data": {"foo": 1, "bar": 2, "baz" : 3},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with missing optional property",
+        "schema": {
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": true,
+                        "baz": true
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": true
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": {"bar": 8},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": {"foo": "foo"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": {"foo": "foo", "bar": 8},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": {"baz": "quux"},
                 "valid": false
             }
         ]

--- a/src/test/resources/draft7/oneOf.json
+++ b/src/test/resources/draft7/oneOf.json
@@ -115,7 +115,8 @@
             "oneOf": [
                 {
                     "properties": {
-                        "bar": {"type": "integer"}
+                        "bar": {"type": "integer"},
+                        "baz": {"type": "integer"}
                     },
                     "required": ["bar"]
                 },


### PR DESCRIPTION
The schema
```
"oneOf": [
  {
    "properties": {
      "bar": {"type": "integer"},
      "baz": {"type": "integer"}
    },
    "required": ["bar"]
  },
  {
    "properties": {
      "foo": {"type": "string"}
    },
    "required": ["foo"]
  }
]
```
fails to match the instance 
```
{"bar": 2}
```
because `PropertiesValidator` exits the first oneOf branch when "baz" is not matched, even though it is not required. This PR fixes this.