### PR TITLE
Handle the situation when context class loader is null

### DIFF
--- a/src/main/java/com/networknt/schema/uri/ClasspathURLStreamHandler.java
+++ b/src/main/java/com/networknt/schema/uri/ClasspathURLStreamHandler.java
@@ -76,11 +76,14 @@ class ClasspathURLStreamHandler extends URLStreamHandler {
                 path = path.substring(1);
             }
 
-            InputStream stream;
+            InputStream stream = null;
             if (mHost != null) {
                 stream = mHost.getClassLoader().getResourceAsStream(path);
             } else {
-                stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
+                ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+                if (contextClassLoader != null) {
+                    stream = contextClassLoader.getResourceAsStream(path);
+                }
                 if (stream == null) {
                     stream = getClass().getClassLoader().getResourceAsStream(path);
                 }


### PR DESCRIPTION
This fixes the errors when trying to load classpath references, like:

    Caused by: java.lang.NullPointerException
            at com.networknt.schema.uri.ClasspathURLStreamHandler$ClassPathURLConnection.getResourceAsStream(ClasspathURLStreamHandler.java:83) ~[amcrm-1.0-SNAPSHOT.jar:?]
            at com.networknt.schema.uri.ClasspathURLStreamHandler$ClassPathURLConnection.getInputStream(ClasspathURLStreamHandler.java:69) ~[amcrm-1.0-SNAPSHOT.jar:?]
            at java.net.URL.openStream(URL.java:1165) ~[?:?]
            at com.networknt.schema.uri.ClasspathURLFetcher.fetch(ClasspathURLFetcher.java:39) ~[amcrm-1.0-SNAPSHOT.jar:?]
            at com.networknt.schema.uri.URISchemeFetcher.fetch(URISchemeFetcher.java:50) ~[amcrm-1.0-SNAPSHOT.jar:?]
            at com.networknt.schema.JsonSchemaFactory.getSchema(JsonSchemaFactory.java:351) ~[amcrm-1.0-SNAPSHOT.jar:?]
            at com.networknt.schema.RefValidator.getRefSchema(RefValidator.java:82) ~[amcrm-1.0-SNAPSHOT.jar:?]
            at com.networknt.schema.RefValidator.<init>(RefValidator.java:45) ~[amcrm-1.0-SNAPSHOT.jar:?]