### PR TITLE
Improve performance of URLFactory.create()

### DIFF
--- a/src/main/java/com/networknt/schema/uri/URLFactory.java
+++ b/src/main/java/com/networknt/schema/uri/URLFactory.java
@@ -40,10 +40,8 @@ public final class URLFactory implements URIFactory {
     @Override
     public URI create(final String uri) {
         try {
-            return new URL(uri).toURI();
-        } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("Unable to create URI.", e);
-        } catch (URISyntaxException e) {
+            return URI.create(uri);
+        } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Unable to create URI.", e);
         }
     }


### PR DESCRIPTION
Hi,

this PR improves the performance of `URLFactory.create()`. An isolated microbenchmark shows the following results.
```
Benchmark                      Mode  Cnt     Score     Error  Units
MyBenchmark.testURINew         avgt   10   717,888 ± 107,067  ns/op
MyBenchmark.testURIOld         avgt   10  1139,942 ±  13,933  ns/op
```
Cheers,
Christoph