### PR TITLE
Remove commons lang as a compile time dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,10 +84,18 @@
             <artifactId>slf4j-api</artifactId>
             <version>${version.slf4j}</version>
         </dependency>
+        <!-- 
+        Commons lang slated for removal but kept for projects that accidentally depend on it
+        through accidental transitive runtime dependencies.
+        
+        For projects that depend on it for compile they will get an immediate failure as the
+        scope is now runtime instead of compile.
+        -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${version.common-lang3}</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.jruby.joni</groupId>

--- a/src/main/java/com/networknt/schema/BaseJsonValidator.java
+++ b/src/main/java/com/networknt/schema/BaseJsonValidator.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.networknt.schema.ValidationContext.DiscriminatorContext;
-import org.apache.commons.lang3.StringUtils;
+import com.networknt.schema.utils.StringUtils;
 import org.slf4j.Logger;
 
 public abstract class BaseJsonValidator implements JsonValidator {

--- a/src/main/java/com/networknt/schema/JsonMetaSchema.java
+++ b/src/main/java/com/networknt/schema/JsonMetaSchema.java
@@ -17,7 +17,7 @@
 package com.networknt.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.commons.lang3.StringUtils;
+import com.networknt.schema.utils.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/networknt/schema/ValidationMessage.java
+++ b/src/main/java/com/networknt/schema/ValidationMessage.java
@@ -16,7 +16,7 @@
 
 package com.networknt.schema;
 
-import org.apache.commons.lang3.StringUtils;
+import com.networknt.schema.utils.StringUtils;
 
 import java.text.MessageFormat;
 import java.util.Arrays;

--- a/src/main/java/com/networknt/schema/utils/StringUtils.java
+++ b/src/main/java/com/networknt/schema/utils/StringUtils.java
@@ -1,0 +1,53 @@
+package com.networknt.schema.utils;
+
+public final class StringUtils {
+
+    private StringUtils() {
+    }
+
+    public static boolean isBlank(final CharSequence cs) {
+        int strLen = length(cs);
+        if (strLen == 0) {
+            return true;
+        }
+        for (int i = 0; i < strLen; i++) {
+            if (!Character.isWhitespace(cs.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean isNotBlank(final CharSequence cs) {
+        return !isBlank(cs);
+    }
+
+    private static int length(final CharSequence cs) {
+        return cs == null ? 0 : cs.length();
+    }
+
+    // The following was borrowed from Apache Commons Lang 3
+    public static boolean equals(final CharSequence cs1, final CharSequence cs2) {
+        if (cs1 == cs2) {
+            return true;
+        }
+        if (cs1 == null || cs2 == null) {
+            return false;
+        }
+        if (cs1.length() != cs2.length()) {
+            return false;
+        }
+        if (cs1 instanceof String && cs2 instanceof String) {
+            return cs1.equals(cs2);
+        }
+        // Step-wise comparison
+        final int length = cs1.length();
+        for (int i = 0; i < length; i++) {
+            if (cs1.charAt(i) != cs2.charAt(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/src/test/java/com/networknt/schema/BaseSuiteJsonSchemaTest.java
+++ b/src/test/java/com/networknt/schema/BaseSuiteJsonSchemaTest.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.undertow.Undertow;
 import io.undertow.server.handlers.resource.FileResourceManager;
-import org.apache.commons.lang3.StringUtils;
+import com.networknt.schema.utils.StringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 


### PR DESCRIPTION
This pull request remove the commons lang dependency such that it maybe excluded in maven or gradle.

There is very little usage of Commons Lang 3 in this library and most of the usage is builtin future JDK versions (e.g. `String.isBlank` is in JDK 11).

I have left the dependency in Maven for projects that accidentally depend on this project to pull Commons Lang in as a transitive dependency.

We need this for our code base as we do not allow commons lang 3 in most of our projects.
