### PR TITLE
Use correct namespace URI to pass XML validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,9 @@
   ~ limitations under the License.
   -->
 <project
-  xmlns="https://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
   >
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Namespace URI can't be changed deliberately from http to https, doing so makes the XML validation to fail

https://maven.apache.org/pom.html 
https://www.w3.org/TR/xmlschema-1/

