### PR TITLE
Fix for StackOverFlowErrors occurring in case of circular $ref validators

### DIFF
--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -47,6 +47,7 @@ public class JsonSchema extends BaseJsonValidator {
     private final String idKeyword;
     private final ValidationContext validationContext;
     private WalkListenerRunner keywordWalkListenerRunner;
+    private boolean validatorsLoaded = false;
 
     /**
      * This is the current uri of this schema. This uri could refer to the uri of this schema's file
@@ -423,8 +424,11 @@ public class JsonSchema extends BaseJsonValidator {
      * instances of the validators.</p>
      */
     public void initializeValidators() {
-        for (final JsonValidator validator : getValidators().values()) {
-            validator.preloadJsonSchema();
+        if (!validatorsLoaded) {
+            validatorsLoaded = true;
+            for (final JsonValidator validator : getValidators().values()) {
+                validator.preloadJsonSchema();
+            }
         }
     }
 }

--- a/src/test/java/com/networknt/schema/Issue406Test.java
+++ b/src/test/java/com/networknt/schema/Issue406Test.java
@@ -9,6 +9,8 @@ import org.junit.function.ThrowingRunnable;
 
 public class Issue406Test {
     protected static final String INVALID_$REF_SCHEMA = "{\"$ref\":\"urn:unresolved\"}";
+    protected static final String CIRCULAR_$REF_SCHEMA = "{\"$ref\":\"#/nestedSchema\","
+            + "\"nestedSchema\":{\"$ref\":\"#/nestedSchema\"}}";
 
     @Test
     public void testPreloadingNotHappening() {
@@ -30,5 +32,12 @@ public class Issue406Test {
                                     schema.initializeValidators();
                                 }
                             });
+    }
+
+    @Test
+    public void testPreloadingHappeningForCircularDependency() {
+        final JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
+        final JsonSchema schema = factory.getSchema(CIRCULAR_$REF_SCHEMA);
+        schema.initializeValidators();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/networknt/json-schema-validator/issues/416 my marking each JsonSchema as being initialized