### PR TITLE
Corrects validation of duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ For the latest version, please check the [release](https://github.com/networknt/
 
 ## [MetaSchema Validation](doc/metaschema-validation.md)
 
+## [Validating RFC 3339 durations](doc/duration.md)
+
 
 ## Known issues
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -24,6 +24,11 @@ JsonSchema jsonSchema = JsonSchemaFactory.getInstance().getSchema(schema, config
 
 When typeLoose is true, the validator will convert strings to different types to match the type defined in the schema. This is mostly used to validate the JSON request or response for headers, query parameters, path parameters, and cookies. For the HTTP protocol, these are all strings and might be defined as other types in the schema. For example, the page number might be an integer in the schema but passed as a query parameter in string. 
 
+* strictness
+This is a map of keywords to whether the keyword's validators should perform a strict or permissive analysis. When strict is true, validators will perform strict checking against the schema.
+This is the default behavior. When set to false, validators are free to relax some constraints but not required. Each validator has its own understanding of what constitutes strict and
+permissive.
+
 * failFast
 
 When set to true, the validation process stops immediately when the first error occurs. This mostly used on microservices that is designed to [fail-fast](https://www.networknt.com/architecture/fail-fast/), or users don't want to see hundreds of errors for a big payload. Please be aware that the validator throws an exception in the case the first error occurs. To learn how to use it, please follow the [test case](https://github.com/networknt/json-schema-validator/blob/master/src/test/java/com/networknt/schema/V4JsonSchemaTest.java#L352). 

--- a/doc/duration.md
+++ b/doc/duration.md
@@ -1,0 +1,31 @@
+## Validating RFC 3339 durations
+
+JSON Schema Draft 2019-09 and later uses RFC 3339 to define dates and times.
+RFC 3339 bases its definition of duration of what is in the 1988 version of
+ISO 1801, which is over 35 years old and has undergone many changes with
+updates in 1991, 2000, 2004, 2019 and an amendment in 2022.
+
+There are notable differences between the current version of ISO 8601 and
+RFC 3339:
+* ISO 8601-2:2019 permits negative durations</li>
+* ISO 8601-2:2019 permits combining weeks with other terms (e.g. `P1Y13W`)
+
+There are also notable differences in how RFC 3339 defines a duration compared
+with how the Java Date/Time API defines it:
+* `java.time.Duration` accepts fractional seconds; RFC 3339 does not
+* `java.time.Period` does not accept a time component while RFC 3339 accepts both date and time components
+* `java.time.Duration` accepts days but not years, months or weeks
+
+By default, the duration validator performs a strict check that the value
+conforms to RFC 3339. You can relax this constraint by setting strict to false.
+
+```java
+SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+config.setStrict("duration", false);
+JsonSchema jsonSchema = JsonSchemaFactory.getInstance().getSchema(schema, config);
+```
+
+The relaxed check permits:
+* Fractional seconds
+* Negative durations
+* Combining weeks with other terms

--- a/src/main/java/com/networknt/schema/SchemaValidatorsConfig.java
+++ b/src/main/java/com/networknt/schema/SchemaValidatorsConfig.java
@@ -66,6 +66,15 @@ public class SchemaValidatorsConfig {
     private boolean openAPI3StyleDiscriminators = false;
 
     /**
+     * Contains a mapping of how strict a keyword's validators should be.
+     * Defaults to {@literal true}.
+     * <p>
+     * Each validator has its own understanding of what constitutes strict
+     * and permissive.
+     */
+    private final Map<String, Boolean> strictness = new HashMap<>(0);
+
+    /**
      * Map of public, normally internet accessible schema URLs to alternate
      * locations; this allows for offline validation of schemas that refer to public
      * URLs. This is merged with any mappings the {@link JsonSchemaFactory} may have
@@ -376,4 +385,32 @@ public class SchemaValidatorsConfig {
     public PathType getPathType() {
         return pathType;
     }
+
+    /**
+     * Answers whether a keyword's validators may relax their analysis. The
+     * default is to perform strict checking. One must explicitly allow a
+     * validator to be more permissive.
+     * <p>
+     * Each validator has its own understanding of what is permissive and
+     * strict. Consult the keyword's documentation for details. 
+     * 
+     * @param keyword the keyword to adjust (not null)
+     * @return Whether to perform a strict validation.
+     */
+    public boolean isStrict(String keyword) {
+        return this.strictness.getOrDefault(Objects.requireNonNull(keyword, "keyword cannot be null"), Boolean.TRUE);
+    }
+
+    /**
+     * Alters the strictness of validations for a specific keyword. When set to
+     * {@literal true}, instructs the keyword's validators to perform strict
+     * validation. Otherwise, a validator may perform a more permissive check.
+     * 
+     * @param keyword The keyword to adjust (not null)
+     * @param strict Whether to perform strict validations
+     */
+    public void setStrict(String keyword, boolean strict) {
+        this.strictness.put(Objects.requireNonNull(keyword, "keyword cannot be null"), strict);
+    }
+
 }

--- a/src/test/java/com/networknt/schema/AbstractJsonSchemaTestSuite.java
+++ b/src/test/java/com/networknt/schema/AbstractJsonSchemaTestSuite.java
@@ -116,6 +116,7 @@ public abstract class AbstractJsonSchemaTestSuite extends HTTPServiceSupport {
 
         SchemaValidatorsConfig config = new SchemaValidatorsConfig();
         config.setTypeLoose(typeLoose);
+        testSpec.getStrictness().forEach(config::setStrict);
         URI testCaseFileUri = URI.create("classpath:" + testSpec.getTestCase().getSpecification());
         JsonSchema schema = validatorFactory.getSchema(testCaseFileUri, testSpec.getTestCase().getSchema(), config);
 

--- a/src/test/java/com/networknt/schema/JsonSchemaTestSuiteTest.java
+++ b/src/test/java/com/networknt/schema/JsonSchemaTestSuiteTest.java
@@ -78,12 +78,10 @@ class JsonSchemaTestSuiteTest extends AbstractJsonSchemaTestSuite {
         disabled.add(Paths.get("src/test/suite/tests/draft2020-12/id.json"));
         disabled.add(Paths.get("src/test/suite/tests/draft2020-12/items.json"));
         disabled.add(Paths.get("src/test/suite/tests/draft2020-12/not.json"));
-        disabled.add(Paths.get("src/test/suite/tests/draft2020-12/optional/content.json"));
         disabled.add(Paths.get("src/test/suite/tests/draft2020-12/optional/cross-draft.json"));
         disabled.add(Paths.get("src/test/suite/tests/draft2020-12/optional/ecmascript-regex.json"));
         disabled.add(Paths.get("src/test/suite/tests/draft2020-12/optional/float-overflow.json"));
         disabled.add(Paths.get("src/test/suite/tests/draft2020-12/optional/format-assertion.json"));
-        disabled.add(Paths.get("src/test/suite/tests/draft2020-12/optional/format/duration.json"));
         disabled.add(Paths.get("src/test/suite/tests/draft2020-12/optional/format/email.json"));
         disabled.add(Paths.get("src/test/suite/tests/draft2020-12/optional/format/idn-email.json"));
         disabled.add(Paths.get("src/test/suite/tests/draft2020-12/optional/format/idn-hostname.json"));
@@ -113,7 +111,6 @@ class JsonSchemaTestSuiteTest extends AbstractJsonSchemaTestSuite {
         disabled.add(Paths.get("src/test/suite/tests/draft2019-09/optional/cross-draft.json"));
         disabled.add(Paths.get("src/test/suite/tests/draft2019-09/optional/ecmascript-regex.json"));
         disabled.add(Paths.get("src/test/suite/tests/draft2019-09/optional/float-overflow.json"));
-        disabled.add(Paths.get("src/test/suite/tests/draft2019-09/optional/format/duration.json"));
         disabled.add(Paths.get("src/test/suite/tests/draft2019-09/optional/format/idn-email.json"));
         disabled.add(Paths.get("src/test/suite/tests/draft2019-09/optional/format/idn-hostname.json"));
         disabled.add(Paths.get("src/test/suite/tests/draft2019-09/optional/format/iri-reference.json"));

--- a/src/test/java/com/networknt/schema/TestSpec.java
+++ b/src/test/java/com/networknt/schema/TestSpec.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -35,6 +37,17 @@ public class TestSpec {
      * valid or not (Required)
      */
     private final boolean valid;
+
+    /**
+     * A mapping of how strict a keyword's validators should be. Defaults to
+     * {@literal true}.
+     * <p>
+     * Each validator has its own understanding of what constitutes strict
+     * and permissive.
+     * <p>
+     * This is an extension of the schema used to describe tests in the compliance suite
+     */
+    private final Map<String, Boolean> strictness = new HashMap<>(0);
 
     /**
      * The set of validation messages expected from testing data against the schema
@@ -80,6 +93,7 @@ public class TestSpec {
      * @param comment Any additional comments about the test
      * @param data The instance which should be validated against the schema in "schema" (Required)
      * @param valid Whether the validation process of this instance should consider the instance valid or not (Required)
+     * @param strictness A mapping of how strict a keyword's validators should be.
      * @param validationMessages A sequence of validation messages expected from testing data against the schema
      * @param disabled Indicates whether this test should be executed (Defaults to FALSE)
      * @param isTypeLoose Indicates whether the test should consider a strict definition of an enum (Defaults to FALSE)
@@ -90,6 +104,7 @@ public class TestSpec {
         @JsonProperty("comment") String comment,
         @JsonProperty("data") JsonNode data,
         @JsonProperty("valid") boolean valid,
+        @JsonProperty("strictness") Map<String, Boolean> strictness,
         @JsonProperty("validationMessages") Set<String> validationMessages,
         @JsonProperty("isTypeLoose") Boolean isTypeLoose,
         @JsonProperty("disabled") Boolean disabled
@@ -101,6 +116,9 @@ public class TestSpec {
         this.validationMessages = validationMessages;
         this.disabled = Boolean.TRUE.equals(disabled);
         this.typeLoose = Boolean.TRUE.equals(isTypeLoose);
+        if (null != strictness) {
+            this.strictness.putAll(strictness);
+        }
     }
 
     /**
@@ -155,6 +173,13 @@ public class TestSpec {
      */
     public boolean isValid() {
         return valid;
+    }
+
+    /**
+     * @return A mapping of how strict a keyword's validators should be (never null).
+     */
+    public Map<String, Boolean> getStrictness() {
+        return strictness;
     }
 
     /**

--- a/src/test/resources/draft2019-09/permissive-duration.json
+++ b/src/test/resources/draft2019-09/permissive-duration.json
@@ -1,0 +1,19 @@
+[
+    {
+        "description": "validation of duration strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "duration"
+        },
+        "tests": [
+            {
+                "description": "weeks can be combined with other units",
+                "data": "P1Y2W",
+                "valid": true,
+                "strictness": {
+                    "duration": false
+                }
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Corrects validation of duration and provides the option to validate against a more recent version of ISO 8601

By default, the duration validator performs a strict check that the value conforms to RFC 3339. You can _relax_ this constraint by setting strict to false.

`config.setStrict("duration", false);`

The relaxed check permits:
* Fractional seconds
* Negative durations
* Combining weeks with other terms
