### PR TITLE
Prevent from throwing an exception when setting default values

### DIFF
--- a/src/main/java/com/networknt/schema/PropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/PropertiesValidator.java
@@ -17,6 +17,7 @@
 package com.networknt.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.networknt.schema.walk.DefaultPropertyWalkListenerRunner;
 import com.networknt.schema.walk.WalkListenerRunner;
@@ -114,7 +115,7 @@ public class PropertiesValidator extends BaseJsonValidator implements JsonValida
     @Override
     public Set<ValidationMessage> walk(JsonNode node, JsonNode rootNode, String at, boolean shouldValidateSchema) {
         HashSet<ValidationMessage> validationMessages = new LinkedHashSet<ValidationMessage>();
-        if (applyDefaultsStrategy.shouldApplyPropertyDefaults()) {
+        if (applyDefaultsStrategy.shouldApplyPropertyDefaults() && node.getNodeType() == JsonNodeType.OBJECT) {
             applyPropertyDefaults((ObjectNode) node);
         }
         if (shouldValidateSchema) {

--- a/src/test/java/com/networknt/schema/PropertiesValidatorTest.java
+++ b/src/test/java/com/networknt/schema/PropertiesValidatorTest.java
@@ -1,0 +1,30 @@
+package com.networknt.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Created by josejulio on 25/04/22.
+ */
+public class PropertiesValidatorTest extends BaseJsonSchemaValidatorTest {
+
+    @Test
+    public void testDoesNotThrowWhenApplyingDefaultPropertiesToNonObjects() throws Exception {
+        Assertions.assertDoesNotThrow(() -> {
+            JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4);
+
+            SchemaValidatorsConfig schemaValidatorsConfig = new SchemaValidatorsConfig();
+            schemaValidatorsConfig.setApplyDefaultsStrategy(new ApplyDefaultsStrategy(
+                    true,
+                    true,
+                    true
+            ));
+
+            JsonSchema schema = factory.getSchema("{\"type\":\"object\",\"properties\":{\"foo\":{\"type\":\"object\", \"properties\": {} },\"i-have-default\":{\"type\":\"string\",\"default\":\"foo\"}}}", schemaValidatorsConfig);
+            JsonNode node = getJsonNodeFromStringContent("{\"foo\": \"bar\"}");
+            ValidationResult result = schema.walk(node, true);
+            Assertions.assertEquals(result.getValidationMessages().size(), 1);
+        });
+    }
+}


### PR DESCRIPTION
 - this happens when an expected object has a different type
   i.e. a string.
 - This is prevented by checking the type of the node before
   attemping to set the defaults
