### PR TITLE
parent schema of additionItems can be correctly referenced (#493)

### DIFF
--- a/src/main/java/com/networknt/schema/ItemsValidator.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator.java
@@ -58,7 +58,7 @@ public class ItemsValidator extends BaseJsonValidator implements JsonValidator {
                 if (addItemNode.isBoolean()) {
                     additionalItems = addItemNode.asBoolean();
                 } else if (addItemNode.isObject()) {
-                    foundAdditionalSchema = new JsonSchema(validationContext, parentSchema.getCurrentUri(), addItemNode);
+                    foundAdditionalSchema = new JsonSchema(validationContext, "#", parentSchema.getCurrentUri(), addItemNode, parentSchema);
                 }
             }
         }

--- a/src/test/java/com/networknt/schema/Issue493Test.java
+++ b/src/test/java/com/networknt/schema/Issue493Test.java
@@ -1,0 +1,94 @@
+package com.networknt.schema;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class Issue493Test
+{
+
+    private static JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909);
+    private static String schemaPath1 = "/schema/issue493.json";
+
+    private JsonNode getJsonNodeFromJsonData (String jsonFilePath)
+            throws Exception
+    {
+        InputStream content = getClass().getResourceAsStream(jsonFilePath);
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readTree(content);
+    }
+
+    @Test
+    @DisplayName("Test valid with required item only")
+    void testValidJson1 ()
+            throws Exception
+    {
+        InputStream schemaInputStream = Issue493Test.class.getResourceAsStream(schemaPath1);
+        JsonSchema schema = factory.getSchema(schemaInputStream);
+        JsonNode node = getJsonNodeFromJsonData("/data/issue493-valid-1.json");
+        Set<ValidationMessage> errors = schema.validate(node);
+        Assertions.assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Test valid with optional item")
+    void testValidJson2 ()
+            throws Exception
+    {
+        InputStream schemaInputStream = Issue493Test.class.getResourceAsStream(schemaPath1);
+        JsonSchema schema = factory.getSchema(schemaInputStream);
+        JsonNode node = getJsonNodeFromJsonData("/data/issue493-valid-2.json");
+        Set<ValidationMessage> errors = schema.validate(node);
+        Assertions.assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Test invalid with required item but wrong type")
+    void testInvalidJson1 ()
+            throws Exception
+    {
+        InputStream schemaInputStream = Issue491Test.class.getResourceAsStream(schemaPath1);
+        JsonSchema schema = factory.getSchema(schemaInputStream);
+        JsonNode node = getJsonNodeFromJsonData("/data/issue493-invalid-1.json");
+        Set<ValidationMessage> errors = schema.validate(node);
+        Assertions.assertEquals(2, errors.size());
+
+        Set<String> allErrorMessages = new HashSet<>();
+        errors.forEach(vm -> {
+            allErrorMessages.add(vm.getMessage());
+        });
+        assertThat(allErrorMessages,
+                   Matchers.containsInAnyOrder("$.parameters[0].value: string found, integer expected",
+                                               "$.parameters[0].value: does not match the regex pattern ^\\{\\{.+\\}\\}$"));
+    }
+
+    @Test
+    @DisplayName("Test invalid with optional item but wrong type")
+    void testInvalidJson2 ()
+            throws Exception
+    {
+        InputStream schemaInputStream = Issue491Test.class.getResourceAsStream(schemaPath1);
+        JsonSchema schema = factory.getSchema(schemaInputStream);
+        JsonNode node = getJsonNodeFromJsonData("/data/issue493-invalid-2.json");
+        Set<ValidationMessage> errors = schema.validate(node);
+        Assertions.assertEquals(2, errors.size());
+
+        Set<String> allErrorMessages = new HashSet<>();
+        errors.forEach(vm -> {
+            allErrorMessages.add(vm.getMessage());
+        });
+        assertThat(allErrorMessages,
+                   Matchers.containsInAnyOrder("$.parameters[1].value: string found, integer expected",
+                                               "$.parameters[1].value: does not match the regex pattern ^\\{\\{.+\\}\\}$"));
+    }
+}

--- a/src/test/resources/data/issue493-invalid-1.json
+++ b/src/test/resources/data/issue493-invalid-1.json
@@ -1,0 +1,8 @@
+{
+  "parameters": [
+    {
+      "name": "param-required",
+      "value": "wrongtype"
+    }
+  ]
+}

--- a/src/test/resources/data/issue493-invalid-2.json
+++ b/src/test/resources/data/issue493-invalid-2.json
@@ -1,0 +1,12 @@
+{
+  "parameters": [
+    {
+      "name": "param-required",
+      "value": 123
+    },
+    {
+      "name": "param-optional",
+      "value": "wrongtype"
+    }
+  ]
+}

--- a/src/test/resources/data/issue493-valid-1.json
+++ b/src/test/resources/data/issue493-valid-1.json
@@ -1,0 +1,12 @@
+{
+  "parameters": [
+    {
+      "name": "param-required",
+      "value": 123
+    },
+    {
+      "name": "param-optional",
+      "value": "{{test}}"
+    }
+  ]
+}

--- a/src/test/resources/data/issue493-valid-2.json
+++ b/src/test/resources/data/issue493-valid-2.json
@@ -1,0 +1,12 @@
+{
+  "parameters": [
+    {
+      "name": "param-required",
+      "value": 123
+    },
+    {
+      "name": "param-optional",
+      "value": "{{test}}"
+    }
+  ]
+}

--- a/src/test/resources/schema/issue493.json
+++ b/src/test/resources/schema/issue493.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "parameters": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": [
+        {
+          "type": "object",
+          "required": [
+            "name",
+            "value"
+          ],
+          "properties": {
+            "name": {
+              "const": "param-required"
+            },
+            "value": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/test-ref1"
+                },
+                {
+                  "$ref": "#/$defs/test-ref2"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "additionalItems": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
+            "properties": {
+              "name": {
+                "const": "param-optional"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/test-ref1"
+                  },
+                  {
+                    "$ref": "#/$defs/test-ref2"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "minItems": 1,
+      "maxItems": 2
+    }
+  },
+  "$defs": {
+    "test-ref1": {
+      "type": "string",
+      "pattern": "^\\{\\{.+\\}\\}$"
+    },
+    "test-ref2": {
+      "type": "integer"
+    }
+  }
+}


### PR DESCRIPTION
From Issue #493 , the root cause is that the 'parent schema' of an additionalItems was always be 'null'. So that when looking for the $ref, only those inside 'additionalItems' can be got successfully.

Please let me know if the code I change makes sense and doesn't cause any side effects.