### PR TITLE
Upgrade javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Old version Javadoc need the JAVA_HOME environment variable, but 3.4.0 don't need it anymore.