### PR TITLE
Add 'anchor' and 'deprecated' as NonValidationKeywords for v2019-09 draft

### DIFF
--- a/src/main/java/com/networknt/schema/JsonMetaSchema.java
+++ b/src/main/java/com/networknt/schema/JsonMetaSchema.java
@@ -176,7 +176,9 @@ public class JsonMetaSchema {
                             new NonValidationKeyword("default"),
                             new NonValidationKeyword("definitions"),
                             new NonValidationKeyword("$comment"),
-                            new NonValidationKeyword("$defs"),  // newly added in 2018-09 release.
+                            new NonValidationKeyword("$defs"),  // newly added in 2019-09 release.
+                            new NonValidationKeyword("$anchor"),
+                            new NonValidationKeyword("deprecated"),
                             new NonValidationKeyword("contentMediaType"),
                             new NonValidationKeyword("contentEncoding"),
                             new NonValidationKeyword("examples")


### PR DESCRIPTION
Following #328 and #341 , also `$anchor` and `deprecated` were introduced as keywords in draft `2019-09`.

See: 
- https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.8.2.3
- https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.9.3