### PR TITLE
schema path fixes in oneOf,allOf and anyOf validators

### DIFF
--- a/src/main/java/com/networknt/schema/AllOfValidator.java
+++ b/src/main/java/com/networknt/schema/AllOfValidator.java
@@ -34,7 +34,7 @@ public class AllOfValidator extends BaseJsonValidator implements JsonValidator {
         int size = schemaNode.size();
         for (int i = 0; i < size; i++) {
             schemas.add(new JsonSchema(validationContext,
-                            parentSchema.getSchemaPath() + "/" + getValidatorType().getValue(),
+                            parentSchema.getSchemaPath() + "/" + getValidatorType().getValue() + "/" + i,
                                        parentSchema.getCurrentUri(),
                                        schemaNode.get(i),
                                        parentSchema));

--- a/src/main/java/com/networknt/schema/AnyOfValidator.java
+++ b/src/main/java/com/networknt/schema/AnyOfValidator.java
@@ -37,7 +37,7 @@ public class AnyOfValidator extends BaseJsonValidator implements JsonValidator {
         int size = schemaNode.size();
         for (int i = 0; i < size; i++) {
             schemas.add(new JsonSchema(validationContext,
-                    parentSchema.getSchemaPath() + "/" + getValidatorType().getValue(),
+                    parentSchema.getSchemaPath() + "/" + getValidatorType().getValue() + "/" + i,
                     parentSchema.getCurrentUri(),
                     schemaNode.get(i),
                     parentSchema));

--- a/src/main/java/com/networknt/schema/BaseJsonValidator.java
+++ b/src/main/java/com/networknt/schema/BaseJsonValidator.java
@@ -182,7 +182,7 @@ public abstract class BaseJsonValidator implements JsonValidator {
     }
 
     protected boolean isPartOfOneOfMultipleType() {
-        return parentSchema.schemaPath.endsWith(ValidatorTypeCode.ONE_OF.getValue());
+        return parentSchema.schemaPath.contains("/" + ValidatorTypeCode.ONE_OF.getValue() + "/");
     }
 
     /* ********************** START OF OpenAPI 3.0.x DISCRIMINATOR METHODS ********************************* */

--- a/src/main/java/com/networknt/schema/OneOfValidator.java
+++ b/src/main/java/com/networknt/schema/OneOfValidator.java
@@ -119,7 +119,7 @@ public class OneOfValidator extends BaseJsonValidator implements JsonValidator {
         int size = schemaNode.size();
         for (int i = 0; i < size; i++) {
             JsonNode childNode = schemaNode.get(i);
-            JsonSchema childSchema = new JsonSchema(validationContext,  parentSchema.getSchemaPath() + "/" + getValidatorType().getValue(), parentSchema.getCurrentUri(), childNode, parentSchema);
+            JsonSchema childSchema = new JsonSchema(validationContext,  parentSchema.getSchemaPath() + "/" + getValidatorType().getValue() + "/" + i, parentSchema.getCurrentUri(), childNode, parentSchema);
             schemas.add(new ShortcutValidator(childNode, parentSchema, validationContext, childSchema));
         }
         parseErrorCode(getValidatorType().getErrorCodeKey());


### PR DESCRIPTION
@stevehu this is in continuation to PR #626. It is correcting the JSON path to include the exact child node index. Can you please review, approve and merge the changes.