### PR TITLE
Resolve schema id from the schema document (for v6 and above)

### DIFF
--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -75,18 +75,18 @@ public class JsonSchema extends BaseJsonValidator {
         this.currentUri = this.combineCurrentUriWithIds(currentUri, schemaNode);
         this.validators = Collections.unmodifiableMap(this.read(schemaNode));
     }
-    
+
     private URI combineCurrentUriWithIds(URI currentUri, JsonNode schemaNode) {
-      final JsonNode idNode = schemaNode.get("id");
-      if (idNode == null) {
-        return currentUri;
-      } else {
-        try {
-          return this.validationContext.getURIFactory().create(currentUri, idNode.asText());
-        } catch (IllegalArgumentException e) {
-          throw new JsonSchemaException(ValidationMessage.of(ValidatorTypeCode.ID.getValue(), ValidatorTypeCode.ID, idNode.asText(), currentUri.toString()));
+        final String id = validationContext.resolveSchemaId(schemaNode);
+        if (id == null) {
+            return currentUri;
+        } else {
+            try {
+                return this.validationContext.getURIFactory().create(currentUri, id);
+            } catch (IllegalArgumentException e) {
+                throw new JsonSchemaException(ValidationMessage.of(ValidatorTypeCode.ID.getValue(), ValidatorTypeCode.ID, id, currentUri.toString()));
+            }
         }
-      }
     }
     
     public URI getCurrentUri()

--- a/src/main/java/com/networknt/schema/ValidationContext.java
+++ b/src/main/java/com/networknt/schema/ValidationContext.java
@@ -50,6 +50,10 @@ public class ValidationContext {
         return metaSchema.newValidator(this, schemaPath, keyword, schemaNode, parentSchema);
     }
 
+    public String resolveSchemaId(JsonNode schemaNode) {
+        return metaSchema.readId(schemaNode);
+    }
+
     public URIFactory getURIFactory() {
         return this.uriFactory;
     }

--- a/src/test/java/com/networknt/schema/V201909JsonSchemaTest.java
+++ b/src/test/java/com/networknt/schema/V201909JsonSchemaTest.java
@@ -11,17 +11,13 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import static io.undertow.Handlers.resource;
-import static org.junit.Assert.*;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
 
 public class V201909JsonSchemaTest {
     protected ObjectMapper mapper = new ObjectMapper();
@@ -400,9 +396,14 @@ public class V201909JsonSchemaTest {
     }
 
     @Test
-    @Ignore
     public void testRefRemoteValidator() throws Exception {
         runTestFile("draft2019-09/refRemote.json");
+    }
+
+    @Test
+    @Ignore
+    public void testRefRemoteValidator_Ignored() throws Exception {
+        runTestFile("draft2019-09/refRemote_ignored.json");
     }
 
     @Test

--- a/src/test/java/com/networknt/schema/V6JsonSchemaTest.java
+++ b/src/test/java/com/networknt/schema/V6JsonSchemaTest.java
@@ -288,9 +288,14 @@ public class V6JsonSchemaTest {
     }
 
     @Test
-    @Ignore
     public void testRefRemoteValidator() throws Exception {
         runTestFile("draft6/refRemote.json");
+    }
+
+    @Test
+    @Ignore
+    public void testRefRemoteValidator_Ignored() throws Exception {
+        runTestFile("draft6/refRemote_ignored.json");
     }
 
     @Test

--- a/src/test/java/com/networknt/schema/V7JsonSchemaTest.java
+++ b/src/test/java/com/networknt/schema/V7JsonSchemaTest.java
@@ -389,9 +389,14 @@ public class V7JsonSchemaTest {
     }
 
     @Test
-    @Ignore
     public void testRefRemoteValidator() throws Exception {
         runTestFile("draft7/refRemote.json");
+    }
+
+    @Test
+    @Ignore
+    public void testRefRemoteValidator_Ignored() throws Exception {
+        runTestFile("draft7/refRemote_ignored.json");
     }
 
     @Test

--- a/src/test/resources/draft2019-09/refRemote.json
+++ b/src/test/resources/draft2019-09/refRemote.json
@@ -99,37 +99,6 @@
         ]
     },
     {
-        "description": "base URI change - change folder in subschema",
-        "schema": {
-            "$id": "http://localhost:1234/scope_change_defs2.json",
-            "type" : "object",
-            "properties": {"list": {"$ref": "#/$defs/baz/$defs/bar"}},
-            "$defs": {
-                "baz": {
-                    "$id": "folder/",
-                    "$defs": {
-                        "bar": {
-                            "type": "array",
-                            "items": {"$ref": "folderInteger.json"}
-                        }
-                    }
-                }
-            }
-        },
-        "tests": [
-            {
-                "description": "number is valid",
-                "data": {"list": [1]},
-                "valid": true
-            },
-            {
-                "description": "string is invalid",
-                "data": {"list": ["a"]},
-                "valid": false
-            }
-        ]
-    },
-    {
         "description": "root ref in remote ref",
         "schema": {
             "$id": "http://localhost:1234/object",

--- a/src/test/resources/draft2019-09/refRemote_ignored.json
+++ b/src/test/resources/draft2019-09/refRemote_ignored.json
@@ -1,0 +1,33 @@
+[
+    {
+        "description": "base URI change - change folder in subschema",
+        "schema": {
+            "$id": "http://localhost:1234/scope_change_defs2.json",
+            "type" : "object",
+            "properties": {"list": {"$ref": "#/$defs/baz/$defs/bar"}},
+            "$defs": {
+                "baz": {
+                    "$id": "folder/",
+                    "$defs": {
+                        "bar": {
+                            "type": "array",
+                            "items": {"$ref": "folderInteger.json"}
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+]

--- a/src/test/resources/draft6/refRemote.json
+++ b/src/test/resources/draft6/refRemote.json
@@ -101,39 +101,6 @@
         ]
     },
     {
-        "description": "base URI change - change folder in subschema",
-        "schema": {
-            "$id": "http://localhost:1234/scope_change_defs2.json",
-            "type" : "object",
-            "properties": {
-                "list": {"$ref": "#/definitions/baz/definitions/bar"}
-            },
-            "definitions": {
-                "baz": {
-                    "$id": "folder/",
-                    "definitions": {
-                        "bar": {
-                            "type": "array",
-                            "items": {"$ref": "folderInteger.json"}
-                        }
-                    }
-                }
-            }
-        },
-        "tests": [
-            {
-                "description": "number is valid",
-                "data": {"list": [1]},
-                "valid": true
-            },
-            {
-                "description": "string is invalid",
-                "data": {"list": ["a"]},
-                "valid": false
-            }
-        ]
-    },
-    {
         "description": "root ref in remote ref",
         "schema": {
             "$id": "http://localhost:1234/object",

--- a/src/test/resources/draft6/refRemote_ignored.json
+++ b/src/test/resources/draft6/refRemote_ignored.json
@@ -1,0 +1,35 @@
+[
+    {
+        "description": "base URI change - change folder in subschema",
+        "schema": {
+            "$id": "http://localhost:1234/scope_change_defs2.json",
+            "type" : "object",
+            "properties": {
+                "list": {"$ref": "#/definitions/baz/definitions/bar"}
+            },
+            "definitions": {
+                "baz": {
+                    "$id": "folder/",
+                    "definitions": {
+                        "bar": {
+                            "type": "array",
+                            "items": {"$ref": "folderInteger.json"}
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/src/test/resources/draft7/refRemote.json
+++ b/src/test/resources/draft7/refRemote.json
@@ -101,39 +101,6 @@
         ]
     },
     {
-        "description": "base URI change - change folder in subschema",
-        "schema": {
-            "$id": "http://localhost:1234/scope_change_defs2.json",
-            "type" : "object",
-            "properties": {
-                "list": {"$ref": "#/definitions/baz/definitions/bar"}
-            },
-            "definitions": {
-                "baz": {
-                    "$id": "folder/",
-                    "definitions": {
-                        "bar": {
-                            "type": "array",
-                            "items": {"$ref": "folderInteger.json"}
-                        }
-                    }
-                }
-            }
-        },
-        "tests": [
-            {
-                "description": "number is valid",
-                "data": {"list": [1]},
-                "valid": true
-            },
-            {
-                "description": "string is invalid",
-                "data": {"list": ["a"]},
-                "valid": false
-            }
-        ]
-    },
-    {
         "description": "root ref in remote ref",
         "schema": {
             "$id": "http://localhost:1234/object",

--- a/src/test/resources/draft7/refRemote_ignored.json
+++ b/src/test/resources/draft7/refRemote_ignored.json
@@ -1,0 +1,35 @@
+[
+    {
+        "description": "base URI change - change folder in subschema",
+        "schema": {
+            "$id": "http://localhost:1234/scope_change_defs2.json",
+            "type" : "object",
+            "properties": {
+                "list": {"$ref": "#/definitions/baz/definitions/bar"}
+            },
+            "definitions": {
+                "baz": {
+                    "$id": "folder/",
+                    "definitions": {
+                        "bar": {
+                            "type": "array",
+                            "items": {"$ref": "folderInteger.json"}
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Schema id has not been resolved correctly for v6 and up as there's different id field name.

Not sure if you require to create a new issue for every pull request, seems like the problem is known (there were ignored test cases), but I haven't found any issue related to this.