### PR TITLE
Add contentMediaType, contentEncoding and examples as a NonValidationKeyword

### DIFF
--- a/src/main/java/com/networknt/schema/JsonMetaSchema.java
+++ b/src/main/java/com/networknt/schema/JsonMetaSchema.java
@@ -142,7 +142,10 @@ public class JsonMetaSchema {
                             new NonValidationKeyword("description"),
                             new NonValidationKeyword("default"),
                             new NonValidationKeyword("definitions"),
-                            new NonValidationKeyword("$comment")
+                            new NonValidationKeyword("$comment"),
+                            new NonValidationKeyword("contentMediaType"),
+                            new NonValidationKeyword("contentEncoding"),
+                            new NonValidationKeyword("examples")
                     ))
                     .build();
         }
@@ -173,7 +176,10 @@ public class JsonMetaSchema {
                             new NonValidationKeyword("default"),
                             new NonValidationKeyword("definitions"),
                             new NonValidationKeyword("$comment"),
-                            new NonValidationKeyword("$defs")  // newly added in 2018-09 release.
+                            new NonValidationKeyword("$defs"),  // newly added in 2018-09 release.
+                            new NonValidationKeyword("contentMediaType"),
+                            new NonValidationKeyword("contentEncoding"),
+                            new NonValidationKeyword("examples")
                     ))
                     .build();
         }


### PR DESCRIPTION
`contentMediaType`, `contentEncoding` and `examples` should be treated as keywords according to the spec
https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.8.6 and https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.9.5