### PR TITLE
Add '$comment' as a NonValidationKeyword for v7 and v2019 drafts

### DIFF
--- a/src/main/java/com/networknt/schema/JsonMetaSchema.java
+++ b/src/main/java/com/networknt/schema/JsonMetaSchema.java
@@ -141,7 +141,8 @@ public class JsonMetaSchema {
                             new NonValidationKeyword("title"),
                             new NonValidationKeyword("description"),
                             new NonValidationKeyword("default"),
-                            new NonValidationKeyword("definitions")
+                            new NonValidationKeyword("definitions"),
+                            new NonValidationKeyword("$comment")
                     ))
                     .build();
         }
@@ -171,6 +172,7 @@ public class JsonMetaSchema {
                             new NonValidationKeyword("description"),
                             new NonValidationKeyword("default"),
                             new NonValidationKeyword("definitions"),
+                            new NonValidationKeyword("$comment"),
                             new NonValidationKeyword("$defs")  // newly added in 2018-09 release.
                     ))
                     .build();


### PR DESCRIPTION
I am not sure I am able to  test this change. I did not find out any idea how to do it 😄 

You can find the reference to the schema here:
https://json-schema.org/understanding-json-schema/reference/generic.html#comments
and here:
https://json-schema.org/draft-07/json-schema-core.html#rfc.section.9