### PR TITLE
#354-fixed OneOf validation error if number of valid schemas is not equal to 1

### DIFF
--- a/src/main/java/com/networknt/schema/OneOfValidator.java
+++ b/src/main/java/com/networknt/schema/OneOfValidator.java
@@ -162,31 +162,12 @@ public class OneOfValidator extends BaseJsonValidator implements JsonValidator {
                     continue;
 
                 numberOfValidSchema++;
-                errors = new LinkedHashSet<ValidationMessage>();
-            } else {
-                errors.addAll(schemaErrors);
             }
         }
 
-        // no valid schema has been found after validating all schema validators
-        if (numberOfValidSchema == 0) {
-            for (Iterator<ValidationMessage> it = errors.iterator(); it.hasNext(); ) {
-                ValidationMessage msg = it.next();
 
-                if (ValidatorTypeCode.ADDITIONAL_PROPERTIES.getValue().equals(msg.getType())) {
-                    it.remove();
-                }
-            }
-            if (errors.isEmpty()) {
-                // ensure there is always an error reported if number of valid schemas is 0
-                errors.add(buildValidationMessage(at, ""));
-            }
-        } else {
-            errors.clear();
-        }
-
-        // validated upfront
-        if (numberOfValidSchema > 1) {
+        // ensure there is always an "OneOf" error reported if number of valid schemas is not equal to 1.
+        if (numberOfValidSchema != 1) {
             errors = Collections.singleton(buildValidationMessage(at, ""));
         }
 

--- a/src/test/resources/draft6/oneOf.json
+++ b/src/test/resources/draft6/oneOf.json
@@ -189,6 +189,11 @@
           "bar": "quux"
         },
         "valid": false
+      },
+      {
+        "description": "neither oneOf given (complex)",
+        "data": {},
+        "valid": false
       }
     ]
   },


### PR DESCRIPTION
OneOf validator is not throwing valid error if any of the child nodes has invalid schemas.
Proposed Fix: If there is no valid schema in child nodes, then clear existing error list which got generated while validating child nodes and push OneOf validation to the error list as per "OneOf" attribute requirement.

Since, "OneOf" validator, in every scenario, validates and generates the error list while validating the child nodes. The error list has to be cleared, in order, to push OneOf validation to the error list as per "OneOf" attribute requirement.

Once the "OneOf" scenario is not detected after counting the valid schemas i.e. 'if (numberOfValidSchema != 1)', then OneOf validation error is pushed to the error list as per "OneOf" attribute requirement.