### PR TITLE
compile configuration is depricated

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Gradle:
 
 ```java
 dependencies {
-    compile(group: 'com.networknt', name: 'json-schema-validator', version: '1.0.87');
+    implementation(group: 'com.networknt', name: 'json-schema-validator', version: '1.0.87');
 }
 ```
 


### PR DESCRIPTION
#901  Starting with Gradle 7.x, the “compile” configuration is no longer used directly