### PR TITLE
changed from isIntegralNumber to canConvertToExactIntegral to support…

### DIFF
--- a/src/main/java/com/networknt/schema/MaxItemsValidator.java
+++ b/src/main/java/com/networknt/schema/MaxItemsValidator.java
@@ -33,7 +33,7 @@ public class MaxItemsValidator extends BaseJsonValidator implements JsonValidato
 
     public MaxItemsValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaPath, schemaNode, parentSchema, ValidatorTypeCode.MAX_ITEMS, validationContext);
-        if (schemaNode.isIntegralNumber()) {
+        if (schemaNode.canConvertToExactIntegral()) {
             max = schemaNode.intValue();
         }
         this.validationContext = validationContext;

--- a/src/main/java/com/networknt/schema/MaxLengthValidator.java
+++ b/src/main/java/com/networknt/schema/MaxLengthValidator.java
@@ -33,7 +33,7 @@ public class MaxLengthValidator extends BaseJsonValidator implements JsonValidat
     public MaxLengthValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaPath, schemaNode, parentSchema, ValidatorTypeCode.MAX_LENGTH, validationContext);
         maxLength = Integer.MAX_VALUE;
-        if (schemaNode != null && schemaNode.isIntegralNumber()) {
+        if (schemaNode != null && schemaNode.canConvertToExactIntegral()) {
             maxLength = schemaNode.intValue();
         }
         this.validationContext = validationContext;

--- a/src/main/java/com/networknt/schema/MaxPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/MaxPropertiesValidator.java
@@ -31,7 +31,7 @@ public class MaxPropertiesValidator extends BaseJsonValidator implements JsonVal
     public MaxPropertiesValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema,
                                   ValidationContext validationContext) {
         super(schemaPath, schemaNode, parentSchema, ValidatorTypeCode.MAX_PROPERTIES, validationContext);
-        if (schemaNode.isIntegralNumber()) {
+        if (schemaNode.canConvertToExactIntegral()) {
             max = schemaNode.intValue();
         }
 

--- a/src/main/java/com/networknt/schema/MinItemsValidator.java
+++ b/src/main/java/com/networknt/schema/MinItemsValidator.java
@@ -32,7 +32,7 @@ public class MinItemsValidator extends BaseJsonValidator implements JsonValidato
 
     public MinItemsValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaPath, schemaNode, parentSchema, ValidatorTypeCode.MIN_ITEMS, validationContext);
-        if (schemaNode.isIntegralNumber()) {
+        if (schemaNode.canConvertToExactIntegral()) {
             min = schemaNode.intValue();
         }
         this.validationContext = validationContext;

--- a/src/main/java/com/networknt/schema/MinLengthValidator.java
+++ b/src/main/java/com/networknt/schema/MinLengthValidator.java
@@ -33,7 +33,7 @@ public class MinLengthValidator extends BaseJsonValidator implements JsonValidat
     public MinLengthValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaPath, schemaNode, parentSchema, ValidatorTypeCode.MIN_LENGTH, validationContext);
         minLength = Integer.MIN_VALUE;
-        if (schemaNode != null && schemaNode.isIntegralNumber()) {
+        if (schemaNode != null && schemaNode.canConvertToExactIntegral()) {
             minLength = schemaNode.intValue();
         }
         this.validationContext = validationContext;

--- a/src/main/java/com/networknt/schema/MinPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/MinPropertiesValidator.java
@@ -31,7 +31,7 @@ public class MinPropertiesValidator extends BaseJsonValidator implements JsonVal
     public MinPropertiesValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema,
                                   ValidationContext validationContext) {
         super(schemaPath, schemaNode, parentSchema, ValidatorTypeCode.MIN_PROPERTIES, validationContext);
-        if (schemaNode.isIntegralNumber()) {
+        if (schemaNode.canConvertToExactIntegral()) {
             min = schemaNode.intValue();
         }
 

--- a/src/test/resources/draft7/maxItems.json
+++ b/src/test/resources/draft7/maxItems.json
@@ -35,5 +35,42 @@
         "valid": true
       }
     ]
+  },
+  {
+    "description": "maxItems decimal validation",
+    "schema": {
+      "maxItems": 2.0
+    },
+    "tests": [
+      {
+        "description": "shorter is valid",
+        "data": [
+          1
+        ],
+        "valid": true
+      },
+      {
+        "description": "exact length is valid",
+        "data": [
+          1,
+          2
+        ],
+        "valid": true
+      },
+      {
+        "description": "too long is invalid",
+        "data": [
+          1,
+          2,
+          3
+        ],
+        "valid": false
+      },
+      {
+        "description": "ignores non-arrays",
+        "data": "foobar",
+        "valid": true
+      }
+    ]
   }
 ]

--- a/src/test/resources/draft7/maxLength.json
+++ b/src/test/resources/draft7/maxLength.json
@@ -31,5 +31,38 @@
         "valid": true
       }
     ]
