### PR TITLE
Fix broken tests on non-english setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <configuration>
+                    <argLine>-Duser.language=en -Duser.region=GB</argLine>
+                </configuration>
             </plugin>
             <!-- JACOCO added for code coverage -->
             <plugin>


### PR DESCRIPTION
Hi,

due to the provided German localization in this lib, tests fail for maintainers with German setups.

This PR sets `-Duser.language=en -Duser.region=GB` when running tests via surefire and makes contributing a bit more convenient.

Cheers,
Christoph