### PR TITLE
Clarify usage of Apache commons lang in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,12 @@ Here are the dependencies.
     <artifactId>slf4j-api</artifactId>
     <version>${version.slf4j}</version>
 </dependency>
-
-<dependency>
-    <groupId>org.apache.commons</groupId>
-    <artifactId>commons-lang3</artifactId>
-    <version>${version.common-lang3}</version>
-</dependency>
 ```
+
+Note: Apache commons lang is included as a compile time dependency but is not
+required anymore. It is still included for the sake of older projects that
+depend on it as an accidental transitive runtime dependency. It is encouraged to
+exclude it as shown below and will be removed in a future release.
 
 #### Community
 
@@ -83,6 +82,12 @@ Maven:
     <groupId>com.networknt</groupId>
     <artifactId>json-schema-validator</artifactId>
     <version>1.0.77</version>
+    <exclusions>
+        <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </exclusion>
+    </exclusions>
 </dependency>
 ```
 


### PR DESCRIPTION
Much like in https://github.com/networknt/json-schema-validator/pull/594 apache commons is banned in a code base I work in. I assumed this library was not suitable for use based on the README but after searching the issues I found the aforementioned pull request. 

Personally I believe it  should be fine to just remove it from `pom.xml` and update the README.md accordingly; as it has been several months since that change was merged, but acknowledge it may break _some_ users functionality if they are not careful about accidental transitive dependency use.