### PR TITLE
Make date-time validation align with RFC3339 (#508)

### DIFF
--- a/src/test/resources/draft2019-09/optional/format/date-time.json
+++ b/src/test/resources/draft2019-09/optional/format/date-time.json
@@ -49,6 +49,21 @@
         "description": "only RFC3339 not all of ISO 8601 are valid",
         "data": "2013-350T01:01:01",
         "valid": false
+      },
+      {
+        "description": "an invalid date-time string without offset",
+        "data": "1963-06-19T08:30:06",
+        "valid": false
+      },
+      {
+        "description": "an invalid date-time string with only hours in offset",
+        "data": "1963-06-19T08:30:06+02",
+        "valid": false
+      },
+      {
+        "description": "an invalid date-time string without colon in offset",
+        "data": "1963-06-19T08:30:06+0200",
+        "valid": false
       }
     ]
   }

--- a/src/test/resources/draft4/optional/format.json
+++ b/src/test/resources/draft4/optional/format.json
@@ -11,9 +11,9 @@
         "valid": true
       },
       {
-        "description": "a valid date-time string without colon",
+        "description": "an invalid date-time string without colon",
         "data": "2018-07-27T00:00:01.000-0300",
-        "valid": true
+        "valid": false
       },
       {
         "description": "a valid date-time string",
@@ -56,14 +56,14 @@
         "valid": true
       },
       {
-        "description": "an valid date-time string",
+        "description": "an invalid date-time string",
         "data": "1963-12-30T08:30:06.283",
-        "valid": true
+        "valid": false
       },
       {
-        "description": "an valid date-time string",
+        "description": "an invalid date-time string",
         "data": "1963-12-30T08:30:06",
-        "valid": true
+        "valid": false
       },
       {
         "description": "an valid date-time string",

--- a/src/test/resources/draft7/optional/format/date-time.json
+++ b/src/test/resources/draft7/optional/format/date-time.json
@@ -49,6 +49,21 @@
         "description": "only RFC3339 not all of ISO 8601 are valid",
         "data": "2013-350T01:01:01",
         "valid": false
+      },
+      {
+        "description": "an invalid date-time string without offset",
+        "data": "1963-06-19T08:30:06",
+        "valid": false
+      },
+      {
+        "description": "an invalid date-time string with only hours in offset",
+        "data": "1963-06-19T08:30:06+02",
+        "valid": false
+      },
+      {
+        "description": "an invalid date-time string without colon in offset",
+        "data": "1963-06-19T08:30:06+0200",
+        "valid": false
       }
     ]
   }


### PR DESCRIPTION
Fixes issue #508 by tightening up the validation regex.