### PR TITLE
Issue 526 reproduction

### DIFF
--- a/src/test/java/com/networknt/schema/Issue526Test.java
+++ b/src/test/java/com/networknt/schema/Issue526Test.java
@@ -1,0 +1,35 @@
+package com.networknt.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.Set;
+
+public class Issue526Test {
+    private static final JsonSchemaFactory FACTORY =
+            JsonSchemaFactory
+                    .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909))
+                    .build();
+
+    @Test
+    public void testBundledSchema()
+            throws Exception {
+        String schemaPath = "/schema/issue526.schema.json";
+        InputStream schemaInputStream = getClass().getResourceAsStream(schemaPath);
+        JsonSchema schema = FACTORY.getSchema(schemaInputStream);
+
+        JsonNode node = getJsonNodeFromJsonData("/data/issue526.example.json");
+        Set<ValidationMessage> errors = schema.validate(node);
+        Assertions.assertTrue(errors.isEmpty());
+    }
+
+    private JsonNode getJsonNodeFromJsonData(String jsonFilePath)
+            throws Exception {
+        InputStream content = getClass().getResourceAsStream(jsonFilePath);
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readTree(content);
+    }
+}

--- a/src/test/resources/data/issue526.example.json
+++ b/src/test/resources/data/issue526.example.json
@@ -1,0 +1,12 @@
+{
+  "phones": [
+    {
+      "number":  "6128675309"
+    }
+  ],
+  "email_addresses": [
+    {
+      "email_address":  "dave@example.com"
+    }
+  ]
+}

--- a/src/test/resources/schema/issue526.schema.json
+++ b/src/test/resources/schema/issue526.schema.json
@@ -1,0 +1,64 @@
+{
+  "$id": "https://schemas.example.com/example-service/commands/1.0.0/example.schema.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "example",
+  "type": "object",
+  "properties": {
+    "phones": {
+      "description": "The example phone numbers",
+      "type": "array",
+      "items": {
+        "$id": "https://schemas.example.com/example-service/objects/1.0.0/phone.schema.json",
+        "description": "try an absolute $ref path"
+      }
+    },
+    "email_addresses": {
+      "description": "The example email address",
+      "type": "array",
+      "items": {
+        "$ref": "../../objects/1.0.0/email-address.schema.json",
+        "description": "try a relative $ref path"
+      }
+    }
+  },
+  "required": [
+    "email_addresses",
+    "phones"
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "https://schemas.example.com/example-service/objects/1.0.0/phone.schema.json": {
+      "$id": "https://schemas.example.com/example-service/objects/1.0.0/phone.schema.json",
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "title": "Phone Object",
+      "type": "object",
+      "properties": {
+        "number": {
+          "description": "10 digit phone number",
+          "type": "string",
+          "pattern": "^[1-9]\\d{9}"
+        }
+      },
+      "required": [
+        "number"
+      ],
+      "additionalProperties": false
+    },
+    "https://schemas.example.com/example-service/objects/1.0.0/email-address.schema.json": {
+      "$id": "https://schemas.example.com/example-service/objects/1.0.0/email-address.schema.json",
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "title": "Email Address Object",
+      "type": "object",
+      "properties": {
+        "email_address": {
+          "description": "email address string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "email_address"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/test/resources/schema/issue526.schema.json
+++ b/src/test/resources/schema/issue526.schema.json
@@ -8,7 +8,7 @@
       "description": "The example phone numbers",
       "type": "array",
       "items": {
-        "$id": "https://schemas.example.com/example-service/objects/1.0.0/phone.schema.json",
+        "$ref": "https://schemas.example.com/example-service/objects/1.0.0/phone.schema.json",
         "description": "try an absolute $ref path"
       }
     },


### PR DESCRIPTION
This reproduces the issue described in #526.

I'd expect the example json document to validate against the bundled schema, but it fails with http errors trying to load example.com instead. 

> 15:06:40.995 [main] ERROR c.networknt.schema.JsonSchemaFactory - Failed to load json schema!
java.net.UnknownHostException: schemas.example.com
...