### PR TITLE
Introduce `forceHttps` flag in `JsonSchemaFactory.Builder`

### DIFF
--- a/src/main/java/com/networknt/schema/SpecVersionDetector.java
+++ b/src/main/java/com/networknt/schema/SpecVersionDetector.java
@@ -39,7 +39,7 @@ public class SpecVersionDetector {
         if (!jsonNode.has(SCHEMA_TAG))
             throw new JsonSchemaException("Schema tag not present");
 
-        String schemaUri = JsonSchemaFactory.normalizeMetaSchemaUri(jsonNode.get(SCHEMA_TAG).asText());
+        String schemaUri = JsonSchemaFactory.normalizeMetaSchemaUri(jsonNode.get(SCHEMA_TAG).asText(), true);
         if (schemaUri.equals(JsonMetaSchema.getV4().getUri()))
             return SpecVersion.VersionFlag.V4;
         else if (schemaUri.equals(JsonMetaSchema.getV6().getUri()))

--- a/src/test/java/com/networknt/schema/Issue314Test.java
+++ b/src/test/java/com/networknt/schema/Issue314Test.java
@@ -12,6 +12,7 @@ public class Issue314Test {
                                     "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0",
                                     JsonMetaSchema.getV7())
                                     .build())
+                    .forceHttps(false)
                     .build();
 
     @Test

--- a/src/test/java/com/networknt/schema/Issue314Test.java
+++ b/src/test/java/com/networknt/schema/Issue314Test.java
@@ -1,0 +1,25 @@
+package com.networknt.schema;
+
+import java.io.InputStream;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Issue314Test {
+    private static final JsonSchemaFactory FACTORY =
+            JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
+                    .addMetaSchema(
+                            JsonMetaSchema.builder(
+                                    "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0",
+                                    JsonMetaSchema.getV7())
+                                    .build())
+                    .build();
+
+    @Test
+    public void testNormalizeHttpOnly() {
+        String schemaPath = "/schema/issue314-v7.json";
+        InputStream schemaInputStream = getClass().getResourceAsStream(schemaPath);
+        JsonSchema schema = FACTORY.getSchema(schemaInputStream);
+
+        Assert.assertNotNull(schema);
+    }
+}

--- a/src/test/java/com/networknt/schema/UnknownMetaSchemaTest.java
+++ b/src/test/java/com/networknt/schema/UnknownMetaSchemaTest.java
@@ -64,10 +64,10 @@ public class UnknownMetaSchemaTest {
         String uri03 = "http://json-schema.org/draft-07/schema?key=value";
         String uri04 = "http://json-schema.org/draft-07/schema?key=value&key2=value2";
         String expected = "https://json-schema.org/draft-07/schema";
-        Assert.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri01));
-        Assert.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri02));
-        Assert.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri03));
-        Assert.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri04));
+        Assert.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri01, true));
+        Assert.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri02, true));
+        Assert.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri03, true));
+        Assert.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri04, true));
 
     }
 }

--- a/src/test/resources/schema/issue314-v7.json
+++ b/src/test/resources/schema/issue314-v7.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "type": "object"
+}


### PR DESCRIPTION
In https://github.com/networknt/json-schema-validator/commit/e32a5410a73efb9ce7f50307cf000e28f0902f84, schema normalization was introduced to fix https://github.com/networknt/json-schema-validator/issues/273 however it assumes the given schema is available over HTTPS.

https://github.com/networknt/json-schema-validator/blob/e32a5410a73efb9ce7f50307cf000e28f0902f84/src/main/java/com/networknt/schema/JsonSchemaFactory.java#L406

As reported in https://github.com/networknt/json-schema-validator/issues/314, some schemas are not available over HTTPS. For example, https://iglucentral.com (it just hangs with https), see https://github.com/snowplow/iglu-central/issues/1067.

Therefore https://github.com/networknt/json-schema-validator/issues/314 blocks https://github.com/snowplow/iglu-scala-client/issues/136 and our internal `json-schema-validator` dependency upgrade from `1.0.39` to `1.0.40+`.

The first commit in this PR provides a failing test for https://github.com/networknt/json-schema-validator/issues/314 and the second one introduces a boolean flag to control the URI scheme.

Fixes https://github.com/networknt/json-schema-validator/issues/314.