### PR TITLE
issue-478 : Time format validation supports milliseconds

### DIFF
--- a/src/main/java/com/networknt/schema/JsonMetaSchema.java
+++ b/src/main/java/com/networknt/schema/JsonMetaSchema.java
@@ -40,7 +40,7 @@ public class JsonMetaSchema {
 
     // this section contains formats that is common for all specification versions.
     static {
-        COMMON_BUILTIN_FORMATS.add(pattern("time", "^\\d{2}:\\d{2}:\\d{2}$"));
+        COMMON_BUILTIN_FORMATS.add(pattern("time", "^\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?$"));
         COMMON_BUILTIN_FORMATS.add(pattern("ip-address",
                 "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"));
         COMMON_BUILTIN_FORMATS.add(pattern("ipv4",

--- a/src/test/java/com/networknt/schema/JsonMetaSchemaTest.java
+++ b/src/test/java/com/networknt/schema/JsonMetaSchemaTest.java
@@ -1,0 +1,27 @@
+package com.networknt.schema;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonMetaSchemaTest {
+
+	@Test
+	void timeFormatValidation() {
+		Format timeFormat = null;
+		for (Format commonBuiltinFormat : JsonMetaSchema.COMMON_BUILTIN_FORMATS) {
+			if ("time".equals(commonBuiltinFormat.getName())) {
+				timeFormat = commonBuiltinFormat;
+			}
+		}
+		if (timeFormat == null) {
+			throw new IllegalArgumentException("time format not found");
+		}
+
+		assertTrue(timeFormat.matches("14:16:23"));
+		assertTrue(timeFormat.matches("14:16:23.123456"));
+		assertFalse(timeFormat.matches("14:16:23."));
+
+	}
+
+}


### PR DESCRIPTION
PR changes regex pattern for time to "^\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?$"