### PR TITLE
Allow walking of schema for items keyword when non-array node is provided

### DIFF
--- a/src/main/java/com/networknt/schema/ItemsValidator202012.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator202012.java
@@ -101,6 +101,8 @@ public class ItemsValidator202012 extends BaseJsonValidator {
                 // Walk the schema.
                 walkSchema(this.schema, n, rootNode, atPath(at, i), shouldValidateSchema, validationMessages);
             }
+        } else {
+            walkSchema(this.schema, node, rootNode, at, shouldValidateSchema, validationMessages);
         }
 
         return validationMessages;

--- a/src/main/java/com/networknt/schema/UnevaluatedPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/UnevaluatedPropertiesValidator.java
@@ -25,7 +25,7 @@ import java.util.*;
 public class UnevaluatedPropertiesValidator extends BaseJsonValidator {
     private static final Logger logger = LoggerFactory.getLogger(UnevaluatedPropertiesValidator.class);
 
-    private static final String UNEVALUATED_PROPERTIES = "com.networknt.schema.UnevaluatedPropertiesValidator.UnevaluatedProperties";
+    public static final String UNEVALUATED_PROPERTIES = "com.networknt.schema.UnevaluatedPropertiesValidator.UnevaluatedProperties";
 
     private final JsonSchema schema;
 


### PR DESCRIPTION
Resolves #785 

Fixing ItemsValidator202012 walk flow.
Making UnevaluatedProperties CollectorContext's key public as was in 1.0.76.