+  },
+  {
+  "description": "maxLength decimal validation",
+  "schema": {
+  "maxLength": 2.0
+},
+  "tests": [
+  {
+    "description": "shorter is valid",
+    "data": "f",
+    "valid": true
+  },
+  {
+    "description": "exact length is valid",
+    "data": "fo",
+    "valid": true
+  },
+  {
+    "description": "too long is invalid",
+    "data": "foo",
+    "valid": false
+  },
+  {
+    "description": "ignores non-strings",
+    "data": 100,
+    "valid": true
+  },
+  {
+    "description": "two supplementary Unicode code points is long enough",
+    "data": "\uD83D\uDCA9\uD83D\uDCA9",
+    "valid": true
+  }
+]
   }
 ]

--- a/src/test/resources/draft7/maxProperties.json
+++ b/src/test/resources/draft7/maxProperties.json
@@ -49,5 +49,56 @@
         "valid": true
       }
     ]
+  },
+  {
+    "description": "maxProperties decimal validation",
+    "schema": {
+      "maxProperties": 2.0
+    },
+    "tests": [
+      {
+        "description": "shorter is valid",
+        "data": {
+          "foo": 1
+        },
+        "valid": true
+      },
+      {
+        "description": "exact length is valid",
+        "data": {
+          "foo": 1,
+          "bar": 2
+        },
+        "valid": true
+      },
+      {
+        "description": "too long is invalid",
+        "data": {
+          "foo": 1,
+          "bar": 2,
+          "baz": 3
+        },
+        "valid": false
+      },
+      {
+        "description": "ignores arrays",
+        "data": [
+          1,
+          2,
+          3
+        ],
+        "valid": true
+      },
+      {
+        "description": "ignores strings",
+        "data": "foobar",
+        "valid": true
+      },
+      {
+        "description": "ignores other non-objects",
+        "data": 12,
+        "valid": true
+      }
+    ]
   }
 ]

--- a/src/test/resources/draft7/minItems.json
+++ b/src/test/resources/draft7/minItems.json
@@ -31,5 +31,38 @@
         "valid": true
       }
     ]
+  },
+  {
+    "description": "minItems decimal validation",
+    "schema": {
+      "minItems": 1.0
+    },
+    "tests": [
+      {
+        "description": "longer is valid",
+        "data": [
+          1,
+          2
+        ],
+        "valid": true
+      },
+      {
+        "description": "exact length is valid",
+        "data": [
+          1
+        ],
+        "valid": true
+      },
+      {
+        "description": "too short is invalid",
+        "data": [],
+        "valid": false
+      },
+      {
+        "description": "ignores non-arrays",
+        "data": "",
+        "valid": true
+      }
+    ]
   }
 ]

--- a/src/test/resources/draft7/minLength.json
+++ b/src/test/resources/draft7/minLength.json
@@ -31,5 +31,38 @@
         "valid": false
       }
     ]
+  },
+  {
+    "description": "minLength decimal validation",
+    "schema": {
+      "minLength": 2.0
+    },
+    "tests": [
+      {
+        "description": "longer is valid",
+        "data": "foo",
+        "valid": true
+      },
+      {
+        "description": "exact length is valid",
+        "data": "fo",
+        "valid": true
+      },
+      {
+        "description": "too short is invalid",
+        "data": "f",
+        "valid": false
+      },
+      {
+        "description": "ignores non-strings",
+        "data": 1,
+        "valid": true
+      },
+      {
+        "description": "one supplementary Unicode code point is not long enough",
+        "data": "\uD83D\uDCA9",
+        "valid": false
+      }
+    ]
   }
 ]

--- a/src/test/resources/draft7/minProperties.json
+++ b/src/test/resources/draft7/minProperties.json
@@ -41,5 +41,48 @@
         "valid": true
       }
     ]
+  },
+  {
+    "description": "minProperties decimal validation",
+    "schema": {
+      "minProperties": 1.0
+    },
+    "tests": [
+      {
+        "description": "longer is valid",
+        "data": {
+          "foo": 1,
+          "bar": 2
+        },
+        "valid": true
+      },
+      {
+        "description": "exact length is valid",
+        "data": {
+          "foo": 1
+        },
+        "valid": true
+      },
+      {
+        "description": "too short is invalid",
+        "data": {},
+        "valid": false
+      },
+      {
+        "description": "ignores arrays",
+        "data": [],
+        "valid": true
+      },
+      {
+        "description": "ignores strings",
+        "data": "",
+        "valid": true
+      },
+      {
+        "description": "ignores other non-objects",
+        "data": 12,
+        "valid": true
+      }
+    ]
   }
 ]


### PR DESCRIPTION
… numbers with 0 decimal value as valid integers for max/min lengths.

Related to: https://github.com/networknt/json-schema-validator/issues/446