### PR TITLE
Correcting the oneOf,anyOf and allOf child schema validators to use the full path

### DIFF
--- a/src/main/java/com/networknt/schema/AllOfValidator.java
+++ b/src/main/java/com/networknt/schema/AllOfValidator.java
@@ -34,7 +34,7 @@ public class AllOfValidator extends BaseJsonValidator implements JsonValidator {
         int size = schemaNode.size();
         for (int i = 0; i < size; i++) {
             schemas.add(new JsonSchema(validationContext,
-                                       getValidatorType().getValue(),
+                            parentSchema.getSchemaPath() + "/" + getValidatorType().getValue(),
                                        parentSchema.getCurrentUri(),
                                        schemaNode.get(i),
                                        parentSchema));

--- a/src/main/java/com/networknt/schema/AnyOfValidator.java
+++ b/src/main/java/com/networknt/schema/AnyOfValidator.java
@@ -37,7 +37,7 @@ public class AnyOfValidator extends BaseJsonValidator implements JsonValidator {
         int size = schemaNode.size();
         for (int i = 0; i < size; i++) {
             schemas.add(new JsonSchema(validationContext,
-                    getValidatorType().getValue(),
+                    parentSchema.getSchemaPath() + "/" + getValidatorType().getValue(),
                     parentSchema.getCurrentUri(),
                     schemaNode.get(i),
                     parentSchema));

--- a/src/main/java/com/networknt/schema/BaseJsonValidator.java
+++ b/src/main/java/com/networknt/schema/BaseJsonValidator.java
@@ -182,7 +182,7 @@ public abstract class BaseJsonValidator implements JsonValidator {
     }
 
     protected boolean isPartOfOneOfMultipleType() {
-        return parentSchema.schemaPath.equals(ValidatorTypeCode.ONE_OF.getValue());
+        return parentSchema.schemaPath.endsWith(ValidatorTypeCode.ONE_OF.getValue());
     }
 
     /* ********************** START OF OpenAPI 3.0.x DISCRIMINATOR METHODS ********************************* */

--- a/src/main/java/com/networknt/schema/OneOfValidator.java
+++ b/src/main/java/com/networknt/schema/OneOfValidator.java
@@ -119,7 +119,7 @@ public class OneOfValidator extends BaseJsonValidator implements JsonValidator {
         int size = schemaNode.size();
         for (int i = 0; i < size; i++) {
             JsonNode childNode = schemaNode.get(i);
-            JsonSchema childSchema = new JsonSchema(validationContext, getValidatorType().getValue(), parentSchema.getCurrentUri(), childNode, parentSchema);
+            JsonSchema childSchema = new JsonSchema(validationContext,  parentSchema.getSchemaPath() + "/" + getValidatorType().getValue(), parentSchema.getCurrentUri(), childNode, parentSchema);
             schemas.add(new ShortcutValidator(childNode, parentSchema, validationContext, childSchema));
         }
         parseErrorCode(getValidatorType().getErrorCodeKey());


### PR DESCRIPTION
Hi @stevehu can you please have a look at this PR, I wasn't sure why we suppressed the schema path's of child schema under oneOf, anyOf, and allOf to use just the name of the respective keyword and ignore the parent path where these keywords exist. We have use cases where we update the schemas dynamically based on the complete schema path to a node. 

I have corrected these classes, can you please have a look and let us know your opinion?

If you feel the PR looks good can you please merge it to the master and release a new version?

Thank you