### PR TITLE
665: Can't load JSON schemas with URN value in id field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <groupId>com.networknt</groupId>
   <artifactId>json-schema-validator</artifactId>
-  <version>1.0.87</version>
+  <version>1.0.88</version>
   <packaging>bundle</packaging>
   <name>JsonSchemaValidator</name>
   <description>A json schema validator that supports draft v4, v6, v7, v2019-09 and v2020-12</description>

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -214,7 +214,7 @@ public class JsonSchema extends BaseJsonValidator {
             if (node.isMissingNode()) {
                 node = handleNullNode(ref, schema);
             }
-        } else if (ref.startsWith("#") && ref.length() > 1) {
+        } else if ((ref.startsWith("#") && ref.length() > 1) || (ref.startsWith("urn:") && ref.length() > 4)) {
             node = this.metaSchema.getNodeByFragmentRef(ref, node);
             if (node == null) {
                 node = handleNullNode(ref, schema);

--- a/src/main/java/com/networknt/schema/JsonSchemaFactory.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaFactory.java
@@ -59,6 +59,8 @@ public class JsonSchemaFactory {
             for (final String scheme : URLFactory.SUPPORTED_SCHEMES) {
                 this.uriFactoryMap.put(scheme, urlFactory);
             }
+            // Adds support for creating URNs.
+            this.uriFactoryMap.put(URNURIFactory.SCHEME, new URNURIFactory());
 
             // Adds support for fetching with {@link URL}s.
             final URIFetcher urlFetcher = new URLFetcher();

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -19,6 +19,7 @@ package com.networknt.schema;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.CollectorContext.Scope;
 import com.networknt.schema.uri.URIFactory;
+import com.networknt.schema.uri.URNURIFactory;
 import com.networknt.schema.urn.URNFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +36,7 @@ public class RefValidator extends BaseJsonValidator {
     private JsonSchema parentSchema;
 
     private static final String REF_CURRENT = "#";
-    private static final String URN_SCHEME = "urn";
+    private static final String URN_SCHEME = URNURIFactory.SCHEME;
 
     public RefValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaPath, schemaNode, parentSchema, ValidatorTypeCode.REF, validationContext);

--- a/src/main/java/com/networknt/schema/uri/URLFactory.java
+++ b/src/main/java/com/networknt/schema/uri/URLFactory.java
@@ -31,7 +31,7 @@ import java.util.Set;
 public final class URLFactory implements URIFactory {
     // These supported schemes are defined in {@link #URL(String, String, int, String)}.
     public static final Set<String> SUPPORTED_SCHEMES = Collections.unmodifiableSet(new HashSet<>(
-            Arrays.asList("http", "https", "ftp", "file", "jar", "urn")));
+            Arrays.asList("http", "https", "ftp", "file", "jar")));
 
     /**
      * @param uri String

--- a/src/main/java/com/networknt/schema/uri/URLFactory.java
+++ b/src/main/java/com/networknt/schema/uri/URLFactory.java
@@ -30,8 +30,8 @@ import java.util.Set;
  */
 public final class URLFactory implements URIFactory {
     // These supported schemes are defined in {@link #URL(String, String, int, String)}.
-    public static final Set<String> SUPPORTED_SCHEMES = Collections.unmodifiableSet(new HashSet<String>(
-            Arrays.asList("http", "https", "ftp", "file", "jar")));
+    public static final Set<String> SUPPORTED_SCHEMES = Collections.unmodifiableSet(new HashSet<>(
+            Arrays.asList("http", "https", "ftp", "file", "jar", "urn")));
 
     /**
      * @param uri String

--- a/src/main/java/com/networknt/schema/uri/URLFetcher.java
+++ b/src/main/java/com/networknt/schema/uri/URLFetcher.java
@@ -34,8 +34,7 @@ public final class URLFetcher implements URIFetcher {
 
     // These supported schemes are defined in {@link #URL(String, String, int, String)}.
     // This fetcher also supports the {@link URL}s created with the {@link ClasspathURIFactory}.
-    public static final Set<String> SUPPORTED_SCHEMES = Collections.unmodifiableSet(new HashSet<>(
-            Arrays.asList("http", "https", "ftp", "file", "jar")));
+    public static final Set<String> SUPPORTED_SCHEMES = URLFactory.SUPPORTED_SCHEMES;
 
     /**
      * {@inheritDoc}

--- a/src/main/java/com/networknt/schema/uri/URLFetcher.java
+++ b/src/main/java/com/networknt/schema/uri/URLFetcher.java
@@ -22,7 +22,9 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -32,7 +34,8 @@ public final class URLFetcher implements URIFetcher {
 
     // These supported schemes are defined in {@link #URL(String, String, int, String)}.
     // This fetcher also supports the {@link URL}s created with the {@link ClasspathURIFactory}.
-    public static final Set<String> SUPPORTED_SCHEMES = Collections.unmodifiableSet(URLFactory.SUPPORTED_SCHEMES);
+    public static final Set<String> SUPPORTED_SCHEMES = Collections.unmodifiableSet(new HashSet<>(
+            Arrays.asList("http", "https", "ftp", "file", "jar")));
 
     /**
      * {@inheritDoc}

--- a/src/main/java/com/networknt/schema/uri/URNURIFactory.java
+++ b/src/main/java/com/networknt/schema/uri/URNURIFactory.java
@@ -1,0 +1,30 @@
+package com.networknt.schema.uri;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * A URIFactory that handles "urn" scheme of {@link URI}s.
+ */
+public final class URNURIFactory implements URIFactory {
+
+    public static final String SCHEME = "urn";
+
+    @Override
+    public URI create(final String uri) {
+        try {
+            return URI.create(uri);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unable to create URI.", e);
+        }
+    }
+
+    @Override
+    public URI create(final URI baseURI, final String segment) {
+        String urnPart = baseURI.getRawSchemeSpecificPart();
+        int pos = urnPart.indexOf(':');
+        String namespace = pos < 0 ? urnPart : urnPart.substring(0, pos);
+        return URI.create(SCHEME + ":" + namespace + ":" + segment);
+    }
+}

--- a/src/test/java/com/networknt/schema/Issue665Test.java
+++ b/src/test/java/com/networknt/schema/Issue665Test.java
@@ -1,0 +1,49 @@
+package com.networknt.schema;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Set;
+
+public class Issue665Test extends BaseJsonSchemaValidatorTest {
+
+    @Test
+    void testUrnUriAsLocalRef() throws IOException {
+        JsonSchema schema = getJsonSchemaFromClasspath("draft7/urn/issue665.json", SpecVersion.VersionFlag.V7);
+        Assertions.assertNotNull(schema);
+        Assertions.assertDoesNotThrow(schema::initializeValidators);
+        Set<ValidationMessage> messages = schema.validate(getJsonNodeFromStringContent(
+                "{\"myData\": {\"value\": \"hello\"}}"));
+        Assertions.assertEquals(messages, Collections.emptySet());
+    }
+
+    @Test
+    void testUrnUriAsLocalRef_ExternalURN() {
+        JsonSchemaFactory factory = JsonSchemaFactory
+                .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
+                .uriFetcher(uri -> uri.equals(URI.create("urn:data"))
+                        ? Thread.currentThread().getContextClassLoader()
+                            .getResourceAsStream("draft7/urn/issue665_external_urn_subschema.json")
+                        : null,
+                        "urn")
+                .build();
+
+        try (InputStream is = Thread.currentThread().getContextClassLoader()
+                .getResourceAsStream("draft7/urn/issue665_external_urn_ref.json")) {
+            JsonSchema schema = factory.getSchema(is);
+            Assertions.assertNotNull(schema);
+            Assertions.assertDoesNotThrow(schema::initializeValidators);
+            Set<ValidationMessage> messages = schema.validate(getJsonNodeFromStringContent(
+                    "{\"myData\": {\"value\": \"hello\"}}"));
+            Assertions.assertEquals(messages, Collections.emptySet());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+}

--- a/src/test/resources/draft7/urn/issue665.json
+++ b/src/test/resources/draft7/urn/issue665.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "myData"
+  ],
+  "properties": {
+    "myData": {
+      "$ref": "urn:data"
+    }
+  },
+  "definitions": {
+    "data": {
+      "$id": "urn:data",
+      "type": "object",
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/draft7/urn/issue665_external_urn_ref.json
+++ b/src/test/resources/draft7/urn/issue665_external_urn_ref.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "myData"
+  ],
+  "properties": {
+    "myData": {
+      "$ref": "urn:data"
+    }
+  }
+}

--- a/src/test/resources/draft7/urn/issue665_external_urn_subschema.json
+++ b/src/test/resources/draft7/urn/issue665_external_urn_subschema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "urn:data",
+  "type": "object",
+  "required": [
+    "value"
+  ],
+  "properties": {
+    "value": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
(Hopefully) a fix for #665.
Added a special handling for "urn:" URIs
When an the same URN is present in some id/anchor, a reference is created. Otherwise, it falls back to the current logic and a special `URIFetcher` needs to be present.