### PR TITLE
Normalize uri keys of JsonSchemaFactory.jsonMetaSchemas on read and write

### DIFF
--- a/src/main/java/com/networknt/schema/SpecVersionDetector.java
+++ b/src/main/java/com/networknt/schema/SpecVersionDetector.java
@@ -58,12 +58,8 @@ public final class SpecVersionDetector {
     public static Optional<VersionFlag> detectOptionalVersion(JsonNode jsonNode) {
         return Optional.ofNullable(jsonNode.get(SCHEMA_TAG)).map(schemaTag -> {
 
-            final boolean forceHttps = true;
-            final boolean removeEmptyFragmentSuffix = true;
-
             String schemaTagValue = schemaTag.asText();
-            String schemaUri = JsonSchemaFactory.normalizeMetaSchemaUri(schemaTagValue, forceHttps,
-                    removeEmptyFragmentSuffix);
+            String schemaUri = JsonSchemaFactory.normalizeMetaSchemaUri(schemaTagValue);
 
             return VersionFlag.fromId(schemaUri)
                 .orElseThrow(() -> new JsonSchemaException("'" + schemaTagValue + "' is unrecognizable schema"));

--- a/src/test/java/com/networknt/schema/Issue832Test.java
+++ b/src/test/java/com/networknt/schema/Issue832Test.java
@@ -1,0 +1,59 @@
+package com.networknt.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.format.AbstractFormat;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class Issue832Test {
+    private class NoMatchFormat extends AbstractFormat {
+        public NoMatchFormat() {
+            super("no_match", "always fail match");
+        }
+
+        @Override
+        public boolean matches(String value) {
+            return false;
+        }
+    }
+
+    private JsonSchemaFactory buildV7PlusNoFormatSchemaFactory() {
+        List<Format> formats;
+        formats = new ArrayList<>();
+        formats.add(new NoMatchFormat());
+
+        JsonMetaSchema jsonMetaSchema = JsonMetaSchema.builder(
+                JsonMetaSchema.getV7().getUri(),
+                JsonMetaSchema.getV7())
+                .addFormats(formats)
+                .build();
+        return new JsonSchemaFactory.Builder().defaultMetaSchemaURI(jsonMetaSchema.getUri()).addMetaSchema(jsonMetaSchema).build();
+    }
+
+    protected JsonNode getJsonNodeFromStreamContent(InputStream content) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readTree(content);
+    }
+
+    @Test
+    public void testV7WithNonMatchingCustomFormat() throws IOException {
+        String schemaPath = "/schema/issue832-v7.json";
+        String dataPath = "/data/issue832.json";
+        InputStream schemaInputStream = getClass().getResourceAsStream(schemaPath);
+        JsonSchemaFactory factory = buildV7PlusNoFormatSchemaFactory();
+        JsonSchema schema = factory.getSchema(schemaInputStream);
+        InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
+        JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
+        Set<ValidationMessage> errors = schema.validate(node);
+        // Both the custom no_match format and the standard email format should fail.
+        // This ensures that both the standard and custom formatters have been invoked.
+        Assertions.assertEquals(2, errors.size());
+    }
+}

--- a/src/test/java/com/networknt/schema/UnknownMetaSchemaTest.java
+++ b/src/test/java/com/networknt/schema/UnknownMetaSchemaTest.java
@@ -59,8 +59,6 @@ public class UnknownMetaSchemaTest {
 
     @Test
     public void testNormalize() throws JsonSchemaException {
-        final boolean forceHttps = true;
-        final boolean removeEmptyFragmentSuffix = true;
 
         String uri01 = "http://json-schema.org/draft-07/schema";
         String uri02 = "http://json-schema.org/draft-07/schema#";
@@ -68,44 +66,10 @@ public class UnknownMetaSchemaTest {
         String uri04 = "http://json-schema.org/draft-07/schema?key=value&key2=value2";
         String expected = "https://json-schema.org/draft-07/schema";
 
-        Assertions.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri01, forceHttps, removeEmptyFragmentSuffix));
-        Assertions.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri02, forceHttps, removeEmptyFragmentSuffix));
-        Assertions.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri03, forceHttps, removeEmptyFragmentSuffix));
-        Assertions.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri04, forceHttps, removeEmptyFragmentSuffix));
-
-    }
-
-    @Test
-    public void testNormalizeForceHttpsDisabled() throws JsonSchemaException {
-        final boolean forceHttps = false;
-        final boolean removeEmptyFragmentSuffix = true;
-
-        String uri01 = "http://json-schema.org/draft-07/schema";
-        String uri02 = "http://json-schema.org/draft-07/schema#";
-        String uri03 = "http://json-schema.org/draft-07/schema?key=value";
-        String uri04 = "http://json-schema.org/draft-07/schema?key=value&key2=value2";
-        String expected = "http://json-schema.org/draft-07/schema";
-
-        Assertions.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri01, forceHttps, removeEmptyFragmentSuffix));
-        Assertions.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri02, forceHttps, removeEmptyFragmentSuffix));
-        Assertions.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri03, forceHttps, removeEmptyFragmentSuffix));
-        Assertions.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri04, forceHttps, removeEmptyFragmentSuffix));
-
-    }
-
-    @Test
-    public void testNormalizeRemovingEmptyFragmentSuffixDisabled() throws JsonSchemaException {
-        final boolean forceHttps = true;
-        final boolean removeEmptyFragmentSuffix = false;
-
-        String uri01 = "http://json-schema.org/draft-07/schema#";
-        String uri02 = "http://json-schema.org/draft-07/schema?key=value#";
-        String uri03 = "http://json-schema.org/draft-07/schema?key=value&key2=value2#";
-        String expected = "https://json-schema.org/draft-07/schema#";
-
-        Assertions.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri01, forceHttps, removeEmptyFragmentSuffix));
-        Assertions.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri02, forceHttps, removeEmptyFragmentSuffix));
-        Assertions.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri03, forceHttps, removeEmptyFragmentSuffix));
+        Assertions.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri01));
+        Assertions.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri02));
+        Assertions.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri03));
+        Assertions.assertEquals(expected, JsonSchemaFactory.normalizeMetaSchemaUri(uri04));
 
     }
 }

--- a/src/test/resources/data/issue832.json
+++ b/src/test/resources/data/issue832.json
@@ -1,0 +1,4 @@
+{
+  "foo": "does not match",
+  "contact": "not an email address"
+}

--- a/src/test/resources/schema/issue832-v7.json
+++ b/src/test/resources/schema/issue832-v7.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "foo": {
+      "type": "string",
+      "format": "no_match"
+    },
+    "contact": {
+      "type": "string",
+      "format": "email"
+    }
+  },
+  "required": ["foo", "contact"],
+  "type": "object"
+}


### PR DESCRIPTION
Fixes #832 

Previously, when writing to the JsonSchemaFactory.jsonMetaSchemas hash map, the uri key was not normalized, but upon reading from the hash map, the key was normalized.

In addition, if a key is not found in this hash map, the standard meta schema for the uri is loaded.

The result was that an attempt to augment a standard meta schema with custom formatters did not work because the standard meta schema was always used instead of the custom augmented meta schema.

This change normalizes the uri keys of JsonSchemaFactory.jsonMetaSchemas on both read and write. Normalizing the uri keys on both reads and writes also eliminates the need for the forceHttps and removeEmptyFragmentSuffix arguments to the normalizeMetaSchemaUri() method.