### PR TITLE
Avoid NPE in AdditionalPropertiesValidator

### DIFF
--- a/src/main/java/com/networknt/schema/AdditionalPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/AdditionalPropertiesValidator.java
@@ -108,6 +108,8 @@ public class AdditionalPropertiesValidator extends BaseJsonValidator implements 
 
     @Override
     public void preloadJsonSchema() {
-        additionalPropertiesSchema.initializeValidators();
+        if(additionalPropertiesSchema!=null) {
+            additionalPropertiesSchema.initializeValidators();
+        }
     }
 }


### PR DESCRIPTION
additionalPropertiesSchema can be null by some code paths, but preloadJsonSchema assumes it's always non-null.