### PR TITLE
removed unnecessary check which causes nullable=true, handleNullableFields= true with value=null to fail in all cases except OneOf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.networknt</groupId>
     <artifactId>json-schema-validator</artifactId>
-    <version>1.0.68</version>
+    <version>1.0.68-SNAPSHOT1</version>
     <packaging>bundle</packaging>
     <description>A json schema validator that supports draft v4, v6, v7 and v2019-09</description>
     <url>https://github.com/networknt/json-schema-validator</url>

--- a/src/main/java/com/networknt/schema/utils/JsonNodeUtil.java
+++ b/src/main/java/com/networknt/schema/utils/JsonNodeUtil.java
@@ -85,7 +85,7 @@ public class JsonNodeUtil {
 
             ValidatorState state = (ValidatorState) CollectorContext.getInstance().get(ValidatorState.VALIDATOR_STATE_KEY);
             if(JsonType.NULL.equals(nodeType)) {
-                if(state.isComplexValidator() && parentSchema != null) {
+                if(parentSchema != null) {
                     if( parentSchema.getParentSchema() != null && JsonNodeUtil.isNodeNullable(parentSchema.getParentSchema().getSchemaNode(), config) || JsonNodeUtil.isNodeNullable(parentSchema.getSchemaNode()) ) {
                         return true;
                     }


### PR DESCRIPTION
when nullable = true , handlenullableFields = true and value supplied = null , then getting this failure message `"null found, string expected"` for this example:

```
 "schema": {
      "properties": {
        "values": {
          "type": "string",
          "nullable": true,
          "default": null
        }
      }
    }
```

Data to be created:

```
"data": {
          "values": null
        }
```

Reason appears this unnecessary check for `state.isComplexValidator()` which is true only in case of oneOf . so it suppresses all handleNullableFields configurations causing the above error message.

This is related to my latest query on this issue https://github.com/networknt/json-schema-validator/issues/183