### PR TITLE
Fix violations of Sonar rule 2142

### DIFF
--- a/src/test/java/com/networknt/schema/BaseSuiteJsonSchemaTest.java
+++ b/src/test/java/com/networknt/schema/BaseSuiteJsonSchemaTest.java
@@ -60,6 +60,7 @@ public abstract class BaseSuiteJsonSchemaTest {
             try {
                 Thread.sleep(100);
             } catch (InterruptedException ignored) {
+				Thread.currentThread().interrupt();
 
             }
             server.stop();

--- a/src/test/java/com/networknt/schema/Issue425Test.java
+++ b/src/test/java/com/networknt/schema/Issue425Test.java
@@ -46,6 +46,7 @@ public class Issue425Test {
             try {
                 Thread.sleep(100);
             } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
 
             }
             server.stop();

--- a/src/test/java/com/networknt/schema/Issue428Test.java
+++ b/src/test/java/com/networknt/schema/Issue428Test.java
@@ -46,6 +46,7 @@ public class Issue428Test {
             try {
                 Thread.sleep(100);
             } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
 
             }
             server.stop();

--- a/src/test/java/com/networknt/schema/OpenAPI30JsonSchemaTest.java
+++ b/src/test/java/com/networknt/schema/OpenAPI30JsonSchemaTest.java
@@ -46,6 +46,7 @@ public class OpenAPI30JsonSchemaTest {
             try {
                 Thread.sleep(100);
             } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
 
             }
             server.stop();


### PR DESCRIPTION
Hi,

This PR fixes 4 violations of [Sonar Rule 2142: '"InterruptedException" should not be ignored'](https://rules.sonarsource.com/java/RSPEC-2142). This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2142](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#interruptedexception-should-not-be-ignored-sonar-rule-2142).

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.