### PR TITLE
Added exampleSetFlag to nonValidationKeyword

### DIFF
--- a/src/main/java/com/networknt/schema/JsonMetaSchema.java
+++ b/src/main/java/com/networknt/schema/JsonMetaSchema.java
@@ -117,7 +117,8 @@ public class JsonMetaSchema {
                             new NonValidationKeyword("title"),
                             new NonValidationKeyword("description"),
                             new NonValidationKeyword("default"),
-                            new NonValidationKeyword("definitions")
+                            new NonValidationKeyword("definitions"),
+                            new NonValidationKeyword("exampleSetFlag")
                     ))
                     .build();
         }


### PR DESCRIPTION
Issue:

When using vertx, there is a keyword `exampleSetFlag` present in swagger which is transitive dependency of vertx . So when we run the verticle we get a warning like this :- 
`<onMetaSchema:338> [oop-thread-1]  Unknown keyword exampleSetFlag - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword`

PR purpose :- 

It adds the variable `exampleSetFlag` to the nonValidationKeyword in V4 since the OpenApiv3 use the Json schema v4 --> `    private static final JsonMetaSchema META_SCHEMA = JsonMetaSchema.builder(JsonMetaSchema.getV4().getUri(), JsonMetaSchema.getV4()).addKeyword(new NonValidationKeyword("example")).build();`
