### PR TITLE
Fixed parallel processing (issue-335)

### DIFF
--- a/src/main/java/com/networknt/schema/AdditionalPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/AdditionalPropertiesValidator.java
@@ -40,8 +40,7 @@ public class AdditionalPropertiesValidator extends BaseJsonValidator implements 
             additionalPropertiesSchema = null;
         } else if (schemaNode.isObject()) {
             allowAdditionalProperties = true;
-            additionalPropertiesSchema = new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), schemaNode, parentSchema)
-                .initialize();
+            additionalPropertiesSchema = new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), schemaNode, parentSchema);
         } else {
             allowAdditionalProperties = false;
             additionalPropertiesSchema = null;

--- a/src/main/java/com/networknt/schema/AllOfValidator.java
+++ b/src/main/java/com/networknt/schema/AllOfValidator.java
@@ -31,8 +31,7 @@ public class AllOfValidator extends BaseJsonValidator implements JsonValidator {
         super(schemaPath, schemaNode, parentSchema, ValidatorTypeCode.ALL_OF, validationContext);
         int size = schemaNode.size();
         for (int i = 0; i < size; i++) {
-            schemas.add(new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), schemaNode.get(i), parentSchema)
-                .initialize());
+            schemas.add(new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), schemaNode.get(i), parentSchema));
         }
     }
 

--- a/src/main/java/com/networknt/schema/AnyOfValidator.java
+++ b/src/main/java/com/networknt/schema/AnyOfValidator.java
@@ -31,8 +31,7 @@ public class AnyOfValidator extends BaseJsonValidator implements JsonValidator {
         super(schemaPath, schemaNode, parentSchema, ValidatorTypeCode.ANY_OF, validationContext);
         int size = schemaNode.size();
         for (int i = 0; i < size; i++) {
-            schemas.add(new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), schemaNode.get(i), parentSchema)
-                .initialize());
+            schemas.add(new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), schemaNode.get(i), parentSchema));
         }
     }
 
@@ -43,8 +42,8 @@ public class AnyOfValidator extends BaseJsonValidator implements JsonValidator {
         String typeValidatorName = "anyOf/type";
 
         for (JsonSchema schema : schemas) {
-            if (schema.validators.containsKey(typeValidatorName)) {
-                TypeValidator typeValidator = ((TypeValidator) schema.validators.get(typeValidatorName));
+            if (schema.getValidators().containsKey(typeValidatorName)) {
+                TypeValidator typeValidator = ((TypeValidator) schema.getValidators().get(typeValidatorName));
                 //If schema has type validator and node type doesn't match with schemaType then ignore it
                 //For union type, it is must to call TypeValidator
                 if (typeValidator.getSchemaType() != JsonType.UNION && !typeValidator.equalsToSchemaType(node)) {

--- a/src/main/java/com/networknt/schema/ContainsValidator.java
+++ b/src/main/java/com/networknt/schema/ContainsValidator.java
@@ -31,8 +31,7 @@ public class ContainsValidator extends BaseJsonValidator implements JsonValidato
     public ContainsValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaPath, schemaNode, parentSchema, ValidatorTypeCode.CONTAINS, validationContext);
         if (schemaNode.isObject() || schemaNode.isBoolean()) {
-            schema = new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), schemaNode, parentSchema)
-                .initialize();
+            schema = new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), schemaNode, parentSchema);
         }
 
         parseErrorCode(getValidatorType().getErrorCodeKey());

--- a/src/main/java/com/networknt/schema/DependenciesValidator.java
+++ b/src/main/java/com/networknt/schema/DependenciesValidator.java
@@ -44,8 +44,7 @@ public class DependenciesValidator extends BaseJsonValidator implements JsonVali
                     depsProps.add(pvalue.get(i).asText());
                 }
             } else if (pvalue.isObject() || pvalue.isBoolean()) {
-                schemaDeps.put(pname, new JsonSchema(validationContext, pname, parentSchema.getCurrentUri(), pvalue, parentSchema)
-                    .initialize());
+                schemaDeps.put(pname, new JsonSchema(validationContext, pname, parentSchema.getCurrentUri(), pvalue, parentSchema));
             }
         }
 

--- a/src/main/java/com/networknt/schema/IfValidator.java
+++ b/src/main/java/com/networknt/schema/IfValidator.java
@@ -37,14 +37,11 @@ public class IfValidator extends BaseJsonValidator implements JsonValidator {
         for (final String keyword : KEYWORDS) {
             final JsonNode node = schemaNode.get(keyword);
             if (keyword.equals("if")) {
-                ifSchema = new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), node, parentSchema)
-                    .initialize();
+                ifSchema = new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), node, parentSchema);
             } else if (keyword.equals("then") && node != null) {
-                thenSchema = new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), node, parentSchema)
-                    .initialize();
+                thenSchema = new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), node, parentSchema);
             } else if (keyword.equals("else") && node != null) {
-                elseSchema = new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), node, parentSchema)
-                    .initialize();
+                elseSchema = new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), node, parentSchema);
             }
         }
     }

