### PR TITLE
Support fragment references using `$anchor`

### DIFF
--- a/src/main/java/com/networknt/schema/JsonMetaSchema.java
+++ b/src/main/java/com/networknt/schema/JsonMetaSchema.java
@@ -368,12 +368,24 @@ public class JsonMetaSchema {
         return idNode.textValue();
     }
 
-    public String getUri() {
-        return uri;
+    public JsonNode getNodeByFragmentRef(String ref, JsonNode node) {
+        boolean nodeContainsRef = ref.equals(readId(node));
+        if (nodeContainsRef) {
+            return node;
+        } else {
+            Iterator<JsonNode> children = node.elements();
+            while (children.hasNext()) {
+                JsonNode refNode = getNodeByFragmentRef(ref, children.next());
+                if (refNode != null) {
+                    return refNode;
+                }
+            }
+        }
+        return null;
     }
 
-    public String getIdKeyword() {
-        return idKeyword;
+    public String getUri() {
+        return uri;
     }
 
 

--- a/src/main/java/com/networknt/schema/JsonMetaSchema.java
+++ b/src/main/java/com/networknt/schema/JsonMetaSchema.java
@@ -361,15 +361,15 @@ public class JsonMetaSchema {
     }
 
     public String readId(JsonNode schemaNode) {
-        JsonNode idNode = schemaNode.get(idKeyword);
-        if (idNode == null || !idNode.isTextual()) {
-            return null;
-        }
-        return idNode.textValue();
+        return readText(schemaNode, idKeyword);
     }
 
     public JsonNode getNodeByFragmentRef(String ref, JsonNode node) {
-        boolean nodeContainsRef = ref.equals(readId(node));
+        boolean supportsAnchor = keywords.containsKey("$anchor");
+        String refName = supportsAnchor ? ref.substring(1) : ref;
+        String fieldToRead = supportsAnchor ? "$anchor" : idKeyword;
+
+        boolean nodeContainsRef = refName.equals(readText(node, fieldToRead));
         if (nodeContainsRef) {
             return node;
         } else {
@@ -382,6 +382,14 @@ public class JsonMetaSchema {
             }
         }
         return null;
+    }
+
+    private String readText(JsonNode node, String field) {
+        JsonNode idNode = node.get(field);
+        if (idNode == null || !idNode.isTextual()) {
+            return null;
+        }
+        return idNode.textValue();
     }
 
     public String getUri() {


### PR DESCRIPTION
As is, this PR already resolves the first test case in [`V201909JsonSchemaTest.testAnchorValidator()`](https://github.com/networknt/json-schema-validator/blob/master/src/test/java/com/networknt/schema/V201909JsonSchemaTest.java#L162), but not the latter two which include absolute URIs.

It causes `java.io.FileNotFoundException: http://localhost:1234/bar` due to `"$ref": "http://localhost:1234/bar#foo"` [pointing to a local `$id`](https://github.com/networknt/json-schema-validator/blob/master/src/test/resources/draft2019-09/anchor.json#L35).

I suspect this fails for the same reason some of the other V2019_09 currently fail, e.g. [`testRefValidator()`](https://github.com/networknt/json-schema-validator/blob/master/src/test/java/com/networknt/schema/V201909JsonSchemaTest.java#L309).

It seems like this PR may already resolve the original issue I ran into (the first test case). It's less obvious how to resolve these next two errors, and whether they are related at all. Could this PR be released, as is, already? Perhaps by splitting up the test cases?

Closes #227 