### PR TITLE
Add ability to detect spec version optionally

### DIFF
--- a/src/test/java/com/networknt/schema/SpecVersionDetectorTest.java
+++ b/src/test/java/com/networknt/schema/SpecVersionDetectorTest.java
@@ -2,11 +2,13 @@ package com.networknt.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -41,5 +43,14 @@ class SpecVersionDetectorTest {
         JsonNode node = mapper.readTree(in);
         JsonSchemaException exception = assertThrows(JsonSchemaException.class, () -> SpecVersionDetector.detect(node));
         assertEquals(expectedError, exception.getMessage());
+    }
+
+    @Test
+    void detectOptionalSpecVersion() throws IOException {
+        InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(
+                "data/schemaTagMissing.json");
+        JsonNode node = mapper.readTree(in);
+        Optional<SpecVersion.VersionFlag> flag = SpecVersionDetector.detectOptionalVersion(node);
+        assertEquals(Optional.empty(), flag);
     }
 }


### PR DESCRIPTION
There could be cases when schemas are managed by third-parties, in this case client side logic can either use spec version defined in schema if available or some default one. Having current implementation of `SpecVersionDetector` it's not really convenient to catch exception to fallback to some default value then. Also exceptions are quite heavy mechanism, thus new method is proposed which returns an empty `Optional` value, if the schema tag is not present.

Also small refactoring of `SpecVersionDetector` class is done in order to make it true-utility class:
 - class is marked as `final`
 - private constructor is added