### PR TITLE
issue_563 Support adding custom message and custom validator

### DIFF
--- a/src/main/java/com/networknt/schema/JsonMetaSchema.java
+++ b/src/main/java/com/networknt/schema/JsonMetaSchema.java
@@ -104,7 +104,7 @@ public class JsonMetaSchema {
         }
 
         private static Map<String, Keyword> createKeywordsMap(Map<String, Keyword> kwords, Map<String, Format> formats) {
-            final Map<String, Keyword> map = new HashMap<String, Keyword>();
+            Map<String, Keyword> map = new HashMap<String, Keyword>();
             for (Map.Entry<String, Keyword> type : kwords.entrySet()) {
                 String keywordName = type.getKey();
                 Keyword keyword = type.getValue();
@@ -119,7 +119,7 @@ public class JsonMetaSchema {
             }
             final FormatKeyword formatKeyword = new FormatKeyword(ValidatorTypeCode.FORMAT, formats);
             map.put(formatKeyword.getValue(), formatKeyword);
-            return Collections.unmodifiableMap(map);
+            return map;
         }
 
         public Builder addKeyword(Keyword keyword) {
@@ -154,14 +154,14 @@ public class JsonMetaSchema {
 
         public JsonMetaSchema build() {
             // create builtin keywords with (custom) formats.
-            final Map<String, Keyword> kwords = createKeywordsMap(keywords, formats);
+            Map<String, Keyword> kwords = createKeywordsMap(keywords, formats);
             return new JsonMetaSchema(uri, idKeyword, kwords);
         }
     }
 
     private final String uri;
     private final String idKeyword;
-    private final Map<String, Keyword> keywords;
+    private Map<String, Keyword> keywords;
 
     private JsonMetaSchema(String uri, String idKeyword, Map<String, Keyword> keywords) {
         if (StringUtils.isBlank(uri)) {
@@ -267,6 +267,9 @@ public class JsonMetaSchema {
         return uri;
     }
 
+    public Map<String, Keyword> getKeywords() {
+        return keywords;
+    }
 
     public JsonValidator newValidator(ValidationContext validationContext, String schemaPath, String keyword /* keyword */, JsonNode schemaNode,
                                       JsonSchema parentSchema, String customMessage) {

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -238,19 +238,23 @@ public class JsonSchema extends BaseJsonValidator {
 
     private String getCustomMessage(JsonNode schemaNode, String pname) {
         final JsonSchema parentSchema = getParentSchema();
-        final JsonNode message = getMessageNode(schemaNode, parentSchema);
+        final JsonNode message = getMessageNode(schemaNode, parentSchema, pname);
         if (message != null && message.get(pname) != null) {
             return message.get(pname).asText();
         }
         return null;
     }
 
-    private JsonNode getMessageNode(JsonNode schemaNode, JsonSchema parentSchema) {
+    private JsonNode getMessageNode(JsonNode schemaNode, JsonSchema parentSchema, String pname) {
+        if (schemaNode.get("message") != null && schemaNode.get("message").get(pname) != null) {
+            return schemaNode.get("message");
+        }
         JsonNode nodeContainingMessage;
-        if (parentSchema == null)
+        if (parentSchema == null) {
             nodeContainingMessage = schemaNode;
-        else
+        } else {
             nodeContainingMessage = parentSchema.schemaNode;
+        }
         return nodeContainingMessage.get("message");
     }
 

--- a/src/main/java/com/networknt/schema/JsonSchemaFactory.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaFactory.java
@@ -223,7 +223,7 @@ public class JsonSchemaFactory {
      *
      * @return a builder instance without any keywords or formats - usually not what one needs.
      */
-    static Builder builder() {
+    public static Builder builder() {
         return new Builder();
     }
 

--- a/src/main/java/com/networknt/schema/JsonSchemaVersion.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaVersion.java
@@ -3,7 +3,7 @@ package com.networknt.schema;
 import java.util.ArrayList;
 import java.util.List;
 
-abstract class JsonSchemaVersion {
+public abstract class JsonSchemaVersion {
     protected static String URI;
     protected static String ID;
     public static final List<Format> BUILTIN_FORMATS = new ArrayList<Format>(JsonMetaSchema.COMMON_BUILTIN_FORMATS);
@@ -11,5 +11,5 @@ abstract class JsonSchemaVersion {
         // add version specific formats here.
         //BUILTIN_FORMATS.add(pattern("phone", "^\\+(?:[0-9] ?){6,14}[0-9]$"));
     }
-    abstract JsonMetaSchema getInstance();
+    public abstract JsonMetaSchema getInstance();
 }

--- a/src/main/java/com/networknt/schema/Version201909.java
+++ b/src/main/java/com/networknt/schema/Version201909.java
@@ -11,7 +11,7 @@ public class Version201909 extends JsonSchemaVersion{
         //BUILTIN_FORMATS.add(pattern("phone", "^\\+(?:[0-9] ?){6,14}[0-9]$"));
     }
     @Override
-    JsonMetaSchema getInstance() {
+    public JsonMetaSchema getInstance() {
         return new JsonMetaSchema.Builder(URI)
                 .idKeyword(ID)
                 .addFormats(BUILTIN_FORMATS)

--- a/src/main/java/com/networknt/schema/Version202012.java
+++ b/src/main/java/com/networknt/schema/Version202012.java
@@ -12,7 +12,7 @@ public class Version202012 extends JsonSchemaVersion {
     }
 
     @Override
-    JsonMetaSchema getInstance() {
+    public JsonMetaSchema getInstance() {
         return new JsonMetaSchema.Builder(URI)
                 .idKeyword(ID)
                 .addFormats(BUILTIN_FORMATS)

--- a/src/main/java/com/networknt/schema/Version4.java
+++ b/src/main/java/com/networknt/schema/Version4.java
@@ -11,7 +11,7 @@ public class Version4 extends JsonSchemaVersion{
         //BUILTIN_FORMATS.add(pattern("phone", "^\\+(?:[0-9] ?){6,14}[0-9]$"));
     }
 
-    JsonMetaSchema getInstance() {
+    public JsonMetaSchema getInstance() {
         return new JsonMetaSchema.Builder(URI)
                 .idKeyword(ID)
                 .addFormats(BUILTIN_FORMATS)

--- a/src/main/java/com/networknt/schema/Version6.java
+++ b/src/main/java/com/networknt/schema/Version6.java
@@ -12,7 +12,7 @@ public class Version6 extends JsonSchemaVersion{
         //BUILTIN_FORMATS.add(pattern("phone", "^\\+(?:[0-9] ?){6,14}[0-9]$"));
     }
 
-    JsonMetaSchema getInstance() {
+    public JsonMetaSchema getInstance() {
         return new JsonMetaSchema.Builder(URI)
                 .idKeyword(ID)
                 .addFormats(BUILTIN_FORMATS)

--- a/src/main/java/com/networknt/schema/Version7.java
+++ b/src/main/java/com/networknt/schema/Version7.java
@@ -11,7 +11,7 @@ public class Version7 extends JsonSchemaVersion{
         //BUILTIN_FORMATS.add(pattern("phone", "^\\+(?:[0-9] ?){6,14}[0-9]$"));
     }
     @Override
-    JsonMetaSchema getInstance() {
+    public JsonMetaSchema getInstance() {
         return new JsonMetaSchema.Builder(URI)
                 .idKeyword(ID)
                 .addFormats(BUILTIN_FORMATS)


### PR DESCRIPTION
Support adding a custom message at attribute level and custom validator for all schema versions. The documented info for the  [custom validator](https://github.com/networknt/json-schema-validator/blob/master/doc/validators.md ), only supports one version, but actually, we may use different schemes by different members. So we can provide the JsonMetaSchema#getKeywords.
In this way, we can easy to add additional custom validators. For example: 
`JsonSchemaVersion jsonSchemaVersion = JsonSchemaFactory.checkVersion(versionFlag);
        JsonMetaSchema metaSchema = jsonSchemaVersion.getInstance();
        metaSchema.getKeywords().put(DATE_PATTERN, new DatePatternKeyWord(DATE_PATTERN));
        return JsonSchemaFactory.builder()
            .defaultMetaSchemaURI(metaSchema.getUri())
            .addMetaSchema(metaSchema)
            .build();`