--- a/src/main/java/com/networknt/schema/ItemsValidator.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator.java
@@ -41,13 +41,12 @@ public class ItemsValidator extends BaseJsonValidator implements JsonValidator {
         super(schemaPath, schemaNode, parentSchema, ValidatorTypeCode.ITEMS, validationContext);
         if (schemaNode.isObject() || schemaNode.isBoolean()) {
             schema = new JsonSchema(validationContext, schemaPath, parentSchema.getCurrentUri(), schemaNode,
-                    parentSchema).initialize();
+                    parentSchema);
         } else {
             tupleSchema = new ArrayList<JsonSchema>();
             for (JsonNode s : schemaNode) {
                 tupleSchema.add(
-                        new JsonSchema(validationContext, schemaPath, parentSchema.getCurrentUri(), s, parentSchema)
-                                .initialize());
+                        new JsonSchema(validationContext, schemaPath, parentSchema.getCurrentUri(), s, parentSchema));
             }
 
             JsonNode addItemNode = getParentSchema().getSchemaNode().get(PROPERTY_ADDITIONAL_ITEMS);
@@ -55,8 +54,7 @@ public class ItemsValidator extends BaseJsonValidator implements JsonValidator {
                 if (addItemNode.isBoolean()) {
                     additionalItems = addItemNode.asBoolean();
                 } else if (addItemNode.isObject()) {
-                    additionalSchema = new JsonSchema(validationContext, parentSchema.getCurrentUri(), addItemNode)
-                            .initialize();
+                    additionalSchema = new JsonSchema(validationContext, parentSchema.getCurrentUri(), addItemNode);
                 }
             }
         }

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
  */
 public class JsonSchema extends BaseJsonValidator {
     private static final Pattern intPattern = Pattern.compile("^[0-9]+$");
-    protected Map<String, JsonValidator> validators;
+    private Map<String, JsonValidator> validators;
     private final String idKeyword;
     private final ValidationContext validationContext;
     private WalkListenerRunner keywordWalkListenerRunner;
@@ -78,11 +78,6 @@ public class JsonSchema extends BaseJsonValidator {
 		if (config != null) {
 			this.keywordWalkListenerRunner = new DefaultKeywordWalkListenerRunner(config.getKeywordWalkListenersMap());
 		}
-    }
-
-    JsonSchema initialize() {
-        this.validators = Collections.unmodifiableMap(this.read(getSchemaNode()));
-        return this;
     }
 
     private URI combineCurrentUriWithIds(URI currentUri, JsonNode schemaNode) {
@@ -225,7 +220,7 @@ public class JsonSchema extends BaseJsonValidator {
 
     public Set<ValidationMessage> validate(JsonNode jsonNode, JsonNode rootNode, String at) {
         Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
-        for (JsonValidator v : validators.values()) {
+        for (JsonValidator v : getValidators().values()) {
             errors.addAll(v.validate(jsonNode, rootNode, at));
         }
         return errors;
@@ -296,7 +291,7 @@ public class JsonSchema extends BaseJsonValidator {
 	public Set<ValidationMessage> walk(JsonNode node, JsonNode rootNode, String at, boolean shouldValidateSchema) {
 		Set<ValidationMessage> validationMessages = new LinkedHashSet<ValidationMessage>();
 		// Walk through all the JSONWalker's.
-		for (Entry<String, JsonValidator> entry : validators.entrySet()) {
+		for (Entry<String, JsonValidator> entry : getValidators().entrySet()) {
 			JsonSchemaWalker jsonWalker = entry.getValue();
 			String schemaPathWithKeyword = entry.getKey();
 			try {
@@ -343,6 +338,9 @@ public class JsonSchema extends BaseJsonValidator {
     }
 
     public Map<String, JsonValidator> getValidators() {
+        if (validators == null) {
+            validators = Collections.unmodifiableMap(this.read(getSchemaNode()));
+        }
         return validators;
     }
 

--- a/src/main/java/com/networknt/schema/JsonSchemaFactory.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaFactory.java
@@ -263,7 +263,7 @@ public class JsonSchemaFactory {
     protected JsonSchema newJsonSchema(final URI schemaUri, final JsonNode schemaNode, final SchemaValidatorsConfig config) {
         final ValidationContext validationContext = createValidationContext(schemaNode);
         validationContext.setConfig(config);
-        return new JsonSchema(validationContext, schemaUri, schemaNode).initialize();
+        return new JsonSchema(validationContext, schemaUri, schemaNode);
     }
 
     protected ValidationContext createValidationContext(final JsonNode schemaNode) {
@@ -349,7 +349,6 @@ public class JsonSchemaFactory {
                     jsonSchema = new JsonSchema(validationContext, mappedUri, schemaNode);
                 }
                 uriSchemaCache.put(mappedUri, jsonSchema);
-                jsonSchema.initialize();
 
                 return jsonSchema;
             } finally {

--- a/src/main/java/com/networknt/schema/NotValidator.java
+++ b/src/main/java/com/networknt/schema/NotValidator.java
@@ -31,8 +31,7 @@ public class NotValidator extends BaseJsonValidator implements JsonValidator {
 
     public NotValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaPath, schemaNode, parentSchema, ValidatorTypeCode.NOT, validationContext);
-        schema = new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), schemaNode, parentSchema)
-            .initialize();
+        schema = new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), schemaNode, parentSchema);
 
         parseErrorCode(getValidatorType().getErrorCodeKey());
     }

--- a/src/main/java/com/networknt/schema/OneOfValidator.java
+++ b/src/main/java/com/networknt/schema/OneOfValidator.java
@@ -118,8 +118,7 @@ public class OneOfValidator extends BaseJsonValidator implements JsonValidator {
         int size = schemaNode.size();
         for (int i = 0; i < size; i++) {
             JsonNode childNode = schemaNode.get(i);
-            JsonSchema childSchema = new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), childNode, parentSchema)
-                    .initialize();
+            JsonSchema childSchema = new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), childNode, parentSchema);
             schemas.add(new ShortcutValidator(childNode, parentSchema, validationContext, childSchema));
         }
 

--- a/src/main/java/com/networknt/schema/PatternPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/PatternPropertiesValidator.java
@@ -38,8 +38,7 @@ public class PatternPropertiesValidator extends BaseJsonValidator implements Jso
         Iterator<String> names = schemaNode.fieldNames();
         while (names.hasNext()) {
             String name = names.next();
-            schemas.put(Pattern.compile(name), new JsonSchema(validationContext, name, parentSchema.getCurrentUri(), schemaNode.get(name), parentSchema)
-                .initialize());
+            schemas.put(Pattern.compile(name), new JsonSchema(validationContext, name, parentSchema.getCurrentUri(), schemaNode.get(name), parentSchema));
         }
     }
 

--- a/src/main/java/com/networknt/schema/PropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/PropertiesValidator.java
@@ -37,8 +37,7 @@ public class PropertiesValidator extends BaseJsonValidator implements JsonValida
         schemas = new HashMap<String, JsonSchema>();
         for (Iterator<String> it = schemaNode.fieldNames(); it.hasNext(); ) {
             String pname = it.next();
-            schemas.put(pname, new JsonSchema(validationContext, schemaPath + "/" + pname, parentSchema.getCurrentUri(), schemaNode.get(pname), parentSchema)
-                .initialize());
+            schemas.put(pname, new JsonSchema(validationContext, schemaPath + "/" + pname, parentSchema.getCurrentUri(), schemaNode.get(pname), parentSchema));
         }
 		propertyWalkListenerRunner = new DefaultPropertyWalkListenerRunner(
                 config.getPropertyWalkListeners());    

--- a/src/main/java/com/networknt/schema/PropertyNamesValidator.java
+++ b/src/main/java/com/networknt/schema/PropertyNamesValidator.java
@@ -34,8 +34,7 @@ public class PropertyNamesValidator extends BaseJsonValidator implements JsonVal
             schemas = new HashMap<String, JsonSchema>();
             for (Iterator<String> it = schemaNode.fieldNames(); it.hasNext(); ) {
                 String pname = it.next();
-                schemas.put(pname, new JsonSchema(validationContext, schemaPath + "/" + pname, parentSchema.getCurrentUri(), schemaNode.get(pname), parentSchema)
-                    .initialize());
+                schemas.put(pname, new JsonSchema(validationContext, schemaPath + "/" + pname, parentSchema.getCurrentUri(), schemaNode.get(pname), parentSchema));
             }
         }
     }

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -97,8 +97,7 @@ public class RefValidator extends BaseJsonValidator implements JsonValidator {
                 if (ref == null) {
                     ref = new JsonSchemaRef(validationContext, refValue);
                     validationContext.setReferenceParsingInProgress(refValueOriginal, ref);
-                    JsonSchema ret = new JsonSchema(validationContext, refValue, parentSchema.getCurrentUri(), node, parentSchema)
-                        .initialize();
+                    JsonSchema ret = new JsonSchema(validationContext, refValue, parentSchema.getCurrentUri(), node, parentSchema);
                     ref.set(ret);
                 }
                 return ref;

--- a/src/main/java/com/networknt/schema/UnionTypeValidator.java
+++ b/src/main/java/com/networknt/schema/UnionTypeValidator.java
@@ -50,8 +50,7 @@ public class UnionTypeValidator extends BaseJsonValidator implements JsonValidat
             sep = ", ";
 
             if (n.isObject())
-                schemas.add(new JsonSchema(validationContext, ValidatorTypeCode.TYPE.getValue(), parentSchema.getCurrentUri(), n, parentSchema)
-                    .initialize());
+                schemas.add(new JsonSchema(validationContext, ValidatorTypeCode.TYPE.getValue(), parentSchema.getCurrentUri(), n, parentSchema));
             else
                 schemas.add(new TypeValidator(schemaPath + "/" + i, n, parentSchema, validationContext));
 


### PR DESCRIPTION
Updated `JsonSchema` to lazy load the validators instead of using the `initialize()` function in order to fix parallel processing (https://github.com/networknt/json-schema-validator/issues/335).

This change still works with the `CyclicDependencyTest` added for https://github.com/networknt/json-schema-validator/issues/258. 