### PR TITLE
proposal for issue #535, part 2: fix the same issue in AnyOfValidator, too

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.networknt</groupId>
     <artifactId>json-schema-validator</artifactId>
-    <version>1.0.69</version>
+    <version>1.0.70-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>A json schema validator that supports draft v4, v6, v7 and v2019-09</description>
     <url>https://github.com/networknt/json-schema-validator</url>


### PR DESCRIPTION
As stated in https://github.com/networknt/json-schema-validator/issues/535, the same issue with receiving superfluous validation messages of type "required" after at least one subschema has validated without error does also apply to AnyOfValidator.

Here's my proposed fix for this second part... 😄 

@RenegadeWizard and @stevehu : please validate - many thanks! 👍 