### PR TITLE
Validation of oneOf depends on schema order

### DIFF
--- a/src/main/java/com/networknt/schema/OneOfValidator.java
+++ b/src/main/java/com/networknt/schema/OneOfValidator.java
@@ -145,6 +145,8 @@ public class OneOfValidator extends BaseJsonValidator implements JsonValidator {
 //        }
 
         for (ShortcutValidator validator : schemas) {
+            // Reset state in case the previous validator did not match
+            state.setMatchedNode(true);
             if (!validator.allConstantsMatch(node)) {
                 // take a shortcut: if there is any constant that does not match,
                 // we can bail out of the validation

--- a/src/test/java/com/networknt/schema/Issue295Test.java
+++ b/src/test/java/com/networknt/schema/Issue295Test.java
@@ -1,0 +1,34 @@
+package com.networknt.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.Set;
+
+public class Issue295Test {
+    protected JsonSchema getJsonSchemaFromStreamContentV7(InputStream schemaContent) {
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
+        return factory.getSchema(schemaContent);
+    }
+
+    protected JsonNode getJsonNodeFromStreamContent(InputStream content) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode node = mapper.readTree(content);
+        return node;
+    }
+
+    @Test
+    public void shouldWorkV7() throws Exception {
+        String schemaPath = "/schema/issue295-v7.json";
+        String dataPath = "/data/issue295.json";
+        InputStream schemaInputStream = getClass().getResourceAsStream(schemaPath);
+        JsonSchema schema = getJsonSchemaFromStreamContentV7(schemaInputStream);
+        InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
+        JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
+        Set<ValidationMessage> errors = schema.validate(node);
+        Assert.assertEquals(0, errors.size());
+    }
+}

--- a/src/test/resources/data/issue295.json
+++ b/src/test/resources/data/issue295.json
@@ -1,0 +1,1 @@
+{ "other": "stuff" }

--- a/src/test/resources/schema/issue295-v7.json
+++ b/src/test/resources/schema/issue295-v7.json
@@ -1,0 +1,24 @@
+{
+  "$id": "https://example.com/properties.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "oneOf": [
+    {
+      "required": [
+        "requiredprop"
+      ],
+      "properties": {
+        "requiredprop": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "properties": {
+        "forbiddenprop": {
+          "type": "null"
+        }
+      }
+    }
+  ]
+}
+


### PR DESCRIPTION
Issue #295 appears to be caused when the validation of one element of a oneOf schema fails due to a failed 'required' block (setting ValidatorState.matchedNode to false), and a later schema succeeds without matching any 'properties' block (which would set ValidatorState.matchedNode to true).

I'm not familiar enough with the entire code to be sure that my fix is correct, but it fixes the reported testcase and I see no immediate problems.