### PR TITLE
 [CI] Bump used latest non-LTS Java: `19` -> `20`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 17, 19 ]
+        java: [ 8, 11, 17, 20 ]
     name: Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Java 19 is reached EOL.