### PR TITLE
FIX: potential duplicate log entry due to race condition

### DIFF
--- a/src/main/java/com/networknt/schema/JsonMetaSchema.java
+++ b/src/main/java/com/networknt/schema/JsonMetaSchema.java
@@ -333,8 +333,7 @@ public class JsonMetaSchema {
         try {
             Keyword kw = keywords.get(keyword);
             if (kw == null) {
-                if (!UNKNOWN_KEYWORDS.containsKey(keyword)) {
-                    UNKNOWN_KEYWORDS.put(keyword, keyword);
+                if (UNKNOWN_KEYWORDS.put(keyword, keyword) == null) {
                     logger.warn("Unknown keyword " + keyword + " - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword");
                 }
                 return null;


### PR DESCRIPTION
There was potentially race condition that could lead to situation in which we could get multiple log entries regarding the same keyword being unknown. Such case was when more than one thread was doing check on `containsKey` before they went into `put`.

Simple fix for this is to always add element to the `UNKNOWN_KEYWORDS` map and than check if it was present. See [documentation for `put` method and what value it returns](https://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ConcurrentHashMap.html#put(K,%20V)). Doing this that way shouldn't impact performance.