### PR TITLE
Revert "Bump io.undertow:undertow-core from 2.2.25.Final to 2.3.5.Final (#858)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <version.logback>1.2.11</version.logback>
     <version.slf4j>2.0.7</version.slf4j>
     <version.surefire>3.0.0</version.surefire>
-    <version.undertow>2.3.5.Final</version.undertow>
+    <version.undertow>2.2.25.Final</version.undertow>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This reverts commit 01a7da249bb3e348565410e99c269006dfdec433.

Fixes #861