### PR TITLE
Adds explicit Java module descriptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,41 +186,6 @@
                     </instructions>
                 </configuration>
             </plugin>
-            <!--
-            <plugin>
-                <groupId>org.moditect</groupId>
-                <artifactId>moditect-maven-plugin</artifactId>
-                <version>1.0.0.RC1</version>
-                <executions>
-                    <execution>
-                        <id>add-module-info</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>add-module-info</goal>
-                        </goals>
-                        <configuration>
-                            <jvmVersion>9</jvmVersion>
-                            <module>
-                                <moduleInfoSource>
-                                    module com.networknt.schema {
-                                        requires transitive com.fasterxml.jackson.databind;
-                                        requires org.apache.commons.lang3;
-                                        requires org.jruby.jcodings;
-                                        requires org.jruby.joni;
-                                        requires org.slf4j;
-
-                                        exports com.networknt.schema;
-                                        exports com.networknt.schema.format;
-                                        exports com.networknt.schema.uri;
-                                        exports com.networknt.schema.urn;
-                                    }
-                                </moduleInfoSource>
-                            </module>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            -->
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -378,6 +343,65 @@
                             </execution>
                         </executions>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>java-module</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+        			<plugin>
+        				<groupId>org.moditect</groupId>
+        				<artifactId>moditect-maven-plugin</artifactId>
+        				<version>1.0.0.RC3</version>
+        				<executions>
+        					<execution>
+        						<id>add-module-infos</id>
+        						<phase>package</phase>
+        						<goals>
+        							<goal>add-module-info</goal>
+        						</goals>
+        						<configuration>
+        							<jvmVersion>9</jvmVersion>
+        							<overwriteExistingFiles>true</overwriteExistingFiles>
+        							<module>
+        								<moduleInfo>
+        									<name>com.networknt.schema</name>
+        									<!-- export everything -->
+        									<exports>*;</exports>
+        									<!-- declare services consumed by the artifact -->
+        									<addServiceUses>true</addServiceUses>
+        								</moduleInfo>
+        							</module>
+                                    <!--
+                                       previously configured but commented out
+                                    <module>
+                                        <moduleInfoSource>
+                                            module com.networknt.schema {
+                                                requires transitive com.fasterxml.jackson.databind;
+                                                requires org.apache.commons.lang3;
+                                                requires org.jruby.jcodings;
+                                                requires org.jruby.joni;
+                                                requires org.slf4j;
+                    
+                                                exports com.networknt.schema;
+                                                exports com.networknt.schema.format;
+                                                exports com.networknt.schema.uri;
+                                                exports com.networknt.schema.urn;
+                                            }
+                                        </moduleInfoSource>
+                                    </module>
+                                    -->
+        							<jdepsExtraArgs>
+        								<arg>--multi-release=9</arg>
+        							</jdepsExtraArgs>
+        						</configuration>
+        					</execution>
+        				</executions>
+        			</plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
Resolves #727

Added moditect plugin in a profile guarded by a JDK activation because the plugin requires JDK9+
Tests on CI run on JDK8 and thus would cause a failure.

**NOTE:** This means releases must be performed with DJK9+

There was a previous configuration for the moditect plugin using en explicit module. I left in place in case you'd rather twek it instead of having the plugin create the module from scratch:

```
$ jarviz bytecode show --file target/json-schema-validator-1.0.80.jar 
subject: json-schema-validator-1.0.80.jar
Unversioned classes. Bytecode version: 52 (Java 8) total: 145
Versioned classes 9. Bytecode version: 53 (Java 9) total: 1

$ jarviz module descriptor --file target/json-schema-validator-1.0.80.jar 
subject: json-schema-validator-1.0.80.jar
name: com.networknt.schema
version: 1.0.80
open: false
automatic: false
exports:
  com.networknt.schema
  com.networknt.schema.format
  com.networknt.schema.uri
  com.networknt.schema.urn
  com.networknt.schema.utils
  com.networknt.schema.walk
requires:
  com.fasterxml.jackson.databind
  com.fasterxml.jackson.dataformat.yaml
  itu
  java.base mandated
  org.jruby.jcodings static
  org.jruby.joni static
  org.slf4j
```