### PR TITLE
Quick fix for wrong custom message bug

### DIFF
--- a/src/main/java/com/networknt/schema/BaseJsonValidator.java
+++ b/src/main/java/com/networknt/schema/BaseJsonValidator.java
@@ -39,6 +39,7 @@ public abstract class BaseJsonValidator implements JsonValidator {
     protected ValidationContext validationContext;
     protected final boolean failFast;
     protected final ApplyDefaultsStrategy applyDefaultsStrategy;
+    private final String customMessage;
 
     public BaseJsonValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema,
                              ValidatorTypeCode validatorType, ValidationContext validationContext) {
@@ -69,6 +70,11 @@ public abstract class BaseJsonValidator implements JsonValidator {
         this.suppressSubSchemaRetrieval = suppressSubSchemaRetrieval;
         this.failFast = failFast;
         this.applyDefaultsStrategy = applyDefaultsStrategy != null ? applyDefaultsStrategy : ApplyDefaultsStrategy.EMPTY_APPLY_DEFAULTS_STRATEGY;
+        if (validatorType != null) {
+            this.customMessage = validatorType.getCustomMessage();
+        } else {
+            this.customMessage = null;
+        }
     }
 
     public String getSchemaPath() {
@@ -137,7 +143,7 @@ public abstract class BaseJsonValidator implements JsonValidator {
     }
 
     protected ValidationMessage buildValidationMessage(String at, String... arguments) {
-        final ValidationMessage message = ValidationMessage.of(getValidatorType().getValue(), errorMessageType, at, schemaPath, arguments);
+        final ValidationMessage message = ValidationMessage.ofWithCustom(getValidatorType().getValue(), errorMessageType, customMessage, at, schemaPath, arguments);
         if (failFast && !isPartOfOneOfMultipleType()) {
             throw new JsonSchemaException(message);
         }

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -282,13 +282,15 @@ public class JsonSchema extends BaseJsonValidator {
         if (schemaNode.get("message") != null && schemaNode.get("message").get(pname) != null) {
             return schemaNode.get("message");
         }
-        JsonNode nodeContainingMessage;
-        if (parentSchema == null) {
-            nodeContainingMessage = schemaNode;
-        } else {
-            nodeContainingMessage = parentSchema.schemaNode;
+        JsonNode messageNode;
+        messageNode = schemaNode.get("message");
+        if (messageNode == null && parentSchema != null) {
+            messageNode = parentSchema.schemaNode.get("message");
+            if (messageNode == null) {
+                return getMessageNode(parentSchema.schemaNode, parentSchema.getParentSchema(), pname);
+            }
         }
-        return nodeContainingMessage.get("message");
+        return messageNode;
     }
 
     /************************ START OF VALIDATE METHODS **********************************/

--- a/src/main/java/com/networknt/schema/ValidationMessage.java
+++ b/src/main/java/com/networknt/schema/ValidationMessage.java
@@ -130,12 +130,16 @@ public class ValidationMessage {
         this.type = type;
     }
 
-    public static ValidationMessage of(String type, ErrorMessageType errorMessageType, String at, String schemaPath, String... arguments) {
+    public static ValidationMessage ofWithCustom(String type, ErrorMessageType errorMessageType, String customMessage, String at, String schemaPath, String... arguments) {
         ValidationMessage.Builder builder = new ValidationMessage.Builder();
         builder.code(errorMessageType.getErrorCode()).path(at).schemaPath(schemaPath).arguments(arguments)
                 .format(errorMessageType.getMessageFormat()).type(type)
-                .customMessage(errorMessageType.getCustomMessage());
+                .customMessage(customMessage);
         return builder.build();
+    }
+
+    public static ValidationMessage of(String type, ErrorMessageType errorMessageType, String at, String schemaPath, String... arguments) {
+        return ofWithCustom(type, errorMessageType, errorMessageType.getCustomMessage(), at, schemaPath, arguments);
     }
 
     public static ValidationMessage of(String type, ErrorMessageType errorMessageType, String at, String schemaPath, Map<String, Object> details) {

--- a/src/test/java/com/networknt/schema/OverwritingCustomMessageBugTest.java
+++ b/src/test/java/com/networknt/schema/OverwritingCustomMessageBugTest.java
@@ -1,0 +1,52 @@
+package com.networknt.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.SpecVersion.VersionFlag;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class OverwritingCustomMessageBugTest {
+  private JsonSchema getJsonSchemaFromStreamContentV7(InputStream schemaContent) {
+    JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V7);
+    return factory.getSchema(schemaContent);
+  }
+
+  private JsonNode getJsonNodeFromStreamContent(InputStream content) throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    return mapper.readTree(content);
+  }
+
+  @Test
+  public void customMessageIsNotOverwritten() throws Exception {
+    Set<ValidationMessage> errors = validate();
+    Map<String, String> errorMsgMap = transferErrorMsg(errors);
+    Assertions.assertTrue(errorMsgMap.containsKey("$.toplevel[1].foos"), "error message must contains key: $.foos");
+    Assertions.assertTrue(errorMsgMap.containsKey("$.toplevel[1].bars"), "error message must contains key: $.bars");
+    Assertions.assertEquals("{0}: Must be a string with the a shape foofoofoofoo... with at least one foo", errorMsgMap.get("$.toplevel[1].foos"));
+    Assertions.assertEquals("{0}: Must be a string with the a shape barbarbar... with at least one bar", errorMsgMap.get("$.toplevel[1].bars"));
+  }
+
+
+  private Set<ValidationMessage> validate() throws Exception {
+    String schemaPath = "/schema/OverwritingCustomMessageBug.json";
+    String dataPath = "/data/OverwritingCustomMessageBug.json";
+    InputStream schemaInputStream = OverwritingCustomMessageBugTest.class.getResourceAsStream(schemaPath);
+    JsonSchema schema = getJsonSchemaFromStreamContentV7(schemaInputStream);
+    InputStream dataInputStream = OverwritingCustomMessageBugTest.class.getResourceAsStream(dataPath);
+    JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
+    return schema.validate(node);
+  }
+
+  private Map<String, String> transferErrorMsg(Set<ValidationMessage> validationMessages) {
+    Map<String, String> pathToMessage = new HashMap<>();
+    validationMessages.forEach(msg -> {
+      pathToMessage.put(msg.getPath(), msg.getMessage());
+    });
+    return pathToMessage;
+  }
+}

--- a/src/test/resources/data/OverwritingCustomMessageBug.json
+++ b/src/test/resources/data/OverwritingCustomMessageBug.json
@@ -1,0 +1,19 @@
+{
+  "toplevel": [
+    {
+      "foos": "foo",
+      "Nope": "a",
+      "bars": "bar"
+    },
+    {
+      "foos": "fee",
+      "Nope": "b",
+      "bars": "baz"
+    },
+    {
+      "foos": "foo",
+      "Nope": "c",
+      "bars": "bar"
+    }
+  ]
+}

--- a/src/test/resources/schema/OverwritingCustomMessageBug.json
+++ b/src/test/resources/schema/OverwritingCustomMessageBug.json
@@ -1,0 +1,31 @@
+{
+  "type": "object",
+  "properties": {
+    "toplevel": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "foos": {
+            "type": "string",
+            "pattern": "(foo)+",
+            "message": {
+              "pattern": "{0}: Must be a string with the a shape foofoofoofoo... with at least one foo"
+            }
+          },
+          "Nope": {
+            "type": "string"
+          },
+          "bars": {
+            "type": "string",
+            "pattern": "(bar)+",
+            "message": {
+              "pattern": "{0}: Must be a string with the a shape barbarbar... with at least one bar"
+            }
+          }
+        }
+      },
+      "minItems": 1
+    }
+  }
+}


### PR DESCRIPTION
The essence of the problem seems to be that keywords are unique and can only have one custom message. When there are multiple custom messages assigned to the same keyword in a schema the mutation of the custom message can result in the incorrect error messages to be output. 

This bug goes back to, at least, version 1.0.64.