### PR TITLE
apply default in objects and arrays

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${version.junit}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${version.mockito}</version>

--- a/src/main/java/com/networknt/schema/ApplyDefaultsStrategy.java
+++ b/src/main/java/com/networknt/schema/ApplyDefaultsStrategy.java
@@ -1,6 +1,8 @@
 package com.networknt.schema;
 
 public class ApplyDefaultsStrategy {
+    static final ApplyDefaultsStrategy EMPTY_APPLY_DEFAULTS_STRATEGY = new ApplyDefaultsStrategy(false, false, false);
+
     private final boolean applyPropertyDefaults;
     private final boolean applyPropertyDefaultsIfNull;
     private final boolean applyArrayDefaults;

--- a/src/main/java/com/networknt/schema/ApplyDefaultsStrategy.java
+++ b/src/main/java/com/networknt/schema/ApplyDefaultsStrategy.java
@@ -7,6 +7,11 @@ public class ApplyDefaultsStrategy {
 
     /**
      * Specify which default values to apply.
+     * We can apply property defaults only if they are missing or if they are declared to be null in the input json,
+     * and we can apply array defaults if they are declared to be null in the input json.
+     *
+     * <p>Note that the walker changes the input object in place.
+     * If validation fails, the input object will be changed.
      *
      * @param applyPropertyDefaults if true then apply defaults inside json objects if the attribute is missing
      * @param applyPropertyDefaultsIfNull if true then apply defaults inside json objects if the attribute is explicitly null

--- a/src/main/java/com/networknt/schema/ApplyDefaultsStrategy.java
+++ b/src/main/java/com/networknt/schema/ApplyDefaultsStrategy.java
@@ -1,0 +1,36 @@
+package com.networknt.schema;
+
+public class ApplyDefaultsStrategy {
+    private final boolean applyPropertyDefaults;
+    private final boolean applyPropertyDefaultsIfNull;
+    private final boolean applyArrayDefaults;
+
+    /**
+     * Specify which default values to apply.
+     *
+     * @param applyPropertyDefaults if true then apply defaults inside json objects if the attribute is missing
+     * @param applyPropertyDefaultsIfNull if true then apply defaults inside json objects if the attribute is explicitly null
+     * @param applyArrayDefaults if true then apply defaults inside json arrays if the attribute is explicitly null
+     * @throws IllegalArgumentException if applyPropertyDefaults is false and applyPropertyDefaultsIfNull is true
+     */
+    public ApplyDefaultsStrategy(boolean applyPropertyDefaults, boolean applyPropertyDefaultsIfNull, boolean applyArrayDefaults) {
+        if (!applyPropertyDefaults && applyPropertyDefaultsIfNull) {
+            throw new IllegalArgumentException();
+        }
+        this.applyPropertyDefaults = applyPropertyDefaults;
+        this.applyPropertyDefaultsIfNull = applyPropertyDefaultsIfNull;
+        this.applyArrayDefaults = applyArrayDefaults;
+    }
+
+    public boolean shouldApplyPropertyDefaults() {
+        return applyPropertyDefaults;
+    }
+
+    public boolean shouldApplyPropertyDefaultsIfNull() {
+        return applyPropertyDefaultsIfNull;
+    }
+
+    public boolean shouldApplyArrayDefaults() {
+        return applyArrayDefaults;
+    }
+}

--- a/src/main/java/com/networknt/schema/BaseJsonValidator.java
+++ b/src/main/java/com/networknt/schema/BaseJsonValidator.java
@@ -38,15 +38,18 @@ public abstract class BaseJsonValidator implements JsonValidator {
     private ErrorMessageType errorMessageType;
 
     protected final boolean failFast;
+    protected final boolean shouldApplyDefaults;
 
     public BaseJsonValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema,
                              ValidatorTypeCode validatorType, ValidationContext validationContext) {
         this(schemaPath, schemaNode, parentSchema, validatorType, false,
-             validationContext.getConfig() != null && validationContext.getConfig().isFailFast());
+             validationContext.getConfig() != null && validationContext.getConfig().isFailFast(),
+             validationContext.getConfig() != null && validationContext.getConfig().getShouldApplyDefaults());
     }
 
     public BaseJsonValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema,
