### PR TITLE
#687 Support for (valid) JSONPath and JSONPointer expressions as message paths

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -63,3 +63,10 @@ When set to true, can interpret round doubles as integers.
 Note that setting `javaSemantics = true` will achieve the same functionality at this time.
 
 For more details, please refer to this [issue](https://github.com/networknt/json-schema-validator/issues/344).
+
+* pathType
+
+This defines how path expressions are defined and returned once validation is performed through `ValidationMessage` instances. This can either be set to `PathType.JSON_POINTER` for [JSONPointer](https://www.rfc-editor.org/rfc/rfc6901.html) expressions,
+or to `PathType.JSON_PATH` for [JSONPath](https://datatracker.ietf.org/doc/draft-ietf-jsonpath-base/) expressions. Doing so allows you to report the path for each finding and to potentially lookup nodes
+(see [here](https://github.com/networknt/json-schema-validator/blob/c41df270a71f8423c63cfaa379d2e9b3f570b73e/doc/yaml-line-numbers.md#scenario-2---validationmessage-line-locations) for an example). By default, path expressions use a
+`PathType.LEGACY` format which is close to JSONPath but does not escape reserved characters.

--- a/src/main/java/com/networknt/schema/AbstractJsonValidator.java
+++ b/src/main/java/com/networknt/schema/AbstractJsonValidator.java
@@ -19,40 +19,14 @@ package com.networknt.schema;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
 
 public abstract class AbstractJsonValidator implements JsonValidator {
-    private final String keyword;
-
-    protected AbstractJsonValidator(String keyword) {
-        this.keyword = keyword;
-    }
 
     public Set<ValidationMessage> validate(JsonNode node) {
-        return validate(node, node, AT_ROOT);
+        return validate(node, node, PathType.LEGACY.getRoot());
     }
 
-    protected ValidationMessage buildValidationMessage(ErrorMessageType errorMessageType, String at, String... arguments) {
-        return ValidationMessage.of(keyword, errorMessageType, at, null, arguments);
-    }
-
-    protected ValidationMessage buildValidationMessage(ErrorMessageType errorMessageType, String at, Map<String, Object> details) {
-        return ValidationMessage.of(keyword, errorMessageType, at, null, details);
-    }
-
-    protected Set<ValidationMessage> pass() {
-        return Collections.emptySet();
-    }
-
-    protected Set<ValidationMessage> fail(ErrorMessageType errorMessageType, String at, Map<String, Object> details) {
-        return Collections.singleton(buildValidationMessage(errorMessageType, at, details));
-    }
-
-    protected Set<ValidationMessage> fail(ErrorMessageType errorMessageType, String at, String... arguments) {
-        return Collections.singleton(buildValidationMessage(errorMessageType, at, arguments));
-    }
-    
     @Override
 	public Set<ValidationMessage> walk(JsonNode node, JsonNode rootNode, String at, boolean shouldValidateSchema) {
 		Set<ValidationMessage> validationMessages = Collections.emptySet();

--- a/src/main/java/com/networknt/schema/AdditionalPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/AdditionalPropertiesValidator.java
@@ -88,7 +88,7 @@ public class AdditionalPropertiesValidator extends BaseJsonValidator implements 
         // if allowAdditionalProperties is true, add all the properties as evaluated.
         if (allowAdditionalProperties) {
             for (Iterator<String> it = node.fieldNames(); it.hasNext(); ) {
-                addToEvaluatedProperties(at + "." + it.next());
+                addToEvaluatedProperties(atPath(at, it.next()));
             }
         }
 
@@ -114,9 +114,9 @@ public class AdditionalPropertiesValidator extends BaseJsonValidator implements 
                     if (additionalPropertiesSchema != null) {
                         ValidatorState state = (ValidatorState) CollectorContext.getInstance().get(ValidatorState.VALIDATOR_STATE_KEY);
                         if (state != null && state.isWalkEnabled()) {
-                            errors.addAll(additionalPropertiesSchema.walk(node.get(pname), rootNode, at + "." + pname, state.isValidationEnabled()));
+                            errors.addAll(additionalPropertiesSchema.walk(node.get(pname), rootNode, atPath(at, pname), state.isValidationEnabled()));
                         } else {
-                            errors.addAll(additionalPropertiesSchema.validate(node.get(pname), rootNode, at + "." + pname));
+                            errors.addAll(additionalPropertiesSchema.validate(node.get(pname), rootNode, atPath(at, pname)));
                         }
                     }
                 }
@@ -157,7 +157,7 @@ public class AdditionalPropertiesValidator extends BaseJsonValidator implements 
                     if (additionalPropertiesSchema != null) {
                         ValidatorState state = (ValidatorState) CollectorContext.getInstance().get(ValidatorState.VALIDATOR_STATE_KEY);
                         if (state != null && state.isWalkEnabled()) {
-                           additionalPropertiesSchema.walk(node.get(pname), rootNode, at + "." + pname, state.isValidationEnabled());
+                           additionalPropertiesSchema.walk(node.get(pname), rootNode, atPath(at, pname), state.isValidationEnabled());
                         }
                     }
                 }

--- a/src/main/java/com/networknt/schema/ContainsValidator.java
+++ b/src/main/java/com/networknt/schema/ContainsValidator.java
@@ -55,7 +55,7 @@ public class ContainsValidator extends BaseJsonValidator implements JsonValidato
         } else if (node.isArray()) {
             int i = 0;
             for (JsonNode n : node) {
-                if (schema.validate(n, rootNode, at + "[" + i + "]").isEmpty()) {
+                if (schema.validate(n, rootNode, atPath(at, i)).isEmpty()) {
                     //Short circuit on first success
                     return Collections.emptySet();
                 }

--- a/src/main/java/com/networknt/schema/ItemsValidator.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator.java
@@ -96,17 +96,17 @@ public class ItemsValidator extends BaseJsonValidator implements JsonValidator {
         if (schema != null) {
             // validate with item schema (the whole array has the same item
             // schema)
-            errors.addAll(schema.validate(node, rootNode, at + "[" + i + "]"));
+            errors.addAll(schema.validate(node, rootNode, atPath(at, i)));
         }
 
         if (tupleSchema != null) {
             if (i < tupleSchema.size()) {
                 // validate against tuple schema
-                errors.addAll(tupleSchema.get(i).validate(node, rootNode, at + "[" + i + "]"));
+                errors.addAll(tupleSchema.get(i).validate(node, rootNode, atPath(at, i)));
             } else {
                 if (additionalSchema != null) {
                     // validate against additional item schema
-                    errors.addAll(additionalSchema.validate(node, rootNode, at + "[" + i + "]"));
+                    errors.addAll(additionalSchema.validate(node, rootNode, atPath(at, i)));
                 } else if (!additionalItems) {
                     // no additional item allowed, return error
                     errors.add(buildValidationMessage(at, "" + i));
@@ -143,18 +143,18 @@ public class ItemsValidator extends BaseJsonValidator implements JsonValidator {
             String at, boolean shouldValidateSchema) {
         if (schema != null) {
             // Walk the schema.
-            walkSchema(schema, node, rootNode, at + "[" + i + "]", shouldValidateSchema, validationMessages);
+            walkSchema(schema, node, rootNode, atPath(at, i), shouldValidateSchema, validationMessages);
         }
 
         if (tupleSchema != null) {
             if (i < tupleSchema.size()) {
                 // walk tuple schema
-                walkSchema(tupleSchema.get(i), node, rootNode, at + "[" + i + "]", shouldValidateSchema,
+                walkSchema(tupleSchema.get(i), node, rootNode, atPath(at, i), shouldValidateSchema,
                         validationMessages);
             } else {
                 if (additionalSchema != null) {
                     // walk additional item schema
-                    walkSchema(additionalSchema, node, rootNode, at + "[" + i + "]", shouldValidateSchema,
+                    walkSchema(additionalSchema, node, rootNode, atPath(at, i), shouldValidateSchema,
                             validationMessages);
                 }
             }

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -76,8 +76,9 @@ public class JsonSchema extends BaseJsonValidator {
     private JsonSchema(ValidationContext validationContext, String schemaPath, URI currentUri, JsonNode schemaNode,
                        JsonSchema parent, boolean suppressSubSchemaRetrieval) {
         super(schemaPath, schemaNode, parent, null, suppressSubSchemaRetrieval,
-              validationContext.getConfig() != null && validationContext.getConfig().isFailFast(),
-              validationContext.getConfig() != null ? validationContext.getConfig().getApplyDefaultsStrategy() : null);
+            validationContext.getConfig() != null && validationContext.getConfig().isFailFast(),
+            validationContext.getConfig() != null ? validationContext.getConfig().getApplyDefaultsStrategy() : null,
+            validationContext.getConfig() != null ? validationContext.getConfig().getPathType() : null);
         this.validationContext = validationContext;
         this.metaSchema = validationContext.getMetaSchema();
         this.currentUri = combineCurrentUriWithIds(currentUri, schemaNode);
@@ -298,7 +299,7 @@ public class JsonSchema extends BaseJsonValidator {
     @Override
     public Set<ValidationMessage> validate(JsonNode node) {
         try {
-            Set<ValidationMessage> errors = validate(node, node, AT_ROOT);
+            Set<ValidationMessage> errors = validate(node, node, atRoot());
             return errors;
         } finally {
             if (validationContext.getConfig().isResetCollectorContext()) {
@@ -352,7 +353,7 @@ public class JsonSchema extends BaseJsonValidator {
     }
 
     public ValidationResult validateAndCollect(JsonNode node) {
-        return validateAndCollect(node, node, AT_ROOT);
+        return validateAndCollect(node, node, atRoot());
     }
 
     /**
@@ -402,7 +403,7 @@ public class JsonSchema extends BaseJsonValidator {
      * @return result of ValidationResult
      */
     public ValidationResult walk(JsonNode node, boolean shouldValidateSchema) {
-        return walkAtNodeInternal(node, node, AT_ROOT, shouldValidateSchema);
+        return walkAtNodeInternal(node, node, atRoot(), shouldValidateSchema);
     }
 
     public ValidationResult walkAtNode(JsonNode node, JsonNode rootNode, String at, boolean shouldValidateSchema) {
@@ -425,7 +426,7 @@ public class JsonSchema extends BaseJsonValidator {
                 collectorContext.loadCollectors();
             }
             // Process UnEvaluatedProperties after all the validators are called.
-            errors.addAll(processUnEvaluatedProperties(node, node, AT_ROOT, shouldValidateSchema, false));
+            errors.addAll(processUnEvaluatedProperties(node, node, atRoot(), shouldValidateSchema, false));
             // Collect errors and collector context into validation result.
             ValidationResult validationResult = new ValidationResult(errors, collectorContext);
             return validationResult;

--- a/src/main/java/com/networknt/schema/JsonValidator.java
+++ b/src/main/java/com/networknt/schema/JsonValidator.java
@@ -25,7 +25,6 @@ import com.networknt.schema.walk.JsonSchemaWalker;
  * Standard json validator interface, implemented by all validators and JsonSchema.
  */
 public interface JsonValidator extends JsonSchemaWalker {
-    String AT_ROOT = "$";
 
     /**
      * Validate the given root JsonNode, starting at the root of the data path.

--- a/src/main/java/com/networknt/schema/NonValidationKeyword.java
+++ b/src/main/java/com/networknt/schema/NonValidationKeyword.java
@@ -27,10 +27,6 @@ import java.util.Set;
 public class NonValidationKeyword extends AbstractKeyword {
 
     private static final class Validator extends AbstractJsonValidator {
-        private Validator(String keyword) {
-            super(keyword);
-        }
-
         @Override
         public Set<ValidationMessage> validate(JsonNode node, JsonNode rootNode, String at) {
             return Collections.emptySet();
@@ -44,6 +40,6 @@ public class NonValidationKeyword extends AbstractKeyword {
     @Override
     public JsonValidator newValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema,
                                       ValidationContext validationContext) throws JsonSchemaException, Exception {
-        return new Validator(getValue());
+        return new Validator();
     }
 }

--- a/src/main/java/com/networknt/schema/PathType.java
+++ b/src/main/java/com/networknt/schema/PathType.java
@@ -1,0 +1,99 @@
+package com.networknt.schema;
+
+import java.util.function.Function;
+
+/**
+ * Enumeration defining the different approached available to generate the paths added to validation messages.
+ */
+public enum PathType {
+
+    /**
+     * The legacy approach, loosely based on JSONPath (but not guaranteed to give valid JSONPath expressions).
+     */
+    LEGACY("$", (token) -> "." + token, (index) -> "[" + index + "]"),
+    /**
+     * Paths as JSONPath expressions.
+     */
+    JSON_PATH("$", (token) -> {
+        /*
+         * Accepted characters for shorthand paths:
+         * - 'a' through 'z'
+         * - 'A' through 'Z'
+         * - '0' through '9'
+         * - Underscore ('_')
+         */
+        if (token.codePoints().allMatch(c -> (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_')) {
+            return "." + token;
+        } else {
+            return "[\"" + token + "\"]";
+        }
+    }, (index) -> "[" + index + "]"),
+    /**
+     * Paths as JSONPointer expressions.
+     */
+    JSON_POINTER("", (token) -> {
+        /*
+         * Escape '~' with '~0' and '/' with '~1'.
+         */
+        if (token.indexOf('~') != -1) {
+            token = token.replace("~", "~0");
+        }
+        if (token.indexOf('/') != -1) {
+            token = token.replace("/", "~1");
+        }
+        return "/" + token;
+    }, (index) -> "/" + index);
+
+    /**
+     * The default path generation approach to use.
+     */
+    public static final PathType DEFAULT = LEGACY;
+    private final String rootToken;
+    private final Function<String, String> appendTokenFn;
+    private final Function<Integer, String> appendIndexFn;
+
+    /**
+     * Constructor.
+     *
+     * @param rootToken The token representing the document root.
+     * @param appendTokenFn A function used to define the path fragment used to append a token (e.g. property) to an existing path.
+     * @param appendIndexFn A function used to append an index (for arrays) to an existing path.
+     */
+    PathType(String rootToken, Function<String, String> appendTokenFn, Function<Integer, String> appendIndexFn) {
+        this.rootToken = rootToken;
+        this.appendTokenFn = appendTokenFn;
+        this.appendIndexFn = appendIndexFn;
+    }
+
+    /**
+     * Append the given child token to the provided current path.
+     *
+     * @param currentPath The path to append to.
+     * @param child The child token.
+     * @return The resulting complete path.
+     */
+    public String append(String currentPath, String child) {
+        return currentPath + appendTokenFn.apply(child);
+    }
+
+    /**
+     * Append the given index to the provided current path.
+     *
+     * @param currentPath The path to append to.
+     * @param index The index to append.
+     * @return The resulting complete path.
+     */
+    public String append(String currentPath, int index) {
+        return currentPath + appendIndexFn.apply(index);
+    }
+
+    /**
+     * Return the representation of the document root.
+     *
+     * @return The root token.
+     */
+    public String getRoot() {
+        return rootToken;
+    }
+
+}

--- a/src/main/java/com/networknt/schema/PatternPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/PatternPropertiesValidator.java
@@ -58,8 +58,8 @@ public class PatternPropertiesValidator extends BaseJsonValidator implements Jso
             for (Map.Entry<Pattern, JsonSchema> entry : schemas.entrySet()) {
                 Matcher m = entry.getKey().matcher(name);
                 if (m.find()) {
-                    addToEvaluatedProperties(at + "." + name);
-                    errors.addAll(entry.getValue().validate(n, rootNode, at + "." + name));
+                    addToEvaluatedProperties(atPath(at, name));
+                    errors.addAll(entry.getValue().validate(n, rootNode, atPath(at, name)));
                 }
             }
         }

--- a/src/main/java/com/networknt/schema/PrefixItemsValidator.java
+++ b/src/main/java/com/networknt/schema/PrefixItemsValidator.java
@@ -100,17 +100,17 @@ public class PrefixItemsValidator extends BaseJsonValidator implements JsonValid
         if (schema != null) {
             // validate with item schema (the whole array has the same item
             // schema)
-            errors.addAll(schema.validate(node, rootNode, at + "[" + i + "]"));
+            errors.addAll(schema.validate(node, rootNode, atPath(at, i)));
         }
 
         if (tupleSchema != null) {
             if (i < tupleSchema.size()) {
                 // validate against tuple schema
-                errors.addAll(tupleSchema.get(i).validate(node, rootNode, at + "[" + i + "]"));
+                errors.addAll(tupleSchema.get(i).validate(node, rootNode, atPath(at, i)));
             } else {
                 if (additionalSchema != null) {
                     // validate against additional item schema
-                    errors.addAll(additionalSchema.validate(node, rootNode, at + "[" + i + "]"));
+                    errors.addAll(additionalSchema.validate(node, rootNode, atPath(at, i)));
                 } else if (!additionalItems) {
                     // no additional item allowed, return error
                     errors.add(buildValidationMessage(at, "" + i));
@@ -147,18 +147,18 @@ public class PrefixItemsValidator extends BaseJsonValidator implements JsonValid
             String at, boolean shouldValidateSchema) {
         if (schema != null) {
             // Walk the schema.
-            walkSchema(schema, node, rootNode, at + "[" + i + "]", shouldValidateSchema, validationMessages);
+            walkSchema(schema, node, rootNode, atPath(at, i), shouldValidateSchema, validationMessages);
         }
 
         if (tupleSchema != null) {
             if (i < tupleSchema.size()) {
                 // walk tuple schema
-                walkSchema(tupleSchema.get(i), node, rootNode, at + "[" + i + "]", shouldValidateSchema,
+                walkSchema(tupleSchema.get(i), node, rootNode, atPath(at, i), shouldValidateSchema,
                         validationMessages);
             } else {
                 if (additionalSchema != null) {
                     // walk additional item schema
-                    walkSchema(additionalSchema, node, rootNode, at + "[" + i + "]", shouldValidateSchema,
+                    walkSchema(additionalSchema, node, rootNode, atPath(at, i), shouldValidateSchema,
                             validationMessages);
                 }
             }

--- a/src/main/java/com/networknt/schema/PropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/PropertiesValidator.java
@@ -54,7 +54,7 @@ public class PropertiesValidator extends BaseJsonValidator implements JsonValida
             JsonSchema propertySchema = entry.getValue();
             JsonNode propertyNode = node.get(entry.getKey());
             if (propertyNode != null) {
-                addToEvaluatedProperties(at + "." + entry.getKey());
+                addToEvaluatedProperties(atPath(at, entry.getKey()));
                 // check whether this is a complex validator. save the state
                 boolean isComplex = state.isComplexValidator();
                // if this is a complex validator, the node has matched, and all it's child elements, if available, are to be validated
@@ -66,7 +66,7 @@ public class PropertiesValidator extends BaseJsonValidator implements JsonValida
                 
                 if (!state.isWalkEnabled()) {
                     //validate the child element(s)
-                    errors.addAll(propertySchema.validate(propertyNode, rootNode, at + "." + entry.getKey()));
+                    errors.addAll(propertySchema.validate(propertyNode, rootNode, atPath(at, entry.getKey())));
                 } else {
                     // check if walker is enabled. If it is enabled it is upto the walker implementation to decide about the validation.
                     walkSchema(entry, node, rootNode, at, state.isValidationEnabled(), errors, propertyWalkListenerRunner);
@@ -155,15 +155,15 @@ public class PropertiesValidator extends BaseJsonValidator implements JsonValida
         JsonSchema propertySchema = entry.getValue();
         JsonNode propertyNode = (node == null ? null : node.get(entry.getKey()));
         boolean executeWalk = propertyWalkListenerRunner.runPreWalkListeners(ValidatorTypeCode.PROPERTIES.getValue(),
-                propertyNode, rootNode, at + "." + entry.getKey(), propertySchema.getSchemaPath(),
+                propertyNode, rootNode, atPath(at, entry.getKey()), propertySchema.getSchemaPath(),
                 propertySchema.getSchemaNode(), propertySchema.getParentSchema(), validationContext,
                 validationContext.getJsonSchemaFactory());
         if (executeWalk) {
             validationMessages.addAll(
-                    propertySchema.walk(propertyNode, rootNode, at + "." + entry.getKey(), shouldValidateSchema));
+                    propertySchema.walk(propertyNode, rootNode, atPath(at, entry.getKey()), shouldValidateSchema));
         }
         propertyWalkListenerRunner.runPostWalkListeners(ValidatorTypeCode.PROPERTIES.getValue(), propertyNode, rootNode,
-                at + "." + entry.getKey(), propertySchema.getSchemaPath(), propertySchema.getSchemaNode(),
+                atPath(at, entry.getKey()), propertySchema.getSchemaPath(), propertySchema.getSchemaNode(),
                 propertySchema.getParentSchema(), validationContext, validationContext.getJsonSchemaFactory(), validationMessages);
 
     }

--- a/src/main/java/com/networknt/schema/PropertyNamesValidator.java
+++ b/src/main/java/com/networknt/schema/PropertyNamesValidator.java
@@ -41,7 +41,7 @@ public class PropertyNamesValidator extends BaseJsonValidator implements JsonVal
         for (Iterator<String> it = node.fieldNames(); it.hasNext(); ) {
             final String pname = it.next();
             final TextNode pnameText = TextNode.valueOf(pname);
-            final Set<ValidationMessage> schemaErrors = innerSchema.validate(pnameText, node, at + "." + pname);
+            final Set<ValidationMessage> schemaErrors = innerSchema.validate(pnameText, node, atPath(at, pname));
             for (final ValidationMessage schemaError : schemaErrors) {
                 final String path = schemaError.getPath();
                 String msg = schemaError.getMessage();

--- a/src/main/java/com/networknt/schema/SchemaValidatorsConfig.java
+++ b/src/main/java/com/networknt/schema/SchemaValidatorsConfig.java
@@ -16,16 +16,12 @@
 
 package com.networknt.schema;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.uri.URITranslator;
 import com.networknt.schema.uri.URITranslator.CompositeURITranslator;
 import com.networknt.schema.walk.JsonSchemaWalkListener;
+
+import java.util.*;
 
 public class SchemaValidatorsConfig {
     /**
@@ -101,6 +97,11 @@ public class SchemaValidatorsConfig {
      * When set to true considers that schema is used to write data then ReadOnlyValidator is activated. Default true.
      */
     private boolean writeMode = true;
+
+    /**
+     * The approach used to generate paths in reported messages, logs and errors. Default is the legacy "JSONPath-like" approach.
+     */
+    private PathType pathType = PathType.DEFAULT;
 
     // This is just a constant for listening to all Keywords.
     public static final String ALL_KEYWORD_WALK_LISTENER_KEY = "com.networknt.AllKeywordWalkListener";
@@ -356,5 +357,23 @@ public class SchemaValidatorsConfig {
      */
     public void setWriteMode(boolean writeMode) {
         this.writeMode = writeMode;
+    }
+
+    /**
+     * Set the approach used to generate paths in messages, logs and errors (default is PathType.LEGACY).
+     *
+     * @param pathType The path generation approach.
+     */
+    public void setPathType(PathType pathType) {
+        this.pathType = pathType;
+    }
+
+    /**
+     * Get the approach used to generate paths in messages, logs and errors.
+     *
+     * @return The path generation approach.
+     */
+    public PathType getPathType() {
+        return pathType;
     }
 }

--- a/src/main/java/com/networknt/schema/UnEvaluatedPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/UnEvaluatedPropertiesValidator.java
@@ -89,9 +89,9 @@ public class UnEvaluatedPropertiesValidator extends BaseJsonValidator implements
             String fieldName = nodesIterator.next();
             JsonNode jsonNode = node.get(fieldName);
             if (jsonNode.isObject()) {
-                processAllPaths(jsonNode, at + "." + fieldName, paths);
+                processAllPaths(jsonNode, atPath(at, fieldName), paths);
             }
-            paths.add(at + "." + fieldName);
+            paths.add(atPath(at, fieldName));
         }
     }
 

--- a/src/test/java/com/networknt/schema/CollectorContextTest.java
+++ b/src/test/java/com/networknt/schema/CollectorContextTest.java
@@ -291,7 +291,7 @@ public class CollectorContextTest {
 
         @Override
         public Set<ValidationMessage> validate(JsonNode rootNode) {
-            return validate(rootNode, rootNode, BaseJsonValidator.AT_ROOT);
+            return validate(rootNode, rootNode, PathType.DEFAULT.getRoot());
         }
 
         @Override
@@ -368,7 +368,7 @@ public class CollectorContextTest {
 
         @Override
         public Set<ValidationMessage> validate(JsonNode rootNode) {
-            return validate(rootNode, rootNode, BaseJsonValidator.AT_ROOT);
+            return validate(rootNode, rootNode, PathType.DEFAULT.getRoot());
         }
 
         @Override

--- a/src/test/java/com/networknt/schema/CustomMetaSchemaTest.java
+++ b/src/test/java/com/networknt/schema/CustomMetaSchemaTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -46,14 +47,16 @@ public class CustomMetaSchemaTest {
         private static final class Validator extends AbstractJsonValidator {
             private final List<String> enumValues;
             private final List<String> enumNames;
+            private final String keyword;
 
             private Validator(String keyword, List<String> enumValues, List<String> enumNames) {
-                super(keyword);
+                super();
                 if (enumNames.size() != enumValues.size()) {
                     throw new IllegalArgumentException("enum and enumNames need to be of same length");
                 }
                 this.enumNames = enumNames;
                 this.enumValues = enumValues;
+                this.keyword = keyword;
             }
 
             @Override
@@ -64,7 +67,9 @@ public class CustomMetaSchemaTest {
                     throw new IllegalArgumentException("value not found in enum. value: " + value + " enum: " + enumValues);
                 }
                 String valueName = enumNames.get(idx);
-                return fail(CustomErrorMessageType.of("tests.example.enumNames", new MessageFormat("{0}: enumName is {1}")), at, valueName);
+                Set<ValidationMessage> messages = new HashSet<>();
+                messages.add(ValidationMessage.of(keyword, CustomErrorMessageType.of("tests.example.enumNames", new MessageFormat("{0}: enumName is {1}")), at, null, valueName));
+                return messages;
             }
         }
 

--- a/src/test/java/com/networknt/schema/Issue687Test.java
+++ b/src/test/java/com/networknt/schema/Issue687Test.java
@@ -1,0 +1,91 @@
+package com.networknt.schema;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Issue687Test {
+
+    @Test
+    void testRoot() {
+        assertEquals("$", PathType.LEGACY.getRoot());
+        assertEquals("$", PathType.JSON_PATH.getRoot());
+        assertEquals("", PathType.JSON_POINTER.getRoot());
+    }
+
+    @Test
+    void testDefault() {
+        assertEquals(PathType.LEGACY, PathType.DEFAULT);
+    }
+
+    public static Stream<Arguments> appendTokens() {
+        return Stream.of(
+                Arguments.of(PathType.LEGACY, "$.foo", "bar", "$.foo.bar"),
+                Arguments.of(PathType.LEGACY, "$.foo", "b.ar", "$.foo.b.ar"),
+                Arguments.of(PathType.LEGACY, "$.foo", "b~ar", "$.foo.b~ar"),
+                Arguments.of(PathType.LEGACY, "$.foo", "b/ar", "$.foo.b/ar"),
+                Arguments.of(PathType.JSON_PATH, "$.foo", "bar", "$.foo.bar"),
+                Arguments.of(PathType.JSON_PATH, "$.foo", "b.ar", "$.foo[\"b.ar\"]"),
+                Arguments.of(PathType.JSON_PATH, "$.foo", "b~ar", "$.foo[\"b~ar\"]"),
+                Arguments.of(PathType.JSON_PATH, "$.foo", "b/ar", "$.foo[\"b/ar\"]"),
+                Arguments.of(PathType.JSON_POINTER, "/foo", "bar", "/foo/bar"),
+                Arguments.of(PathType.JSON_POINTER, "/foo", "b.ar", "/foo/b.ar"),
+                Arguments.of(PathType.JSON_POINTER, "/foo", "b~ar", "/foo/b~0ar"),
+                Arguments.of(PathType.JSON_POINTER, "/foo", "b/ar", "/foo/b~1ar")
+        );
+    }
+
+    public static Stream<Arguments> appendIndexes() {
+        return Stream.of(
+                Arguments.of(PathType.LEGACY, "$.foo", 0, "$.foo[0]"),
+                Arguments.of(PathType.JSON_PATH, "$.foo", 0, "$.foo[0]"),
+                Arguments.of(PathType.JSON_POINTER, "/foo", 0, "/foo/0")
+        );
+    }
+
+    public static Stream<Arguments> validationMessages() {
+        String schemaPath = "/schema/issue687.json";
+        String content = "{ \"foo\": \"a\", \"b.ar\": 1, \"children\": [ { \"childFoo\": \"a\", \"c/hildBar\": 1 } ] }";
+        return Stream.of(
+                Arguments.of(PathType.LEGACY, schemaPath, content, new String[] { "$.b.ar", "$.children[0].c/hildBar" }),
+                Arguments.of(PathType.JSON_PATH, schemaPath, content, new String[] { "$[\"b.ar\"]", "$.children[0][\"c/hildBar\"]" }),
+                Arguments.of(PathType.JSON_POINTER, schemaPath, content, new String[] { "/b.ar", "/children/0/c~1hildBar" })
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("appendTokens")
+    void testAppendToken(PathType pathType, String currentPath, String token, String expected) {
+        assertEquals(expected, pathType.append(currentPath, token));
+    }
+
+    @ParameterizedTest
+    @MethodSource("appendIndexes")
+    void testAppendIndex(PathType pathType, String currentPath, Integer index, String expected) {
+        assertEquals(expected, pathType.append(currentPath, index));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validationMessages")
+    void testValidationMessage(PathType pathType, String schemaPath, String content, String[] expectedMessagePaths) throws JsonProcessingException {
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.setPathType(pathType);
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909);
+        JsonSchema schema = factory.getSchema(Issue687Test.class.getResourceAsStream(schemaPath), config);
+        Set<ValidationMessage> messages = schema.validate(new ObjectMapper().readTree(content));
+        assertEquals(expectedMessagePaths.length, messages.size());
+        for (String expectedPath: expectedMessagePaths) {
+            assertTrue(messages.stream().anyMatch(msg -> expectedPath.equals(msg.getPath())));
+        }
+    }
+
+}

--- a/src/test/java/com/networknt/schema/JsonWalkTest.java
+++ b/src/test/java/com/networknt/schema/JsonWalkTest.java
@@ -158,7 +158,7 @@ public class JsonWalkTest {
 
             @Override
             public Set<ValidationMessage> validate(JsonNode rootNode) {
-                return validate(rootNode, rootNode, BaseJsonValidator.AT_ROOT);
+                return validate(rootNode, rootNode, PathType.DEFAULT.getRoot());
             }
 
             @Override

--- a/src/test/resources/schema/issue687.json
+++ b/src/test/resources/schema/issue687.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://json-schema.org/draft/2019-09/schema",
+  "type": "object",
+  "properties": {
+    "foo": { "type": "string" },
+    "b.ar": { "type": "string" },
+    "children" : {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "childFoo": { "type": "string" },
+          "c/hildBar": { "type": "string" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implemented the feature proposed in #687. Note that this update would also resolve issue #567.

Note that while doing this update I took the liberty of making a small cleanup linked to the (barely) used `AbstractJsonValidator` class. This is used in only one place really (apart from unit tests), specifically for the (non) validation of keywords.