### PR TITLE
Generate module-info, fix build on JDK11+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <java.testversion>1.8</java.testversion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.jackson>2.10.4</version.jackson>
-        <version.slf4j>1.7.25</version.slf4j>
+        <version.slf4j>1.7.30</version.slf4j>
         <version.common-lang3>3.7</version.common-lang3>
         <version.joni>2.1.31</version.joni>
         <version.logback>1.2.3</version.logback>
@@ -179,11 +179,11 @@
                             <module>
                                 <moduleInfoSource>
                                     module com.networknt.schema {
-                                        requires com.fasterxml.jackson.databind;
+                                        requires transitive com.fasterxml.jackson.databind;
                                         requires org.apache.commons.lang3;
                                         requires org.jruby.jcodings;
                                         requires org.jruby.joni;
-                                        requires slf4j.api;
+                                        requires org.slf4j;
 
                                         exports com.networknt.schema;
                                         exports com.networknt.schema.format;

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.jackson>2.10.4</version.jackson>
         <version.slf4j>1.7.25</version.slf4j>
-        <version.common-lang3>3.5</version.common-lang3>
+        <version.common-lang3>3.7</version.common-lang3>
         <version.joni>2.1.31</version.joni>
         <version.logback>1.2.3</version.logback>
         <version.junit>4.12</version.junit>
@@ -164,6 +164,39 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.RC1</version>
+                <executions>
+                    <execution>
+                        <id>add-module-info</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfoSource>
+                                    module com.networknt.schema {
+                                        requires com.fasterxml.jackson.databind;
+                                        requires org.apache.commons.lang3;
+                                        requires org.jruby.jcodings;
+                                        requires org.jruby.joni;
+                                        requires slf4j.api;
+
+                                        exports com.networknt.schema;
+                                        exports com.networknt.schema.format;
+                                        exports com.networknt.schema.uri;
+                                        exports com.networknt.schema.urn;
+                                    }
+                                </moduleInfoSource>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
                 <version>1.6.8</version>
@@ -193,13 +226,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <source>8</source>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -243,7 +279,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.9</version>
+                <version>0.8.6</version>
                 <executions>
                     <execution>
                         <id>pre-unit-test</id>
@@ -311,7 +347,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.7.9</version>
+                        <version>0.8.6</version>
                         <executions>
                             <!-- The Executions for merging -->
                             <execution>


### PR DESCRIPTION
This PR makes `json-schema-validator` work better with JDK9+ w.r.t. modularization and a couple build fixes for JDK11+:

* `commons-lang` is bumped from `3.5` to `3.7` so the generated `module-info` can point to a fixed module name (instead of using an "automatic module name" determined from the JAR's filename, which is a discouraged practice).  `slf4j-api` was not bumped because the next version with any module support is `2.0.0-alpha1`, which I figured was too drastic of a version bump.
* `moditect-maven-plugin` is added to build a `module-info.class` class file which serves as the module descriptor.  This works even during a JDK8 build because `moditect-maven-plugin` will generate the `.class` file itself and place it under `META-INF/versions/9`, making this a [multi-release JAR](https://openjdk.java.net/jeps/238).  JDK8 will ignore `module-info` at runtime and JDK9+ will make use of it.
* `maven-javadoc-plugin` and `jacoco-maven-plugin` had their versions bumped to support JDK11+.

Edit: when I said JDK8, that's the lowest version I tested on.  I just noticed that JDK6 is the default build target for this project... I believe this should still work fine with the multi-release JAR trick.