-                             ValidatorTypeCode validatorType, boolean suppressSubSchemaRetrieval, boolean failFast) {
+                             ValidatorTypeCode validatorType, boolean suppressSubSchemaRetrieval, boolean failFast,
+                             boolean shouldApplyDefaults) {
 
         this.errorMessageType = validatorType;
         this.schemaPath = schemaPath;
@@ -55,6 +58,7 @@ public abstract class BaseJsonValidator implements JsonValidator {
         this.validatorType = validatorType;
         this.suppressSubSchemaRetrieval = suppressSubSchemaRetrieval;
         this.failFast = failFast;
+        this.shouldApplyDefaults = shouldApplyDefaults;
     }
 
     public String getSchemaPath() {

--- a/src/main/java/com/networknt/schema/BaseJsonValidator.java
+++ b/src/main/java/com/networknt/schema/BaseJsonValidator.java
@@ -42,19 +42,25 @@ public abstract class BaseJsonValidator implements JsonValidator {
 
     public BaseJsonValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema,
                              ValidatorTypeCode validatorType, ValidationContext validationContext) {
-        this.errorMessageType = validatorType;
-        this.schemaPath = schemaPath;
-        this.schemaNode = schemaNode;
-        this.parentSchema = parentSchema;
-        this.validatorType = validatorType;
-        this.suppressSubSchemaRetrieval = false;
-        this.failFast = validationContext.getConfig() != null && validationContext.getConfig().isFailFast();
-        this.applyDefaultsStrategy = validationContext.getConfig() != null ? validationContext.getConfig().getApplyDefaultsStrategy() : null;
+        this(schemaPath, schemaNode, parentSchema, validatorType, false,
+             validationContext.getConfig() != null && validationContext.getConfig().isFailFast(),
+             validationContext.getConfig() != null ? validationContext.getConfig().getApplyDefaultsStrategy() : null);
     }
 
+    // TODO: can this be made package private?
+    @Deprecated // use the BaseJsonValidator below
     public BaseJsonValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema,
                              ValidatorTypeCode validatorType, boolean suppressSubSchemaRetrieval, boolean failFast) {
+        this(schemaPath, schemaNode, parentSchema, validatorType, false, failFast, null);
+    }
 
+    public BaseJsonValidator(String schemaPath,
+                             JsonNode schemaNode,
+                             JsonSchema parentSchema,
+                             ValidatorTypeCode validatorType,
+                             boolean suppressSubSchemaRetrieval,
+                             boolean failFast,
+                             ApplyDefaultsStrategy applyDefaultsStrategy) {
         this.errorMessageType = validatorType;
         this.schemaPath = schemaPath;
         this.schemaNode = schemaNode;
@@ -62,7 +68,7 @@ public abstract class BaseJsonValidator implements JsonValidator {
         this.validatorType = validatorType;
         this.suppressSubSchemaRetrieval = suppressSubSchemaRetrieval;
         this.failFast = failFast;
-        this.applyDefaultsStrategy = null;
+        this.applyDefaultsStrategy = applyDefaultsStrategy;
     }
 
     public String getSchemaPath() {

--- a/src/main/java/com/networknt/schema/BaseJsonValidator.java
+++ b/src/main/java/com/networknt/schema/BaseJsonValidator.java
@@ -68,7 +68,7 @@ public abstract class BaseJsonValidator implements JsonValidator {
         this.validatorType = validatorType;
         this.suppressSubSchemaRetrieval = suppressSubSchemaRetrieval;
         this.failFast = failFast;
-        this.applyDefaultsStrategy = applyDefaultsStrategy;
+        this.applyDefaultsStrategy = applyDefaultsStrategy != null ? applyDefaultsStrategy : ApplyDefaultsStrategy.EMPTY_APPLY_DEFAULTS_STRATEGY;
     }
 
     public String getSchemaPath() {

--- a/src/main/java/com/networknt/schema/BaseJsonValidator.java
+++ b/src/main/java/com/networknt/schema/BaseJsonValidator.java
@@ -38,18 +38,22 @@ public abstract class BaseJsonValidator implements JsonValidator {
     private ErrorMessageType errorMessageType;
 
     protected final boolean failFast;
-    protected final boolean shouldApplyDefaults;
+    protected final ApplyDefaultsStrategy applyDefaultsStrategy;
 
     public BaseJsonValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema,
                              ValidatorTypeCode validatorType, ValidationContext validationContext) {
-        this(schemaPath, schemaNode, parentSchema, validatorType, false,
-             validationContext.getConfig() != null && validationContext.getConfig().isFailFast(),
-             validationContext.getConfig() != null && validationContext.getConfig().getShouldApplyDefaults());
+        this.errorMessageType = validatorType;
+        this.schemaPath = schemaPath;
+        this.schemaNode = schemaNode;
+        this.parentSchema = parentSchema;
+        this.validatorType = validatorType;
+        this.suppressSubSchemaRetrieval = false;
+        this.failFast = validationContext.getConfig() != null && validationContext.getConfig().isFailFast();
+        this.applyDefaultsStrategy = validationContext.getConfig() != null ? validationContext.getConfig().getApplyDefaultsStrategy() : null;
     }
 
     public BaseJsonValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema,
-                             ValidatorTypeCode validatorType, boolean suppressSubSchemaRetrieval, boolean failFast,
-                             boolean shouldApplyDefaults) {
+                             ValidatorTypeCode validatorType, boolean suppressSubSchemaRetrieval, boolean failFast) {
 
         this.errorMessageType = validatorType;
         this.schemaPath = schemaPath;
@@ -58,7 +62,7 @@ public abstract class BaseJsonValidator implements JsonValidator {
         this.validatorType = validatorType;
         this.suppressSubSchemaRetrieval = suppressSubSchemaRetrieval;
         this.failFast = failFast;
-        this.shouldApplyDefaults = shouldApplyDefaults;
+        this.applyDefaultsStrategy = null;
     }
 
     public String getSchemaPath() {

--- a/src/main/java/com/networknt/schema/ItemsValidator.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator.java
@@ -122,7 +122,7 @@ public class ItemsValidator extends BaseJsonValidator implements JsonValidator {
         if (node instanceof ArrayNode) {
             ArrayNode arrayNode = (ArrayNode) node;
             JsonNode defaultNode = null;
-            if (shouldApplyDefaults && schema != null) {
+            if (applyDefaultsStrategy.shouldApplyArrayDefaults() && schema != null) {
                 defaultNode = schema.getSchemaNode().get("default");
                 if (defaultNode != null && defaultNode.isNull()) {
                     defaultNode = null;

--- a/src/main/java/com/networknt/schema/ItemsValidator.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator.java
@@ -17,6 +17,7 @@
 package com.networknt.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.networknt.schema.walk.DefaultItemWalkListenerRunner;
 import com.networknt.schema.walk.WalkListenerRunner;
 
@@ -118,9 +119,21 @@ public class ItemsValidator extends BaseJsonValidator implements JsonValidator {
     @Override
     public Set<ValidationMessage> walk(JsonNode node, JsonNode rootNode, String at, boolean shouldValidateSchema) {
         HashSet<ValidationMessage> validationMessages = new LinkedHashSet<ValidationMessage>();
-        if (node != null && node.isArray()) {
+        if (node instanceof ArrayNode) {
+            ArrayNode arrayNode = (ArrayNode) node;
+            JsonNode defaultNode = null;
+            if (shouldApplyDefaults && schema != null) {
+                defaultNode = schema.getSchemaNode().get("default");
+                if (defaultNode != null && defaultNode.isNull()) {
+                    defaultNode = null;
+                }
+            }
             int i = 0;
-            for (JsonNode n : node) {
+            for (JsonNode n : arrayNode) {
+                if (n.isNull() && defaultNode != null) {
+                    arrayNode.set(i, defaultNode);
+                    n = defaultNode;
+                }
                 doWalk(validationMessages, i, n, rootNode, at, shouldValidateSchema);
                 i++;
             }

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -19,7 +19,6 @@ package com.networknt.schema;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
-import java.sql.Ref;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -36,8 +35,6 @@ import com.networknt.schema.ValidationContext.DiscriminatorContext;
 import com.networknt.schema.walk.DefaultKeywordWalkListenerRunner;
 import com.networknt.schema.walk.JsonSchemaWalker;
 import com.networknt.schema.walk.WalkListenerRunner;
-
-import javax.xml.validation.Schema;
 
 /**
  * This is the core of json constraint implementation. It parses json constraint
@@ -80,7 +77,8 @@ public class JsonSchema extends BaseJsonValidator {
     private JsonSchema(ValidationContext validationContext, String schemaPath, URI currentUri, JsonNode schemaNode,
                        JsonSchema parent, boolean suppressSubSchemaRetrieval) {
         super(schemaPath, schemaNode, parent, null, suppressSubSchemaRetrieval,
-                validationContext.getConfig() != null && validationContext.getConfig().isFailFast());
+              validationContext.getConfig() != null && validationContext.getConfig().isFailFast(),
+              validationContext.getConfig() != null && validationContext.getConfig().getShouldApplyDefaults());
         this.validationContext = validationContext;
         this.idKeyword = validationContext.getMetaSchema().getIdKeyword();
         this.currentUri = this.combineCurrentUriWithIds(currentUri, schemaNode);
@@ -320,7 +318,7 @@ public class JsonSchema extends BaseJsonValidator {
             SchemaValidatorsConfig config = validationContext.getConfig();
             // Get the collector context from the thread local.
             CollectorContext collectorContext = getCollectorContext();
-            // Valdiate.
+            // Validate.
             Set<ValidationMessage> errors = validate(jsonNode, rootNode, at);
             // When walk is called in series of nested call we don't want to load the collectors every time. Leave to the API to decide when to call collectors.
             if (config.doLoadCollectors()) {
@@ -374,7 +372,7 @@ public class JsonSchema extends BaseJsonValidator {
             JsonSchemaWalker jsonWalker = entry.getValue();
             String schemaPathWithKeyword = entry.getKey();
             try {
-                // Call all the pre-walk listeners. If atleast one of the pre walk listeners
+                // Call all the pre-walk listeners. If at least one of the pre walk listeners
                 // returns SKIP, then skip the walk.
                 if (keywordWalkListenerRunner.runPreWalkListeners(schemaPathWithKeyword,
                         node,

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -77,8 +77,7 @@ public class JsonSchema extends BaseJsonValidator {
     private JsonSchema(ValidationContext validationContext, String schemaPath, URI currentUri, JsonNode schemaNode,
                        JsonSchema parent, boolean suppressSubSchemaRetrieval) {
         super(schemaPath, schemaNode, parent, null, suppressSubSchemaRetrieval,
-              validationContext.getConfig() != null && validationContext.getConfig().isFailFast(),
-              validationContext.getConfig() != null && validationContext.getConfig().getShouldApplyDefaults());
+              validationContext.getConfig() != null && validationContext.getConfig().isFailFast());
         this.validationContext = validationContext;
         this.idKeyword = validationContext.getMetaSchema().getIdKeyword();
         this.currentUri = this.combineCurrentUriWithIds(currentUri, schemaNode);

--- a/src/main/java/com/networknt/schema/PropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/PropertiesValidator.java
@@ -117,10 +117,10 @@ public class PropertiesValidator extends BaseJsonValidator implements JsonValida
                             boolean shouldValidateSchema, Set<ValidationMessage> validationMessages, WalkListenerRunner propertyWalkListenerRunner) {
         JsonSchema propertySchema = entry.getValue();
         JsonNode propertyNode = (node == null ? null : node.get(entry.getKey()));
-        if (propertyNode instanceof ObjectNode && shouldApplyDefaults) {
+        if (propertyNode instanceof ObjectNode && applyDefaultsStrategy.shouldApplyPropertyDefaults()) {
             JsonNode schemaPropertiesNode = propertySchema.getSchemaNode().get("properties");
             if (schemaPropertiesNode != null) {
-                applyDefaults((ObjectNode) propertyNode, schemaPropertiesNode);
+                applyPropertyDefaults((ObjectNode) propertyNode, schemaPropertiesNode, applyDefaultsStrategy.shouldApplyPropertyDefaultsIfNull());
             }
         }
         boolean executeWalk = propertyWalkListenerRunner.runPreWalkListeners(ValidatorTypeCode.PROPERTIES.getValue(),
@@ -137,13 +137,13 @@ public class PropertiesValidator extends BaseJsonValidator implements JsonValida
 
     }
 
-    private void applyDefaults(ObjectNode node, JsonNode schemaPropertiesNode) {
+    private static void applyPropertyDefaults(ObjectNode node, JsonNode schemaPropertiesNode, boolean applyPropertyDefaultsIfNull) {
         for (Iterator<Map.Entry<String, JsonNode>> iter = schemaPropertiesNode.fields(); iter.hasNext(); ) {
             Map.Entry<String, JsonNode> entry = iter.next();
             String name = entry.getKey();
             JsonNode propertyNode = node.get(name);
 
-            if (propertyNode == null || propertyNode.isNull()) {
+            if (propertyNode == null || (applyPropertyDefaultsIfNull && propertyNode.isNull())) {
                 JsonNode defaultNode = entry.getValue().get("default");
                 if (defaultNode != null && !defaultNode.isNull()) {
                     // mutate the input json

--- a/src/main/java/com/networknt/schema/SchemaValidatorsConfig.java
+++ b/src/main/java/com/networknt/schema/SchemaValidatorsConfig.java
@@ -38,6 +38,11 @@ public class SchemaValidatorsConfig {
     private boolean failFast;
 
     /**
+     * When set to true, walker sets nodes that are missing or NullNode to the default value, if any, and mutate the input json.
+     */
+    private boolean shouldApplyDefaults;
+
+    /**
      * When set to true, use ECMA-262 compatible validator
      */
     private boolean ecma262Validator;
@@ -110,6 +115,14 @@ public class SchemaValidatorsConfig {
 
     public boolean isFailFast() {
         return this.failFast;
+    }
+
+    public void setShouldApplyDefaults(boolean shouldApplyDefaults) {
+        this.shouldApplyDefaults = shouldApplyDefaults;
+    }
+
+    public boolean getShouldApplyDefaults() {
+        return shouldApplyDefaults;
     }
 
     public Map<String, String> getUriMappings() {

--- a/src/main/java/com/networknt/schema/SchemaValidatorsConfig.java
+++ b/src/main/java/com/networknt/schema/SchemaValidatorsConfig.java
@@ -40,7 +40,7 @@ public class SchemaValidatorsConfig {
     /**
      * When set to true, walker sets nodes that are missing or NullNode to the default value, if any, and mutate the input json.
      */
-    private boolean shouldApplyDefaults;
+    private ApplyDefaultsStrategy applyDefaultsStrategy;
 
     /**
      * When set to true, use ECMA-262 compatible validator
@@ -117,12 +117,12 @@ public class SchemaValidatorsConfig {
         return this.failFast;
     }
 
-    public void setShouldApplyDefaults(boolean shouldApplyDefaults) {
-        this.shouldApplyDefaults = shouldApplyDefaults;
+    public void setApplyDefaultsStrategy(ApplyDefaultsStrategy applyDefaultsStrategy) {
+        this.applyDefaultsStrategy = applyDefaultsStrategy;
     }
 
-    public boolean getShouldApplyDefaults() {
-        return shouldApplyDefaults;
+    public ApplyDefaultsStrategy getApplyDefaultsStrategy() {
+        return applyDefaultsStrategy;
     }
 
     public Map<String, String> getUriMappings() {

--- a/src/test/java/com/networknt/schema/JsonWalkApplyDefaultsTest.java
+++ b/src/test/java/com/networknt/schema/JsonWalkApplyDefaultsTest.java
@@ -2,44 +2,89 @@ package com.networknt.schema;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.stream.Collectors;
-
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 
-public class JsonWalkApplyDefaultsTest {
+class JsonWalkApplyDefaultsTest {
 
     @Test
-    public void testApplyDefaults() throws IOException {
+    void testApplyDefaults3() throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode inputNode = objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("data/walk-data-default.json"));
-        JsonSchema jsonSchema = createSchema();
+        JsonSchema jsonSchema = createSchema(new ApplyDefaultsStrategy(true, true, true));
         ValidationResult result = jsonSchema.walk(inputNode, true);
         assertThat(result.getValidationMessages().stream().map(ValidationMessage::getMessage).collect(Collectors.toList()),
-                   Matchers.contains("$.outer.mixedObject.intValue_missingButError: string found, integer expected",
-                                     "$.outer.badArray[1]: integer found, string expected"));
-        assertEquals(4, inputNode.get("outer").get("mixedObject").size());
-        assertEquals(11, inputNode.get("outer").get("mixedObject").get("intValue_present").intValue());
-        assertEquals(15, inputNode.get("outer").get("mixedObject").get("intValue_missing").intValue());
-        assertEquals(25, inputNode.get("outer").get("mixedObject").get("intValue_null").intValue());
-        assertEquals("thirty-five", inputNode.get("outer").get("mixedObject").get("intValue_missingButError").textValue());
-        assertEquals(2, inputNode.get("outer").get("goodArray").size());
-        assertEquals("hello", inputNode.get("outer").get("goodArray").get(0).textValue());
-        assertEquals("five", inputNode.get("outer").get("goodArray").get(1).textValue());
-        assertEquals(2, inputNode.get("outer").get("badArray").size());
-        assertEquals("hello", inputNode.get("outer").get("badArray").get(0).textValue());
-        assertEquals(5, inputNode.get("outer").get("badArray").get(1).intValue());
+                   Matchers.containsInAnyOrder("$.outer.mixedObject.intValue_missingButError: string found, integer expected",
+                                               "$.outer.badArray[1]: integer found, string expected"));
+        assertEquals("{\"outer\":{\"mixedObject\":{\"intValue_present\":11,\"intValue_null\":25,\"intValue_missing\":15,\"intValue_missingButError\":\"thirty-five\"},\"goodArray\":[\"hello\",\"five\"],\"badArray\":[\"hello\",5]}}",
+                     inputNode.toString());
     }
 
-    private JsonSchema createSchema() {
+    @Test
+    void testApplyDefaults2() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode inputNode = objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("data/walk-data-default.json"));
+        JsonSchema jsonSchema = createSchema(new ApplyDefaultsStrategy(true, true, false));
+        ValidationResult result = jsonSchema.walk(inputNode, true);
+        assertThat(result.getValidationMessages().stream().map(ValidationMessage::getMessage).collect(Collectors.toList()),
+                   Matchers.containsInAnyOrder("$.outer.mixedObject.intValue_missingButError: string found, integer expected",
+                                               "$.outer.goodArray[1]: null found, string expected",
+                                               "$.outer.badArray[1]: null found, string expected"));
+        assertEquals("{\"outer\":{\"mixedObject\":{\"intValue_present\":11,\"intValue_null\":25,\"intValue_missing\":15,\"intValue_missingButError\":\"thirty-five\"},\"goodArray\":[\"hello\",null],\"badArray\":[\"hello\",null]}}",
+                     inputNode.toString());
+    }
+
+    @Test
+    void testApplyDefaults1() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode inputNode = objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("data/walk-data-default.json"));
+        JsonSchema jsonSchema = createSchema(new ApplyDefaultsStrategy(true, false, false));
+        ValidationResult result = jsonSchema.walk(inputNode, true);
+        assertThat(result.getValidationMessages().stream().map(ValidationMessage::getMessage).collect(Collectors.toList()),
+                   Matchers.containsInAnyOrder("$.outer.mixedObject.intValue_null: null found, integer expected",
+                                               "$.outer.mixedObject.intValue_missingButError: string found, integer expected",
+                                               "$.outer.goodArray[1]: null found, string expected",
+                                               "$.outer.badArray[1]: null found, string expected"));
+        assertEquals("{\"outer\":{\"mixedObject\":{\"intValue_present\":11,\"intValue_null\":null,\"intValue_missing\":15,\"intValue_missingButError\":\"thirty-five\"},\"goodArray\":[\"hello\",null],\"badArray\":[\"hello\",null]}}",
+                     inputNode.toString());
+    }
+
+    @Test
+    void testApplyDefaults0() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode inputNode = objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("data/walk-data-default.json"));
+        JsonNode inputNodeOriginal = objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("data/walk-data-default.json"));
+        JsonSchema jsonSchema = createSchema(new ApplyDefaultsStrategy(false, false, false));
+        ValidationResult result = jsonSchema.walk(inputNode, true);
+        assertThat(result.getValidationMessages().stream().map(ValidationMessage::getMessage).collect(Collectors.toList()),
+                   Matchers.containsInAnyOrder("$.outer.mixedObject.intValue_missing: is missing but it is required",
+                                               "$.outer.mixedObject.intValue_null: null found, integer expected",
+                                               "$.outer.mixedObject.intValue_missingButError: is missing but it is required",
+                                               "$.outer.goodArray[1]: null found, string expected",
+                                               "$.outer.badArray[1]: null found, string expected"));
+        assertEquals(inputNodeOriginal,  inputNode);
+    }
+
+    @Test
+    void testIllegalArgumentException() {
+        try {
+            new ApplyDefaultsStrategy(false, true, false);
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    private JsonSchema createSchema(ApplyDefaultsStrategy applyDefaultsStrategy) {
         JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4);
         SchemaValidatorsConfig schemaValidatorsConfig = new SchemaValidatorsConfig();
-        schemaValidatorsConfig.setShouldApplyDefaults(true);
+        schemaValidatorsConfig.setApplyDefaultsStrategy(applyDefaultsStrategy);
         return schemaFactory.getSchema(getClass().getClassLoader().getResourceAsStream("schema/walk-schema-default.json"), schemaValidatorsConfig);
     }
 }

--- a/src/test/java/com/networknt/schema/JsonWalkApplyDefaultsTest.java
+++ b/src/test/java/com/networknt/schema/JsonWalkApplyDefaultsTest.java
@@ -10,12 +10,18 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 
 class JsonWalkApplyDefaultsTest {
+
+    @AfterEach
+    void cleanup() {
+        CollectorContext.getInstance().reset();
+    }
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false})
@@ -74,42 +80,38 @@ class JsonWalkApplyDefaultsTest {
     @ParameterizedTest
     @ValueSource(strings = { "walkWithEmptyStrategy", "walkWithNoDefaults", "validateWithApplyAllDefaults"} )
     void testApplyDefaults0(String method) throws IOException {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode inputNode = objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("data/walk-data-default.json"));
-            JsonNode inputNodeOriginal = objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("data/walk-data-default.json"));
-            Set<ValidationMessage> validationMessages;
-            switch (method) {
-                case "walkWithEmptyStrategy": {
-                    JsonSchema jsonSchema = createSchema(new ApplyDefaultsStrategy(false, false, false));
-                    validationMessages = jsonSchema.walk(inputNode, true).getValidationMessages();
-                    break;
-                }
-                case "walkWithNoDefaults": {
-                    // same empty strategy, but tests for NullPointerException
-                    JsonSchema jsonSchema = createSchema(null);
-                    validationMessages = jsonSchema.walk(inputNode, true).getValidationMessages();
-                    break;
-                }
-                case "validateWithApplyAllDefaults": {
-                    JsonSchema jsonSchema = createSchema(new ApplyDefaultsStrategy(true, true, true));
-                    validationMessages = jsonSchema.validate(inputNode);
-                    break;
-                }
-                default:
-                    throw new UnsupportedOperationException();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode inputNode = objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("data/walk-data-default.json"));
+        JsonNode inputNodeOriginal = objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("data/walk-data-default.json"));
+        Set<ValidationMessage> validationMessages;
+        switch (method) {
+            case "walkWithEmptyStrategy": {
+                JsonSchema jsonSchema = createSchema(new ApplyDefaultsStrategy(false, false, false));
+                validationMessages = jsonSchema.walk(inputNode, true).getValidationMessages();
+                break;
             }
-            assertThat(validationMessages.stream().map(ValidationMessage::getMessage).collect(Collectors.toList()),
-                       Matchers.containsInAnyOrder("$.outer.mixedObject.intValue_missing: is missing but it is required",
-                                                   "$.outer.mixedObject.intValue_missingButError: is missing but it is required",
-                                                   "$.outer.mixedObject.intValue_null: null found, integer expected",
-                                                   "$.outer.goodArray[1]: null found, string expected",
-                                                   "$.outer.badArray[1]: null found, string expected",
-                                                   "$.outer.reference.stringValue_missing: is missing but it is required"));
-            assertEquals(inputNodeOriginal, inputNode);
-        } finally {
-            CollectorContext.getInstance().reset(); // necessary because we are calling both jsonSchema.walk and jsonSchema.validate
+            case "walkWithNoDefaults": {
+                // same empty strategy, but tests for NullPointerException
+                JsonSchema jsonSchema = createSchema(null);
+                validationMessages = jsonSchema.walk(inputNode, true).getValidationMessages();
+                break;
+            }
+            case "validateWithApplyAllDefaults": {
+                JsonSchema jsonSchema = createSchema(new ApplyDefaultsStrategy(true, true, true));
+                validationMessages = jsonSchema.validate(inputNode);
+                break;
+            }
+            default:
+                throw new UnsupportedOperationException();
         }
+        assertThat(validationMessages.stream().map(ValidationMessage::getMessage).collect(Collectors.toList()),
+                   Matchers.containsInAnyOrder("$.outer.mixedObject.intValue_missing: is missing but it is required",
+                                               "$.outer.mixedObject.intValue_missingButError: is missing but it is required",
+                                               "$.outer.mixedObject.intValue_null: null found, integer expected",
+                                               "$.outer.goodArray[1]: null found, string expected",
+                                               "$.outer.badArray[1]: null found, string expected",
+                                               "$.outer.reference.stringValue_missing: is missing but it is required"));
+        assertEquals(inputNodeOriginal, inputNode);
     }
 
     @Test

--- a/src/test/java/com/networknt/schema/JsonWalkApplyDefaultsTest.java
+++ b/src/test/java/com/networknt/schema/JsonWalkApplyDefaultsTest.java
@@ -1,0 +1,45 @@
+package com.networknt.schema;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.stream.Collectors;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+
+public class JsonWalkApplyDefaultsTest {
+
+    @Test
+    public void testApplyDefaults() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode inputNode = objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("data/walk-data-default.json"));
+        JsonSchema jsonSchema = createSchema();
+        ValidationResult result = jsonSchema.walk(inputNode, true);
+        assertThat(result.getValidationMessages().stream().map(ValidationMessage::getMessage).collect(Collectors.toList()),
+                   Matchers.contains("$.outer.mixedObject.intValue_missingButError: string found, integer expected",
+                                     "$.outer.badArray[1]: integer found, string expected"));
+        assertEquals(4, inputNode.get("outer").get("mixedObject").size());
+        assertEquals(11, inputNode.get("outer").get("mixedObject").get("intValue_present").intValue());
+        assertEquals(15, inputNode.get("outer").get("mixedObject").get("intValue_missing").intValue());
+        assertEquals(25, inputNode.get("outer").get("mixedObject").get("intValue_null").intValue());
+        assertEquals("thirty-five", inputNode.get("outer").get("mixedObject").get("intValue_missingButError").textValue());
+        assertEquals(2, inputNode.get("outer").get("goodArray").size());
+        assertEquals("hello", inputNode.get("outer").get("goodArray").get(0).textValue());
+        assertEquals("five", inputNode.get("outer").get("goodArray").get(1).textValue());
+        assertEquals(2, inputNode.get("outer").get("badArray").size());
+        assertEquals("hello", inputNode.get("outer").get("badArray").get(0).textValue());
+        assertEquals(5, inputNode.get("outer").get("badArray").get(1).intValue());
+    }
+
+    private JsonSchema createSchema() {
+        JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4);
+        SchemaValidatorsConfig schemaValidatorsConfig = new SchemaValidatorsConfig();
+        schemaValidatorsConfig.setShouldApplyDefaults(true);
+        return schemaFactory.getSchema(getClass().getClassLoader().getResourceAsStream("schema/walk-schema-default.json"), schemaValidatorsConfig);
+    }
+}

--- a/src/test/java/com/networknt/schema/JsonWalkApplyDefaultsTest.java
+++ b/src/test/java/com/networknt/schema/JsonWalkApplyDefaultsTest.java
@@ -7,22 +7,31 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 
 class JsonWalkApplyDefaultsTest {
 
-    @Test
-    void testApplyDefaults3() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false})
+    void testApplyDefaults3(boolean shouldValidateSchema) throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode inputNode = objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("data/walk-data-default.json"));
         JsonSchema jsonSchema = createSchema(new ApplyDefaultsStrategy(true, true, true));
-        ValidationResult result = jsonSchema.walk(inputNode, true);
-        assertThat(result.getValidationMessages().stream().map(ValidationMessage::getMessage).collect(Collectors.toList()),
-                   Matchers.containsInAnyOrder("$.outer.mixedObject.intValue_missingButError: string found, integer expected",
-                                               "$.outer.badArray[1]: integer found, string expected"));
+        ValidationResult result = jsonSchema.walk(inputNode, shouldValidateSchema);
+        if (shouldValidateSchema) {
+            assertThat(result.getValidationMessages().stream().map(ValidationMessage::getMessage).collect(Collectors.toList()),
+                       Matchers.containsInAnyOrder("$.outer.mixedObject.intValue_missingButError: string found, integer expected",
+                                                   "$.outer.badArray[1]: integer found, string expected"));
+        } else {
+            assertThat(result.getValidationMessages(), Matchers.empty());
+        }
         assertEquals("{\"outer\":{\"mixedObject\":{\"intValue_present\":11,\"intValue_null\":25,\"intValue_missing\":15,\"intValue_missingButError\":\"thirty-five\"},\"goodArray\":[\"hello\",\"five\"],\"badArray\":[\"hello\",5]}}",
                      inputNode.toString());
     }
@@ -56,20 +65,34 @@ class JsonWalkApplyDefaultsTest {
                      inputNode.toString());
     }
 
-    @Test
-    void testApplyDefaults0() throws IOException {
+    @ParameterizedTest
+    @ValueSource(strings = { "walkWithNoDefaults", "validateWithApplyAllDefaults"} )
+    void testApplyDefaults0(String method) throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode inputNode = objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("data/walk-data-default.json"));
         JsonNode inputNodeOriginal = objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("data/walk-data-default.json"));
-        JsonSchema jsonSchema = createSchema(new ApplyDefaultsStrategy(false, false, false));
-        ValidationResult result = jsonSchema.walk(inputNode, true);
-        assertThat(result.getValidationMessages().stream().map(ValidationMessage::getMessage).collect(Collectors.toList()),
+        Set<ValidationMessage> validationMessages;
+        switch (method) {
+            case "walkWithNoDefaults": {
+                JsonSchema jsonSchema = createSchema(new ApplyDefaultsStrategy(false, false, false));
+                validationMessages = jsonSchema.walk(inputNode, true).getValidationMessages();
+                break;
+            }
+            case "validateWithApplyAllDefaults": {
+                JsonSchema jsonSchema = createSchema(new ApplyDefaultsStrategy(true, true, true));
+                validationMessages = jsonSchema.validate(inputNode);
+                break;
+            }
+            default: throw new UnsupportedOperationException();
+        }
+        assertThat(validationMessages.stream().map(ValidationMessage::getMessage).collect(Collectors.toList()),
                    Matchers.containsInAnyOrder("$.outer.mixedObject.intValue_missing: is missing but it is required",
                                                "$.outer.mixedObject.intValue_null: null found, integer expected",
                                                "$.outer.mixedObject.intValue_missingButError: is missing but it is required",
                                                "$.outer.goodArray[1]: null found, string expected",
                                                "$.outer.badArray[1]: null found, string expected"));
         assertEquals(inputNodeOriginal,  inputNode);
+        CollectorContext.getInstance().reset(); // necessary because we are calling both jsonSchema.walk and jsonSchema.validate
     }
 
     @Test

--- a/src/test/java/com/networknt/schema/JsonWalkApplyDefaultsTest.java
+++ b/src/test/java/com/networknt/schema/JsonWalkApplyDefaultsTest.java
@@ -31,8 +31,11 @@ class JsonWalkApplyDefaultsTest {
         } else {
             assertThat(result.getValidationMessages(), Matchers.empty());
         }
-        assertEquals("{\"outer\":{\"mixedObject\":{\"intValue_present\":11,\"intValue_null\":25,\"intValue_missing\":15,\"intValue_missingButError\":\"thirty-five\"},\"goodArray\":[\"hello\",\"five\"],\"badArray\":[\"hello\",5]}}",
-                     inputNode.toString());
+        // TODO: In Java 14 use text blocks
+        assertEquals(
+                objectMapper.readTree(
+                        "{\"outer\":{\"mixedObject\":{\"intValue_present\":8,\"intValue_missing\":15,\"intValue_missing_notRequired\":25,\"intValue_null\":35,\"intValue_missingButError\":\"forty-five\"},\"goodArray\":[\"hello\",\"five\"],\"badArray\":[\"hello\",5],\"reference\":{\"stringValue_missing\":\"hello\"}}}"),
+                inputNode);
     }
 
     @Test
@@ -45,8 +48,10 @@ class JsonWalkApplyDefaultsTest {
                    Matchers.containsInAnyOrder("$.outer.mixedObject.intValue_missingButError: string found, integer expected",
                                                "$.outer.goodArray[1]: null found, string expected",
                                                "$.outer.badArray[1]: null found, string expected"));
-        assertEquals("{\"outer\":{\"mixedObject\":{\"intValue_present\":11,\"intValue_null\":25,\"intValue_missing\":15,\"intValue_missingButError\":\"thirty-five\"},\"goodArray\":[\"hello\",null],\"badArray\":[\"hello\",null]}}",
-                     inputNode.toString());
+        assertEquals(
+                objectMapper.readTree(
+                        "{\"outer\":{\"mixedObject\":{\"intValue_present\":8,\"intValue_missing\":15,\"intValue_missing_notRequired\":25,\"intValue_null\":35,\"intValue_missingButError\":\"forty-five\"},\"goodArray\":[\"hello\",null],\"badArray\":[\"hello\",null],\"reference\":{\"stringValue_missing\":\"hello\"}}}"),
+                inputNode);
     }
 
     @Test
@@ -60,8 +65,10 @@ class JsonWalkApplyDefaultsTest {
                                                "$.outer.mixedObject.intValue_missingButError: string found, integer expected",
                                                "$.outer.goodArray[1]: null found, string expected",
                                                "$.outer.badArray[1]: null found, string expected"));
-        assertEquals("{\"outer\":{\"mixedObject\":{\"intValue_present\":11,\"intValue_null\":null,\"intValue_missing\":15,\"intValue_missingButError\":\"thirty-five\"},\"goodArray\":[\"hello\",null],\"badArray\":[\"hello\",null]}}",
-                     inputNode.toString());
+        assertEquals(
+                objectMapper.readTree(
+                        "{\"outer\":{\"mixedObject\":{\"intValue_present\":8,\"intValue_missing\":15,\"intValue_missing_notRequired\":25,\"intValue_null\":null,\"intValue_missingButError\":\"forty-five\"},\"goodArray\":[\"hello\",null],\"badArray\":[\"hello\",null],\"reference\":{\"stringValue_missing\":\"hello\"}}}"),
+                inputNode);
     }
 
     @ParameterizedTest
@@ -89,7 +96,8 @@ class JsonWalkApplyDefaultsTest {
                                                "$.outer.mixedObject.intValue_null: null found, integer expected",
                                                "$.outer.mixedObject.intValue_missingButError: is missing but it is required",
                                                "$.outer.goodArray[1]: null found, string expected",
-                                               "$.outer.badArray[1]: null found, string expected"));
+                                               "$.outer.badArray[1]: null found, string expected",
+                                               "$.outer.reference.stringValue_missing: is missing but it is required"));
         assertEquals(inputNodeOriginal,  inputNode);
         CollectorContext.getInstance().reset(); // necessary because we are calling both jsonSchema.walk and jsonSchema.validate
     }

--- a/src/test/java/com/networknt/schema/JsonWalkApplyDefaultsTest.java
+++ b/src/test/java/com/networknt/schema/JsonWalkApplyDefaultsTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.hamcrest.Matchers;

--- a/src/test/resources/data/walk-data-default.json
+++ b/src/test/resources/data/walk-data-default.json
@@ -1,0 +1,10 @@
+{
+  "outer": {
+    "mixedObject": {
+      "intValue_present": 11,
+      "intValue_null": null
+    },
+    "goodArray": ["hello", null],
+    "badArray": ["hello", null]
+  }
+}

--- a/src/test/resources/data/walk-data-default.json
+++ b/src/test/resources/data/walk-data-default.json
@@ -1,10 +1,12 @@
 {
   "outer": {
     "mixedObject": {
-      "intValue_present": 11,
+      "intValue_present": 8,
       "intValue_null": null
     },
     "goodArray": ["hello", null],
-    "badArray": ["hello", null]
+    "badArray": ["hello", null],
+    "reference": {
+    }
   }
 }

--- a/src/test/resources/schema/walk-schema-default.json
+++ b/src/test/resources/schema/walk-schema-default.json
@@ -2,6 +2,9 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Schema with default values ",
   "type": "object",
+  "definitions": {
+    ""
+  },
   "properties": {
     "outer": {
       "type": "object",
@@ -15,17 +18,17 @@
               "default": 5
             },
             "intValue_missing": {
-              "description": "the test data does not have this attribute, so default should be applied",
+              "description": "the test data does not have this attribute, so default should be applied if the ApplyDefaultsStrategy requires it",
               "type": "integer",
               "default": 15
             },
             "intValue_null": {
-              "description": "the test data supplies the value null for this attribute so the default should be applied",
+              "description": "the test data supplies the value null for this attribute so the default should be applied if the ApplyDefaultsStrategy requires it",
               "type": "integer",
               "default": 25
             },
             "intValue_missingButError": {
-              "description": "the test data does not have this attribute, so default should be applied, but the default is wrong so there should be an error",
+              "description": "the test data does not have this attribute, so default should be applied if the ApplyDefaultsStrategy requires it, but the default is wrong so there should be an error",
               "type": "integer",
               "default": "thirty-five"
             }
@@ -41,7 +44,7 @@
         "goodArray": {
           "type": "array",
           "items": {
-            "description": "if an item in the array is null, then default value should be applied",
+            "description": "if an item in the array is null, then default value should be applied if the ApplyDefaultsStrategy requires it",
             "type": "string",
             "default": "five"
           }
@@ -49,7 +52,7 @@
         "badArray": {
           "type": "array",
           "items": {
-            "description": "if an item in the array is null, then default value should be applied",
+            "description": "if an item in the array is null, then default value should be applied if the ApplyDefaultsStrategy requires it, but the default is wrong so there should be an error",
             "type": "string",
             "default": 5
           }

--- a/src/test/resources/schema/walk-schema-default.json
+++ b/src/test/resources/schema/walk-schema-default.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Schema with default values ",
+  "type": "object",
+  "properties": {
+    "outer": {
+      "type": "object",
+      "properties": {
+        "mixedObject": {
+          "type": "object",
+          "properties": {
+            "intValue_present": {
+              "description": "the test data supplies a value for this attribute so the default is ignored",
+              "type": "integer",
+              "default": 5
+            },
+            "intValue_missing": {
+              "description": "the test data does not have this attribute, so default should be applied",
+              "type": "integer",
+              "default": 15
+            },
+            "intValue_null": {
+              "description": "the test data supplies the value null for this attribute so the default should be applied",
+              "type": "integer",
+              "default": 25
+            },
+            "intValue_missingButError": {
+              "description": "the test data does not have this attribute, so default should be applied, but the default is wrong so there should be an error",
+              "type": "integer",
+              "default": "thirty-five"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "intValue_present",
+            "intValue_missing",
+            "intValue_null",
+            "intValue_missingButError"
+          ]
+        },
+        "goodArray": {
+          "type": "array",
+          "items": {
+            "description": "if an item in the array is null, then default value should be applied",
+            "type": "string",
+            "default": "five"
+          }
+        },
+        "badArray": {
+          "type": "array",
+          "items": {
+            "description": "if an item in the array is null, then default value should be applied",
+            "type": "string",
+            "default": 5
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["mixedObject", "goodArray", "badArray"]
+    }
+  },
+  "additionalProperties": false,
+  "required": ["outer"]
+}

--- a/src/test/resources/schema/walk-schema-default.json
+++ b/src/test/resources/schema/walk-schema-default.json
@@ -1,10 +1,24 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Schema with default values ",
-  "type": "object",
+
   "definitions": {
-    ""
+    "RandomObject": {
+      "type": "object",
+      "properties": {
+        "stringValue_missing": {
+          "description": "the test data does not have this attribute, so default should be applied if the ApplyDefaultsStrategy requires it",
+          "type": "string",
+          "default": "hello"
+        }
+      },
+      "required": [
+        "stringValue_missing"
+      ]
+    }
   },
+
+  "type": "object",
   "properties": {
     "outer": {
       "type": "object",
@@ -22,15 +36,20 @@
               "type": "integer",
               "default": 15
             },
+            "intValue_missing_notRequired": {
+              "description": "the test data does not have this attribute, so default should be applied if the ApplyDefaultsStrategy requires it",
+              "type": "integer",
+              "default": 25
+            },
             "intValue_null": {
               "description": "the test data supplies the value null for this attribute so the default should be applied if the ApplyDefaultsStrategy requires it",
               "type": "integer",
-              "default": 25
+              "default": 35
             },
             "intValue_missingButError": {
               "description": "the test data does not have this attribute, so default should be applied if the ApplyDefaultsStrategy requires it, but the default is wrong so there should be an error",
               "type": "integer",
-              "default": "thirty-five"
+              "default": "forty-five"
             }
           },
           "additionalProperties": false,
@@ -41,6 +60,7 @@
             "intValue_missingButError"
           ]
         },
+
         "goodArray": {
           "type": "array",
           "items": {
@@ -49,6 +69,7 @@
             "default": "five"
           }
         },
+
         "badArray": {
           "type": "array",
           "items": {
@@ -56,10 +77,14 @@
             "type": "string",
             "default": 5
           }
+        },
+
+        "reference": {
+          "$ref": "#/definitions/RandomObject"
         }
       },
       "additionalProperties": false,
-      "required": ["mixedObject", "goodArray", "badArray"]
+      "required": ["mixedObject", "goodArray", "badArray", "reference"]
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
At https://json-schema.org/understanding-json-schema/reference/generic.html they say of the default keyword

> The default keyword specifies a default value. This value is not used to fill in missing values during the validation process. Non-validation tools such as documentation generators or form generators may use this value to give hints to users about how to use a value. However, default is typically used to express that if a value is missing, then the value is semantically the same as if the value was present with the default value. The value of default should validate against the schema in which it resides, but that isn’t required.

So before this PR, the 'default' keyword is ignored during both validation and walking.  But this PR allow the user to apply defaults during walking.  They still have to set a flag indicating that they want defaults to be applied (and they can apply defaults only if property is missing, or if it missing or is explicitly null).

If JSON blobs were saved to the database, and the JSON schema changed to add defaults, the db migration tool could use read the JSON blobs and walk them against the schema again to apply defaults.