### PR TITLE
NPE due to concurrency bug #392: Make JsonSchemaRef more thread-safe;…

### DIFF
--- a/src/main/java/com/networknt/schema/JsonSchemaRef.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaRef.java
@@ -28,20 +28,9 @@ import java.util.Set;
 
 public class JsonSchemaRef {
 
-    private JsonSchema schema;
-    private ValidationContext validationContext;
-    private String refValue;
-
-    public JsonSchemaRef(ValidationContext validationContext, String refValue) {
-        this.validationContext = validationContext;
-        this.refValue = refValue;
-    }
+    private final JsonSchema schema;
 
     public JsonSchemaRef(JsonSchema schema) {
-        this.schema = schema;
-    }
-
-    public void set(JsonSchema schema) {
         this.schema = schema;
     }
 

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -95,10 +95,9 @@ public class RefValidator extends BaseJsonValidator implements JsonValidator {
             if (node != null) {
                 JsonSchemaRef ref = validationContext.getReferenceParsingInProgress(refValueOriginal);
                 if (ref == null) {
-                    ref = new JsonSchemaRef(validationContext, refValue);
+                    final JsonSchema schema = new JsonSchema(validationContext, refValue, parentSchema.getCurrentUri(), node, parentSchema);
+                    ref = new JsonSchemaRef(schema);
                     validationContext.setReferenceParsingInProgress(refValueOriginal, ref);
-                    JsonSchema ret = new JsonSchema(validationContext, refValue, parentSchema.getCurrentUri(), node, parentSchema);
-                    ref.set(ret);
                 }
                 return ref;
             }


### PR DESCRIPTION
A new release with this fix would be nice. We could then remove our workaraound.