### PR TITLE
JsonValidator: mark `preloadJsonSchema` as default

### DIFF
--- a/src/main/java/com/networknt/schema/BaseJsonValidator.java
+++ b/src/main/java/com/networknt/schema/BaseJsonValidator.java
@@ -165,11 +165,6 @@ public abstract class BaseJsonValidator implements JsonValidator {
         return validationMessages;
     }
 
-    @Override
-    public void preloadJsonSchema() {
-        // do nothing by default - to be overridden in subclasses
-    }
-
     protected void preloadJsonSchemas(final Collection<JsonSchema> schemas) {
         for (final JsonSchema schema: schemas) {
             schema.initializeValidators();

--- a/src/main/java/com/networknt/schema/JsonValidator.java
+++ b/src/main/java/com/networknt/schema/JsonValidator.java
@@ -56,5 +56,7 @@ public interface JsonValidator extends JsonSchemaWalker {
      * are invalid (like <code>$ref</code> not resolving)
      * @since 1.0.54
      */
-    void preloadJsonSchema() throws JsonSchemaException;
+    default void preloadJsonSchema() throws JsonSchemaException {
+        // do nothing by default - to be overridden in subclasses
+    }
 }

--- a/src/main/java/com/networknt/schema/NonValidationKeyword.java
+++ b/src/main/java/com/networknt/schema/NonValidationKeyword.java
@@ -35,11 +35,6 @@ public class NonValidationKeyword extends AbstractKeyword {
         public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
             return Collections.emptySet();
         }
-
-        @Override
-        public void preloadJsonSchema() {
-            // not used and the Validator is not extending from BaseJsonValidator
-        }
     }
 
     public NonValidationKeyword(String keyword) {

--- a/src/main/java/com/networknt/schema/PatternValidator.java
+++ b/src/main/java/com/networknt/schema/PatternValidator.java
@@ -161,9 +161,4 @@ public class PatternValidator implements JsonValidator {
             return Collections.emptySet();
         }
     }
-
-    @Override
-    public void preloadJsonSchema() {
-        // not used and the validator does not inherit from BaseJsonValidator
-    }
 }

--- a/src/test/java/com/networknt/schema/CollectorContextTest.java
+++ b/src/test/java/com/networknt/schema/CollectorContextTest.java
@@ -296,11 +296,6 @@ public class CollectorContextTest {
             // Ignore this method for testing.
             return null;
         }
-
-        @Override
-        public void preloadJsonSchema() {
-            // not used in testing
-        }
     }
 
     private class CustomCollector extends AbstractCollector<List<String>> {
@@ -377,11 +372,6 @@ public class CollectorContextTest {
         public Set<ValidationMessage> walk(JsonNode node, JsonNode rootNode, String at, boolean shouldValidateSchema) {
             // Ignore this method for testing.
             return null;
-        }
-
-        @Override
-        public void preloadJsonSchema() {
-            // not used in testing
         }
     }
 

--- a/src/test/java/com/networknt/schema/CustomMetaSchemaTest.java
+++ b/src/test/java/com/networknt/schema/CustomMetaSchemaTest.java
@@ -66,11 +66,6 @@ public class CustomMetaSchemaTest {
                 String valueName = enumNames.get(idx);
                 return fail(CustomErrorMessageType.of("tests.example.enumNames", new MessageFormat("{0}: enumName is {1}")), at, valueName);
             }
-
-            @Override
-            public void preloadJsonSchema() {
-                // not used in testing
-            }
         }
 
 

--- a/src/test/java/com/networknt/schema/JsonWalkTest.java
+++ b/src/test/java/com/networknt/schema/JsonWalkTest.java
@@ -120,11 +120,6 @@ public class JsonWalkTest {
                                                boolean shouldValidateSchema) {
                 return new LinkedHashSet<ValidationMessage>();
             }
-
-            @Override
-            public void preloadJsonSchema() {
-                // not used in testing
-            }
         }
     }
 


### PR DESCRIPTION
`JsonValidator#preloadJsonSchema` is not required so there is no point in forcing it to be implemented in each validator. 

I came across the fact that I need to implement this method in my custom validator. It looks like this is not required, so let's mark it as the default value.