### PR TITLE
Refactor validation message generation

### DIFF
--- a/doc/cust-msg.md
+++ b/doc/cust-msg.md
@@ -6,7 +6,7 @@ The json schema itself has a place for the customised message.
 ## Examples
 ### Example 1 :
 The custom message can be provided outside properties for each type, as shown in the schema below.
-````json
+```json
 {
   "type": "object",
   "properties": {
@@ -24,10 +24,10 @@ The custom message can be provided outside properties for each type, as shown in
     "type" : "Invalid type"
   }
 }
-````
+```
 ### Example 2 :
 To keep custom messages distinct for each type, one can even give them in each property.
-````json
+```json
 {
   "type": "object",
   "properties": {
@@ -47,14 +47,62 @@ To keep custom messages distinct for each type, one can even give them in each p
     }
   }
 }
-````
+```
+### Example 3 :
+For the keywords `required` and `dependencies`, different messages can be specified for different properties.
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "foo": {
+      "type": "number"
+    },
+    "bar": {
+      "type": "string"
+    }
+  },
+  "required": ["foo", "bar"],
+  "message": {
+    "type" : "should be an object",
+    "required": {
+      "foo" : "'foo' is required",
+      "bar" : "'bar' is required"
+    }
+  }
+}
+```
+### Example 4 :
+The message can use arguments but note that single quotes need to be escaped as `java.text.MessageFormat` will be used to format the message.
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "foo": {
+      "type": "number"
+    },
+    "bar": {
+      "type": "string"
+    }
+  },
+  "required": ["foo", "bar"],
+  "message": {
+    "type" : "should be an object",
+    "required": {
+      "foo" : "{0}: ''foo'' is required",
+      "bar" : "{0}: ''bar'' is required"
+    }
+  }
+}
+```
 
 ## Format
-````json
+```json
 "message": {
     [validationType] : [customMessage]
   }
-````
+```
 Users can express custom message in the **'message'** field. 
 The **'validation type'** should be the key and the **'custom message'** should be the value.
 

--- a/doc/multiple-language.md
+++ b/doc/multiple-language.md
@@ -24,15 +24,47 @@ JsonSchema schema = factory.getSchema(source, config);
 ```
 
 Besides setting the locale and using the default resource bundle, you may also specify your own to cover any languages you
-choose without adapting the library's source, or to override default messages. In doing so you however you should ensure that
-your resource bundle covers all the keys defined by the default bundle. 
+choose without adapting the library's source, or to override default messages. In doing so you however you should ensure that your resource bundle covers all the keys defined by the default bundle. 
 
 ```
-// Set the configuration with a custom resource bundle (you can create this before each validation)
-ResourceBundle myBundle = ResourceBundle.getBundle("my-messages", myLocale);
+// Set the configuration with a custom message source
+MessageSource messageSource = new ResourceBundleMessageSource("my-messages");
 SchemaValidatorsConfig config = new SchemaValidatorsConfig();
-config.setResourceBundle(myBundle);
+config.setMessageSource(messageSource);
 JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909);
 JsonSchema schema = factory.getSchema(source, config);
+...
+```
+
+It is possible to override specific keys from the default resource bundle. Note however that you will need to supply all the languages for that specific key as it will not fallback on the default resource bundle. For instance the jsv-messages-override resource bundle will take precedence when resolving the message key.
+
+```
+// Set the configuration with a custom message source
+MessageSource messageSource = new ResourceBundleMessageSource("jsv-messages-override", DefaultMessageSource.BUNDLE_BASE_NAME);
+SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+config.setMessageSource(messageSource);
+JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909);
+JsonSchema schema = factory.getSchema(source, config);
+...
+```
+
+The following approach can be used to determine the locale to use on a per user basis using a language tag priority list.
+
+```
+SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909);
+JsonSchema schema = factory.getSchema(source, config);
+
+// Uses the fr locale for this user
+Locale locale = Locales.findSupported("it;q=0.9,fr;q=1.0");
+ExecutionContext executionContext = jsonSchema.createExecutionContext();
+executionContext.getExecutionConfig().setLocale(locale);
+Set<ValidationMessage> messages = jsonSchema.validate(executionContext, rootNode);
+
+// Uses the it locale for this user
+locale = Locales.findSupported("it;q=1.0,fr;q=0.9");
+executionContext = jsonSchema.createExecutionContext();
+executionContext.getExecutionConfig().setLocale(locale);
+messages = jsonSchema.validate(executionContext, rootNode);
 ...
 ```

--- a/src/main/java/com/networknt/schema/AdditionalPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/AdditionalPropertiesValidator.java
@@ -97,7 +97,7 @@ public class AdditionalPropertiesValidator extends BaseJsonValidator {
 
             if (!allowedProperties.contains(pname) && !handledByPatternProperties) {
                 if (!allowAdditionalProperties) {
-                    errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), pname));
+                    errors.add(buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale(), pname));
                 } else {
                     if (additionalPropertiesSchema != null) {
                         ValidatorState state = (ValidatorState) collectorContext.get(ValidatorState.VALIDATOR_STATE_KEY);

--- a/src/main/java/com/networknt/schema/AdditionalPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/AdditionalPropertiesValidator.java
@@ -97,7 +97,7 @@ public class AdditionalPropertiesValidator extends BaseJsonValidator {
 
             if (!allowedProperties.contains(pname) && !handledByPatternProperties) {
                 if (!allowAdditionalProperties) {
-                    errors.add(buildValidationMessage(at, pname));
+                    errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), pname));
                 } else {
                     if (additionalPropertiesSchema != null) {
                         ValidatorState state = (ValidatorState) collectorContext.get(ValidatorState.VALIDATOR_STATE_KEY);

--- a/src/main/java/com/networknt/schema/AnyOfValidator.java
+++ b/src/main/java/com/networknt/schema/AnyOfValidator.java
@@ -77,7 +77,8 @@ public class AnyOfValidator extends BaseJsonValidator {
                         //If schema has type validator and node type doesn't match with schemaType then ignore it
                         //For union type, it is a must to call TypeValidator
                         if (typeValidator.getSchemaType() != JsonType.UNION && !typeValidator.equalsToSchemaType(node)) {
-                            allErrors.add(buildValidationMessage(at, typeValidator.getSchemaType().toString()));
+                            allErrors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
+                                    typeValidator.getSchemaType().toString()));
                             continue;
                         }
                     }
@@ -106,7 +107,8 @@ public class AnyOfValidator extends BaseJsonValidator {
                         if (this.discriminatorContext.isDiscriminatorMatchFound()) {
                             if (!errors.isEmpty()) {
                                 allErrors.addAll(errors);
-                                allErrors.add(buildValidationMessage(at, DISCRIMINATOR_REMARK));
+                                allErrors.add(buildValidationMessage(at,
+                                        executionContext.getExecutionConfig().getLocale(), DISCRIMINATOR_REMARK));
                             } else {
                                 // Clear all errors.
                                 allErrors.clear();
@@ -133,7 +135,8 @@ public class AnyOfValidator extends BaseJsonValidator {
 
             if (this.validationContext.getConfig().isOpenAPI3StyleDiscriminators() && this.discriminatorContext.isActive()) {
                 final Set<ValidationMessage> errors = new HashSet<>();
-                errors.add(buildValidationMessage(at, "based on the provided discriminator. No alternative could be chosen based on the discriminator property"));
+                errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
+                        "based on the provided discriminator. No alternative could be chosen based on the discriminator property"));
                 return Collections.unmodifiableSet(errors);
             }
         } finally {

--- a/src/main/java/com/networknt/schema/AnyOfValidator.java
+++ b/src/main/java/com/networknt/schema/AnyOfValidator.java
@@ -77,8 +77,8 @@ public class AnyOfValidator extends BaseJsonValidator {
                         //If schema has type validator and node type doesn't match with schemaType then ignore it
                         //For union type, it is a must to call TypeValidator
                         if (typeValidator.getSchemaType() != JsonType.UNION && !typeValidator.equalsToSchemaType(node)) {
-                            allErrors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
-                                    typeValidator.getSchemaType().toString()));
+                            allErrors.add(buildValidationMessage(null, at,
+                                    executionContext.getExecutionConfig().getLocale(), typeValidator.getSchemaType().toString()));
                             continue;
                         }
                     }
@@ -107,8 +107,8 @@ public class AnyOfValidator extends BaseJsonValidator {
                         if (this.discriminatorContext.isDiscriminatorMatchFound()) {
                             if (!errors.isEmpty()) {
                                 allErrors.addAll(errors);
-                                allErrors.add(buildValidationMessage(at,
-                                        executionContext.getExecutionConfig().getLocale(), DISCRIMINATOR_REMARK));
+                                allErrors.add(buildValidationMessage(null,
+                                        at, executionContext.getExecutionConfig().getLocale(), DISCRIMINATOR_REMARK));
                             } else {
                                 // Clear all errors.
                                 allErrors.clear();
@@ -135,8 +135,8 @@ public class AnyOfValidator extends BaseJsonValidator {
 
             if (this.validationContext.getConfig().isOpenAPI3StyleDiscriminators() && this.discriminatorContext.isActive()) {
                 final Set<ValidationMessage> errors = new HashSet<>();
-                errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
-                        "based on the provided discriminator. No alternative could be chosen based on the discriminator property"));
+                errors.add(buildValidationMessage(null, at,
+                        executionContext.getExecutionConfig().getLocale(), "based on the provided discriminator. No alternative could be chosen based on the discriminator property"));
                 return Collections.unmodifiableSet(errors);
             }
         } finally {

--- a/src/main/java/com/networknt/schema/BaseJsonValidator.java
+++ b/src/main/java/com/networknt/schema/BaseJsonValidator.java
@@ -19,6 +19,8 @@ package com.networknt.schema;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.networknt.schema.ValidationContext.DiscriminatorContext;
+import com.networknt.schema.i18n.DefaultMessageSource;
+
 import org.slf4j.Logger;
 
 import java.net.URI;
@@ -47,7 +49,7 @@ public abstract class BaseJsonValidator extends ValidationMessageHandler impleme
                              ValidatorTypeCode validatorType,
                              ValidationContext validationContext,
                              boolean suppressSubSchemaRetrieval) {
-        super(validationContext != null && validationContext.getConfig() != null && validationContext.getConfig().isFailFast(), validatorType, validatorType != null ? validatorType.getCustomMessage() : null, (validationContext != null && validationContext.getConfig() != null) ? validationContext.getConfig().getResourceBundle() : I18nSupport.DEFAULT_RESOURCE_BUNDLE, validatorType, parentSchema, schemaPath);
+        super(validationContext != null && validationContext.getConfig() != null && validationContext.getConfig().isFailFast(), validatorType, validatorType != null ? validatorType.getCustomMessage() : null, (validationContext != null && validationContext.getConfig() != null) ? validationContext.getConfig().getMessageSource() : DefaultMessageSource.getInstance(), validatorType, parentSchema, schemaPath);
         this.schemaNode = schemaNode;
         this.suppressSubSchemaRetrieval = suppressSubSchemaRetrieval;
         this.applyDefaultsStrategy = (validationContext != null && validationContext.getConfig() != null && validationContext.getConfig().getApplyDefaultsStrategy() != null) ? validationContext.getConfig().getApplyDefaultsStrategy() : ApplyDefaultsStrategy.EMPTY_APPLY_DEFAULTS_STRATEGY;

--- a/src/main/java/com/networknt/schema/ConstValidator.java
+++ b/src/main/java/com/networknt/schema/ConstValidator.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class ConstValidator extends BaseJsonValidator implements JsonValidator {
@@ -35,14 +34,15 @@ public class ConstValidator extends BaseJsonValidator implements JsonValidator {
     public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
         if (schemaNode.isNumber() && node.isNumber()) {
             if (schemaNode.decimalValue().compareTo(node.decimalValue()) != 0) {
-                errors.add(buildValidationMessage(at, schemaNode.asText()));
+                return Collections.singleton(buildValidationMessage(at,
+                        executionContext.getExecutionConfig().getLocale(), schemaNode.asText()));
             }
         } else if (!schemaNode.equals(node)) {
-            errors.add(buildValidationMessage(at, schemaNode.asText()));
+            return Collections.singleton(
+                    buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), schemaNode.asText()));
         }
-        return Collections.unmodifiableSet(errors);
+        return Collections.emptySet();
     }
 }

--- a/src/main/java/com/networknt/schema/ConstValidator.java
+++ b/src/main/java/com/networknt/schema/ConstValidator.java
@@ -36,12 +36,12 @@ public class ConstValidator extends BaseJsonValidator implements JsonValidator {
 
         if (schemaNode.isNumber() && node.isNumber()) {
             if (schemaNode.decimalValue().compareTo(node.decimalValue()) != 0) {
-                return Collections.singleton(buildValidationMessage(at,
-                        executionContext.getExecutionConfig().getLocale(), schemaNode.asText()));
+                return Collections.singleton(buildValidationMessage(null,
+                        at, executionContext.getExecutionConfig().getLocale(), schemaNode.asText()));
             }
         } else if (!schemaNode.equals(node)) {
             return Collections.singleton(
-                    buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), schemaNode.asText()));
+                    buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale(), schemaNode.asText()));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/ContainsValidator.java
+++ b/src/main/java/com/networknt/schema/ContainsValidator.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
@@ -89,14 +90,16 @@ public class ContainsValidator extends BaseJsonValidator {
                 if(isMinV201909) {
                     updateValidatorType(ValidatorTypeCode.MIN_CONTAINS);
                 }
-                return boundsViolated(isMinV201909 ? CONTAINS_MIN : ValidatorTypeCode.CONTAINS.getValue(), at, this.min);
+                return boundsViolated(isMinV201909 ? CONTAINS_MIN : ValidatorTypeCode.CONTAINS.getValue(),
+                        executionContext.getExecutionConfig().getLocale(), at, this.min);
             }
 
             if (actual > this.max) {
                 if(isMinV201909) {
                     updateValidatorType(ValidatorTypeCode.MAX_CONTAINS);
                 }
-                return boundsViolated(isMinV201909 ? CONTAINS_MAX : ValidatorTypeCode.CONTAINS.getValue(), at, this.max);
+                return boundsViolated(isMinV201909 ? CONTAINS_MAX : ValidatorTypeCode.CONTAINS.getValue(),
+                        executionContext.getExecutionConfig().getLocale(), at, this.max);
             }
         }
 
@@ -108,7 +111,7 @@ public class ContainsValidator extends BaseJsonValidator {
         Optional.ofNullable(this.schema).ifPresent(JsonSchema::initializeValidators);
     }
 
-    private Set<ValidationMessage> boundsViolated(String messageKey, String at, int bounds) {
-        return Collections.singleton(constructValidationMessage(messageKey, at, String.valueOf(bounds), this.schema.getSchemaNode().toString()));
+    private Set<ValidationMessage> boundsViolated(String messageKey, Locale locale, String at, int bounds) {
+        return Collections.singleton(buildValidationMessage(at, messageKey, locale, String.valueOf(bounds), this.schema.getSchemaNode().toString()));
     }
 }

--- a/src/main/java/com/networknt/schema/ContainsValidator.java
+++ b/src/main/java/com/networknt/schema/ContainsValidator.java
@@ -112,6 +112,6 @@ public class ContainsValidator extends BaseJsonValidator {
     }
 
     private Set<ValidationMessage> boundsViolated(String messageKey, Locale locale, String at, int bounds) {
-        return Collections.singleton(buildValidationMessage(at, messageKey, locale, String.valueOf(bounds), this.schema.getSchemaNode().toString()));
+        return Collections.singleton(buildValidationMessage(null, at, messageKey, locale, String.valueOf(bounds), this.schema.getSchemaNode().toString()));
     }
 }

--- a/src/main/java/com/networknt/schema/DependenciesValidator.java
+++ b/src/main/java/com/networknt/schema/DependenciesValidator.java
@@ -62,8 +62,8 @@ public class DependenciesValidator extends BaseJsonValidator implements JsonVali
             if (deps != null && !deps.isEmpty()) {
                 for (String field : deps) {
                     if (node.get(field) == null) {
-                        errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
-                                propertyDeps.toString()));
+                        errors.add(buildValidationMessage(pname, at,
+                                executionContext.getExecutionConfig().getLocale(), propertyDeps.toString()));
                     }
                 }
             }

--- a/src/main/java/com/networknt/schema/DependenciesValidator.java
+++ b/src/main/java/com/networknt/schema/DependenciesValidator.java
@@ -62,7 +62,8 @@ public class DependenciesValidator extends BaseJsonValidator implements JsonVali
             if (deps != null && !deps.isEmpty()) {
                 for (String field : deps) {
                     if (node.get(field) == null) {
-                        errors.add(buildValidationMessage(at, propertyDeps.toString()));
+                        errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
+                                propertyDeps.toString()));
                     }
                 }
             }

--- a/src/main/java/com/networknt/schema/DependentRequired.java
+++ b/src/main/java/com/networknt/schema/DependentRequired.java
@@ -56,7 +56,8 @@ public class DependentRequired extends BaseJsonValidator implements JsonValidato
             if (dependencies != null && !dependencies.isEmpty()) {
                 for (String field : dependencies) {
                     if (node.get(field) == null) {
-                        errors.add(buildValidationMessage(at, field, pname));
+                        errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), field,
+                                pname));
                     }
                 }
             }

--- a/src/main/java/com/networknt/schema/DependentRequired.java
+++ b/src/main/java/com/networknt/schema/DependentRequired.java
@@ -56,8 +56,8 @@ public class DependentRequired extends BaseJsonValidator implements JsonValidato
             if (dependencies != null && !dependencies.isEmpty()) {
                 for (String field : dependencies) {
                     if (node.get(field) == null) {
-                        errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), field,
-                                pname));
+                        errors.add(buildValidationMessage(pname, at, executionContext.getExecutionConfig().getLocale(),
+                                field, pname));
                     }
                 }
             }

--- a/src/main/java/com/networknt/schema/EnumValidator.java
+++ b/src/main/java/com/networknt/schema/EnumValidator.java
@@ -82,7 +82,7 @@ public class EnumValidator extends BaseJsonValidator implements JsonValidator {
 
         if (node.isNumber()) node = DecimalNode.valueOf(node.decimalValue());
         if (!nodes.contains(node) && !( this.validationContext.getConfig().isTypeLoose() && isTypeLooseContainsInEnum(node))) {
-            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), error));
+            return Collections.singleton(buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale(), error));
         }
 
         return Collections.emptySet();

--- a/src/main/java/com/networknt/schema/EnumValidator.java
+++ b/src/main/java/com/networknt/schema/EnumValidator.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class EnumValidator extends BaseJsonValidator implements JsonValidator {
@@ -81,13 +80,12 @@ public class EnumValidator extends BaseJsonValidator implements JsonValidator {
     public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
         if (node.isNumber()) node = DecimalNode.valueOf(node.decimalValue());
         if (!nodes.contains(node) && !( this.validationContext.getConfig().isTypeLoose() && isTypeLooseContainsInEnum(node))) {
-            errors.add(buildValidationMessage(at, error));
+            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), error));
         }
 
-        return Collections.unmodifiableSet(errors);
+        return Collections.emptySet();
     }
 
     /**

--- a/src/main/java/com/networknt/schema/ErrorMessageType.java
+++ b/src/main/java/com/networknt/schema/ErrorMessageType.java
@@ -16,6 +16,8 @@
 
 package com.networknt.schema;
 
+import java.util.Map;
+
 public interface ErrorMessageType {
     /**
      * Your error code. Please ensure global uniqueness. Builtin error codes are sequential numbers.
@@ -26,7 +28,7 @@ public interface ErrorMessageType {
      */
     String getErrorCode();
 
-    default String getCustomMessage() {
+    default Map<String, String> getCustomMessage() {
         return null;
     }
 

--- a/src/main/java/com/networknt/schema/ExclusiveMaximumValidator.java
+++ b/src/main/java/com/networknt/schema/ExclusiveMaximumValidator.java
@@ -107,8 +107,8 @@ public class ExclusiveMaximumValidator extends BaseJsonValidator {
         }
 
         if (typedMaximum.crossesThreshold(node)) {
-            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
-                    typedMaximum.thresholdValue()));
+            return Collections.singleton(buildValidationMessage(null, at,
+                    executionContext.getExecutionConfig().getLocale(), typedMaximum.thresholdValue()));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/ExclusiveMaximumValidator.java
+++ b/src/main/java/com/networknt/schema/ExclusiveMaximumValidator.java
@@ -107,7 +107,8 @@ public class ExclusiveMaximumValidator extends BaseJsonValidator {
         }
 
         if (typedMaximum.crossesThreshold(node)) {
-            return Collections.singleton(buildValidationMessage(at, typedMaximum.thresholdValue()));
+            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
+                    typedMaximum.thresholdValue()));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/ExclusiveMinimumValidator.java
+++ b/src/main/java/com/networknt/schema/ExclusiveMinimumValidator.java
@@ -114,8 +114,8 @@ public class ExclusiveMinimumValidator extends BaseJsonValidator {
         }
 
         if (typedMinimum.crossesThreshold(node)) {
-            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
-                    typedMinimum.thresholdValue()));
+            return Collections.singleton(buildValidationMessage(null, at,
+                    executionContext.getExecutionConfig().getLocale(), typedMinimum.thresholdValue()));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/ExclusiveMinimumValidator.java
+++ b/src/main/java/com/networknt/schema/ExclusiveMinimumValidator.java
@@ -114,7 +114,8 @@ public class ExclusiveMinimumValidator extends BaseJsonValidator {
         }
 
         if (typedMinimum.crossesThreshold(node)) {
-            return Collections.singleton(buildValidationMessage(at, typedMinimum.thresholdValue()));
+            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
+                    typedMinimum.thresholdValue()));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/ExecutionConfig.java
+++ b/src/main/java/com/networknt/schema/ExecutionConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.networknt.schema;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Configuration per execution.
+ */
+public class ExecutionConfig {
+    private Locale locale = Locale.ROOT;
+
+    public Locale getLocale() {
+        return locale;
+    }
+
+    public void setLocale(Locale locale) {
+        this.locale = Objects.requireNonNull(locale, "Locale must not be null");
+    }
+
+}

--- a/src/main/java/com/networknt/schema/ExecutionContext.java
+++ b/src/main/java/com/networknt/schema/ExecutionContext.java
@@ -20,6 +20,7 @@ package com.networknt.schema;
  * Stores the execution context for the validation run.
  */
 public class ExecutionContext {
+    private ExecutionConfig executionConfig;
     private CollectorContext collectorContext;
 
     public ExecutionContext() {
@@ -27,7 +28,16 @@ public class ExecutionContext {
     }
 
     public ExecutionContext(CollectorContext collectorContext) {
+        this(new ExecutionConfig(), collectorContext);
+    }
+    
+    public ExecutionContext(ExecutionConfig executionConfig) {
+        this(executionConfig, new CollectorContext());
+    }
+    
+    public ExecutionContext(ExecutionConfig executionConfig, CollectorContext collectorContext) {
         this.collectorContext = collectorContext;
+        this.executionConfig = executionConfig;
     }
 
     public CollectorContext getCollectorContext() {
@@ -36,5 +46,13 @@ public class ExecutionContext {
 
     public void setCollectorContext(CollectorContext collectorContext) {
         this.collectorContext = collectorContext;
+    }
+
+    public ExecutionConfig getExecutionConfig() {
+        return executionConfig;
+    }
+
+    public void setExecutionConfig(ExecutionConfig executionConfig) {
+        this.executionConfig = executionConfig;
     }
 }

--- a/src/main/java/com/networknt/schema/FalseValidator.java
+++ b/src/main/java/com/networknt/schema/FalseValidator.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class FalseValidator extends BaseJsonValidator implements JsonValidator {
@@ -33,8 +32,6 @@ public class FalseValidator extends BaseJsonValidator implements JsonValidator {
     public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
         // For the false validator, it is always not valid
-        Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
-        errors.add(buildValidationMessage(at));
-        return Collections.unmodifiableSet(errors);
+        return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale()));
     }
 }

--- a/src/main/java/com/networknt/schema/FalseValidator.java
+++ b/src/main/java/com/networknt/schema/FalseValidator.java
@@ -32,6 +32,6 @@ public class FalseValidator extends BaseJsonValidator implements JsonValidator {
     public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
         // For the false validator, it is always not valid
-        return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale()));
+        return Collections.singleton(buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale()));
     }
 }

--- a/src/main/java/com/networknt/schema/FormatKeyword.java
+++ b/src/main/java/com/networknt/schema/FormatKeyword.java
@@ -73,7 +73,7 @@ public class FormatKeyword implements Keyword {
     }
 
     @Override
-    public void setCustomMessage(String message) {
+    public void setCustomMessage(Map<String, String> message) {
         this.type.setCustomMessage(message);
     }
 }

--- a/src/main/java/com/networknt/schema/FormatValidator.java
+++ b/src/main/java/com/networknt/schema/FormatValidator.java
@@ -50,18 +50,18 @@ public class FormatValidator extends BaseJsonValidator implements JsonValidator 
             if(format.getName().equals("ipv6")) {
                 if(!node.textValue().trim().equals(node.textValue())) {
                     // leading and trailing spaces
-                    errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
-                            format.getName(), format.getErrorMessageDescription()));
+                    errors.add(buildValidationMessage(null, at,
+                            executionContext.getExecutionConfig().getLocale(), format.getName(), format.getErrorMessageDescription()));
                 } else if(node.textValue().contains("%")) {
                     // zone id is not part of the ipv6
-                    errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
-                            format.getName(), format.getErrorMessageDescription()));
+                    errors.add(buildValidationMessage(null, at,
+                            executionContext.getExecutionConfig().getLocale(), format.getName(), format.getErrorMessageDescription()));
                 }
             }
             try {
                 if (!format.matches(executionContext, node.textValue())) {
-                    errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
-                            format.getName(), format.getErrorMessageDescription()));
+                    errors.add(buildValidationMessage(null, at,
+                            executionContext.getExecutionConfig().getLocale(), format.getName(), format.getErrorMessageDescription()));
                 }
             } catch (PatternSyntaxException pse) {
                 // String is considered valid if pattern is invalid

--- a/src/main/java/com/networknt/schema/FormatValidator.java
+++ b/src/main/java/com/networknt/schema/FormatValidator.java
@@ -40,26 +40,28 @@ public class FormatValidator extends BaseJsonValidator implements JsonValidator 
     public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new LinkedHashSet<ValidationMessage>();
-
         JsonType nodeType = TypeFactory.getValueNodeType(node, this.validationContext.getConfig());
         if (nodeType != JsonType.STRING) {
-            return errors;
+            return Collections.emptySet();
         }
 
+        Set<ValidationMessage> errors = new LinkedHashSet<>();
         if (format != null) {
             if(format.getName().equals("ipv6")) {
                 if(!node.textValue().trim().equals(node.textValue())) {
                     // leading and trailing spaces
-                    errors.add(buildValidationMessage(at, format.getName(), format.getErrorMessageDescription()));
+                    errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
+                            format.getName(), format.getErrorMessageDescription()));
                 } else if(node.textValue().contains("%")) {
                     // zone id is not part of the ipv6
-                    errors.add(buildValidationMessage(at, format.getName(), format.getErrorMessageDescription()));
+                    errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
+                            format.getName(), format.getErrorMessageDescription()));
                 }
             }
             try {
                 if (!format.matches(executionContext, node.textValue())) {
-                    errors.add(buildValidationMessage(at, format.getName(), format.getErrorMessageDescription()));
+                    errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
+                            format.getName(), format.getErrorMessageDescription()));
                 }
             } catch (PatternSyntaxException pse) {
                 // String is considered valid if pattern is invalid

--- a/src/main/java/com/networknt/schema/I18nSupport.java
+++ b/src/main/java/com/networknt/schema/I18nSupport.java
@@ -8,6 +8,7 @@ import java.util.ResourceBundle;
  *
  * @author leaves chen leaves615@gmail.com
  */
+@Deprecated
 public class I18nSupport {
 
     public static final String DEFAULT_BUNDLE_BASE_NAME = "jsv-messages";

--- a/src/main/java/com/networknt/schema/ItemsValidator.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator.java
@@ -128,7 +128,7 @@ public class ItemsValidator extends BaseJsonValidator {
                     } else {
                         // no additional item allowed, return error
                         errors.add(
-                                buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + i));
+                                buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale(), "" + i));
                     }
                 }
             }

--- a/src/main/java/com/networknt/schema/ItemsValidator.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator.java
@@ -127,7 +127,8 @@ public class ItemsValidator extends BaseJsonValidator {
                         evaluatedItems.add(path);
                     } else {
                         // no additional item allowed, return error
-                        errors.add(buildValidationMessage(at, "" + i));
+                        errors.add(
+                                buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + i));
                     }
                 }
             }

--- a/src/main/java/com/networknt/schema/JsonMetaSchema.java
+++ b/src/main/java/com/networknt/schema/JsonMetaSchema.java
@@ -264,7 +264,7 @@ public class JsonMetaSchema {
     }
 
     public JsonValidator newValidator(ValidationContext validationContext, String schemaPath, String keyword /* keyword */, JsonNode schemaNode,
-                                      JsonSchema parentSchema, String customMessage) {
+                                      JsonSchema parentSchema, Map<String, String> customMessage) {
 
         try {
             Keyword kw = this.keywords.get(keyword);

--- a/src/main/java/com/networknt/schema/Keyword.java
+++ b/src/main/java/com/networknt/schema/Keyword.java
@@ -17,12 +17,14 @@
 package com.networknt.schema;
 
 
+import java.util.Map;
+
 import com.fasterxml.jackson.databind.JsonNode;
 
 public interface Keyword {
     String getValue();
 
-    default void setCustomMessage(String message) {
+    default void setCustomMessage(Map<String, String> message) {
         //setCustom message
     }
 

--- a/src/main/java/com/networknt/schema/MaxItemsValidator.java
+++ b/src/main/java/com/networknt/schema/MaxItemsValidator.java
@@ -44,11 +44,11 @@ public class MaxItemsValidator extends BaseJsonValidator implements JsonValidato
 
         if (node.isArray()) {
             if (node.size() > max) {
-                return Collections.singleton(buildValidationMessage(at, "" + max));
+                return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + max));
             }
         } else if (this.validationContext.getConfig().isTypeLoose()) {
             if (1 > max) {
-                return Collections.singleton(buildValidationMessage(at, "" + max));
+                return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + max));
             }
         }
 

--- a/src/main/java/com/networknt/schema/MaxItemsValidator.java
+++ b/src/main/java/com/networknt/schema/MaxItemsValidator.java
@@ -44,11 +44,11 @@ public class MaxItemsValidator extends BaseJsonValidator implements JsonValidato
 
         if (node.isArray()) {
             if (node.size() > max) {
-                return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + max));
+                return Collections.singleton(buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale(), "" + max));
             }
         } else if (this.validationContext.getConfig().isTypeLoose()) {
             if (1 > max) {
-                return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + max));
+                return Collections.singleton(buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale(), "" + max));
             }
         }
 

--- a/src/main/java/com/networknt/schema/MaxLengthValidator.java
+++ b/src/main/java/com/networknt/schema/MaxLengthValidator.java
@@ -47,7 +47,8 @@ public class MaxLengthValidator extends BaseJsonValidator implements JsonValidat
             return Collections.emptySet();
         }
         if (node.textValue().codePointCount(0, node.textValue().length()) > maxLength) {
-            return Collections.singleton(buildValidationMessage(at, "" + maxLength));
+            return Collections.singleton(
+                    buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + maxLength));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/MaxLengthValidator.java
+++ b/src/main/java/com/networknt/schema/MaxLengthValidator.java
@@ -48,7 +48,7 @@ public class MaxLengthValidator extends BaseJsonValidator implements JsonValidat
         }
         if (node.textValue().codePointCount(0, node.textValue().length()) > maxLength) {
             return Collections.singleton(
-                    buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + maxLength));
+                    buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale(), "" + maxLength));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/MaxPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/MaxPropertiesValidator.java
@@ -43,7 +43,8 @@ public class MaxPropertiesValidator extends BaseJsonValidator implements JsonVal
 
         if (node.isObject()) {
             if (node.size() > max) {
-                return Collections.singleton(buildValidationMessage(at, "" + max));
+                return Collections.singleton(
+                        buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + max));
             }
         }
 

--- a/src/main/java/com/networknt/schema/MaxPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/MaxPropertiesValidator.java
@@ -44,7 +44,7 @@ public class MaxPropertiesValidator extends BaseJsonValidator implements JsonVal
         if (node.isObject()) {
             if (node.size() > max) {
                 return Collections.singleton(
-                        buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + max));
+                        buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale(), "" + max));
             }
         }
 

--- a/src/main/java/com/networknt/schema/MaximumValidator.java
+++ b/src/main/java/com/networknt/schema/MaximumValidator.java
@@ -116,8 +116,8 @@ public class MaximumValidator extends BaseJsonValidator {
         }
 
         if (typedMaximum.crossesThreshold(node)) {
-            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
-                    typedMaximum.thresholdValue()));
+            return Collections.singleton(buildValidationMessage(null, at,
+                    executionContext.getExecutionConfig().getLocale(), typedMaximum.thresholdValue()));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/MaximumValidator.java
+++ b/src/main/java/com/networknt/schema/MaximumValidator.java
@@ -116,7 +116,8 @@ public class MaximumValidator extends BaseJsonValidator {
         }
 
         if (typedMaximum.crossesThreshold(node)) {
-            return Collections.singleton(buildValidationMessage(at, typedMaximum.thresholdValue()));
+            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
+                    typedMaximum.thresholdValue()));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/MinItemsValidator.java
+++ b/src/main/java/com/networknt/schema/MinItemsValidator.java
@@ -43,12 +43,12 @@ public class MinItemsValidator extends BaseJsonValidator implements JsonValidato
         if (node.isArray()) {
             if (node.size() < min) {
                 return Collections.singleton(
-                        buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + min));
+                        buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale(), "" + min));
             }
         } else if (this.validationContext.getConfig().isTypeLoose()) {
             if (1 < min) {
                 return Collections.singleton(
-                        buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + min));
+                        buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale(), "" + min));
             }
         }
 

--- a/src/main/java/com/networknt/schema/MinItemsValidator.java
+++ b/src/main/java/com/networknt/schema/MinItemsValidator.java
@@ -42,11 +42,13 @@ public class MinItemsValidator extends BaseJsonValidator implements JsonValidato
 
         if (node.isArray()) {
             if (node.size() < min) {
-                return Collections.singleton(buildValidationMessage(at, "" + min));
+                return Collections.singleton(
+                        buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + min));
             }
         } else if (this.validationContext.getConfig().isTypeLoose()) {
             if (1 < min) {
-                return Collections.singleton(buildValidationMessage(at, "" + min));
+                return Collections.singleton(
+                        buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + min));
             }
         }
 

--- a/src/main/java/com/networknt/schema/MinLengthValidator.java
+++ b/src/main/java/com/networknt/schema/MinLengthValidator.java
@@ -48,7 +48,8 @@ public class MinLengthValidator extends BaseJsonValidator implements JsonValidat
         }
 
         if (node.textValue().codePointCount(0, node.textValue().length()) < minLength) {
-            return Collections.singleton(buildValidationMessage(at, "" + minLength));
+            return Collections.singleton(
+                    buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + minLength));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/MinLengthValidator.java
+++ b/src/main/java/com/networknt/schema/MinLengthValidator.java
@@ -49,7 +49,7 @@ public class MinLengthValidator extends BaseJsonValidator implements JsonValidat
 
         if (node.textValue().codePointCount(0, node.textValue().length()) < minLength) {
             return Collections.singleton(
-                    buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + minLength));
+                    buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale(), "" + minLength));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/MinMaxContainsValidator.java
+++ b/src/main/java/com/networknt/schema/MinMaxContainsValidator.java
@@ -62,8 +62,8 @@ public class MinMaxContainsValidator extends BaseJsonValidator {
     public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             String at) {
         return this.analysis != null ? this.analysis.stream()
-                .map(analysis -> buildValidationMessage(analysis.getAt(), analysis.getMessageKey(),
-                        executionContext.getExecutionConfig().getLocale(), parentSchema.getSchemaNode().toString()))
+                .map(analysis -> buildValidationMessage(null, analysis.getAt(),
+                        analysis.getMessageKey(), executionContext.getExecutionConfig().getLocale(), parentSchema.getSchemaNode().toString()))
                 .collect(Collectors.toCollection(LinkedHashSet::new)) : Collections.emptySet();
     }
     

--- a/src/main/java/com/networknt/schema/MinMaxContainsValidator.java
+++ b/src/main/java/com/networknt/schema/MinMaxContainsValidator.java
@@ -2,8 +2,10 @@ package com.networknt.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Tests the validity of {@literal maxContains} and {@literal minContains} in a schema.
@@ -13,18 +15,23 @@ import java.util.Set;
  * and {@literal minContains} constraints exists within {@code ContainsValidator}.
  */
 public class MinMaxContainsValidator extends BaseJsonValidator {
-    private final Set<ValidationMessage> analysis = new LinkedHashSet<>();
+    private final Set<Analysis> analysis;
 
-    public MinMaxContainsValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
+    public MinMaxContainsValidator(String schemaPath, JsonNode schemaNode, JsonSchema parentSchema,
+            ValidationContext validationContext) {
         super(schemaPath, schemaNode, parentSchema, ValidatorTypeCode.MAX_CONTAINS, validationContext);
 
+        Set<Analysis> analysis = null;
         int min = 1;
         int max = Integer.MAX_VALUE;
 
         JsonNode minNode = parentSchema.getSchemaNode().get("minContains");
         if (null != minNode) {
             if (!minNode.isNumber() || !minNode.canConvertToExactIntegral() || minNode.intValue() < 0) {
-                report("minContains", schemaPath);
+                if (analysis == null) {
+                    analysis = new LinkedHashSet<>();
+                }
+                analysis.add(new Analysis("minContains", schemaPath));
             } else {
                 min = minNode.intValue();
             }
@@ -33,24 +40,49 @@ public class MinMaxContainsValidator extends BaseJsonValidator {
         JsonNode maxNode = parentSchema.getSchemaNode().get("maxContains");
         if (null != maxNode) {
             if (!maxNode.isNumber() || !maxNode.canConvertToExactIntegral() || maxNode.intValue() < 0) {
-                report("maxContains", schemaPath);
+                if (analysis == null) {
+                    analysis = new LinkedHashSet<>();
+                }
+                analysis.add(new Analysis("maxContains", schemaPath));
             } else {
                 max = maxNode.intValue();
             }
         }
 
         if (max < min) {
-            report("minContainsVsMaxContains", schemaPath);
+            if (analysis == null) {
+                analysis = new LinkedHashSet<>();
+            }
+            analysis.add(new Analysis("minContainsVsMaxContains", schemaPath));
         }
-    }
-
-    private void report(String messageKey, String at) {
-        this.analysis.add(constructValidationMessage(messageKey, at, parentSchema.getSchemaNode().toString()));
+        this.analysis = analysis;
     }
 
     @Override
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, String at) {
-        return this.analysis;
+    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+            String at) {
+        return this.analysis != null ? this.analysis.stream()
+                .map(analysis -> buildValidationMessage(analysis.getAt(), analysis.getMessageKey(),
+                        executionContext.getExecutionConfig().getLocale(), parentSchema.getSchemaNode().toString()))
+                .collect(Collectors.toCollection(LinkedHashSet::new)) : Collections.emptySet();
     }
+    
+    public static class Analysis {
+        public String getMessageKey() {
+            return messageKey;
+        }
 
+        public String getAt() {
+            return at;
+        }
+
+        private final String messageKey;
+        private final String at;
+
+        public Analysis(String messageKey, String at) {
+            super();
+            this.messageKey = messageKey;
+            this.at = at;
+        }
+    }
 }

--- a/src/main/java/com/networknt/schema/MinPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/MinPropertiesValidator.java
@@ -43,7 +43,8 @@ public class MinPropertiesValidator extends BaseJsonValidator implements JsonVal
 
         if (node.isObject()) {
             if (node.size() < min) {
-                return Collections.singleton(buildValidationMessage(at, "" + min));
+                return Collections.singleton(
+                        buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + min));
             }
         }
 

--- a/src/main/java/com/networknt/schema/MinPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/MinPropertiesValidator.java
@@ -44,7 +44,7 @@ public class MinPropertiesValidator extends BaseJsonValidator implements JsonVal
         if (node.isObject()) {
             if (node.size() < min) {
                 return Collections.singleton(
-                        buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), "" + min));
+                        buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale(), "" + min));
             }
         }
 

--- a/src/main/java/com/networknt/schema/MinimumValidator.java
+++ b/src/main/java/com/networknt/schema/MinimumValidator.java
@@ -123,7 +123,8 @@ public class MinimumValidator extends BaseJsonValidator {
         }
 
         if (typedMinimum.crossesThreshold(node)) {
-            return Collections.singleton(buildValidationMessage(at, typedMinimum.thresholdValue()));
+            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
+                    typedMinimum.thresholdValue()));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/MinimumValidator.java
+++ b/src/main/java/com/networknt/schema/MinimumValidator.java
@@ -123,8 +123,8 @@ public class MinimumValidator extends BaseJsonValidator {
         }
 
         if (typedMinimum.crossesThreshold(node)) {
-            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
-                    typedMinimum.thresholdValue()));
+            return Collections.singleton(buildValidationMessage(null, at,
+                    executionContext.getExecutionConfig().getLocale(), typedMinimum.thresholdValue()));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/MultipleOfValidator.java
+++ b/src/main/java/com/networknt/schema/MultipleOfValidator.java
@@ -49,8 +49,8 @@ public class MultipleOfValidator extends BaseJsonValidator implements JsonValida
                 BigDecimal accurateDividend = node.isBigDecimal() ? node.decimalValue() : new BigDecimal(String.valueOf(nodeValue));
                 BigDecimal accurateDivisor = new BigDecimal(String.valueOf(divisor));
                 if (accurateDividend.divideAndRemainder(accurateDivisor)[1].abs().compareTo(BigDecimal.ZERO) > 0) {
-                    return Collections.singleton(buildValidationMessage(at,
-                            executionContext.getExecutionConfig().getLocale(), "" + divisor));
+                    return Collections.singleton(buildValidationMessage(null,
+                            at, executionContext.getExecutionConfig().getLocale(), "" + divisor));
                 }
             }
         }

--- a/src/main/java/com/networknt/schema/MultipleOfValidator.java
+++ b/src/main/java/com/networknt/schema/MultipleOfValidator.java
@@ -49,7 +49,8 @@ public class MultipleOfValidator extends BaseJsonValidator implements JsonValida
                 BigDecimal accurateDividend = node.isBigDecimal() ? node.decimalValue() : new BigDecimal(String.valueOf(nodeValue));
                 BigDecimal accurateDivisor = new BigDecimal(String.valueOf(divisor));
                 if (accurateDividend.divideAndRemainder(accurateDivisor)[1].abs().compareTo(BigDecimal.ZERO) > 0) {
-                    return Collections.singleton(buildValidationMessage(at, "" + divisor));
+                    return Collections.singleton(buildValidationMessage(at,
+                            executionContext.getExecutionConfig().getLocale(), "" + divisor));
                 }
             }
         }

--- a/src/main/java/com/networknt/schema/NotAllowedValidator.java
+++ b/src/main/java/com/networknt/schema/NotAllowedValidator.java
@@ -49,7 +49,7 @@ public class NotAllowedValidator extends BaseJsonValidator implements JsonValida
             JsonNode propertyNode = node.get(fieldName);
 
             if (propertyNode != null) {
-                errors.add(buildValidationMessage(at, fieldName));
+                errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), fieldName));
             }
         }
 

--- a/src/main/java/com/networknt/schema/NotAllowedValidator.java
+++ b/src/main/java/com/networknt/schema/NotAllowedValidator.java
@@ -49,7 +49,7 @@ public class NotAllowedValidator extends BaseJsonValidator implements JsonValida
             JsonNode propertyNode = node.get(fieldName);
 
             if (propertyNode != null) {
-                errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), fieldName));
+                errors.add(buildValidationMessage(fieldName, at, executionContext.getExecutionConfig().getLocale(), fieldName));
             }
         }
 

--- a/src/main/java/com/networknt/schema/NotValidator.java
+++ b/src/main/java/com/networknt/schema/NotValidator.java
@@ -46,8 +46,8 @@ public class NotValidator extends BaseJsonValidator {
             debug(logger, node, rootNode, at);
             errors = this.schema.validate(executionContext, node, rootNode, at);
             if (errors.isEmpty()) {
-                return Collections.singleton(buildValidationMessage(at,
-                        executionContext.getExecutionConfig().getLocale(), this.schema.toString()));
+                return Collections.singleton(buildValidationMessage(null,
+                        at, executionContext.getExecutionConfig().getLocale(), this.schema.toString()));
             }
             return Collections.emptySet();
         } finally {
@@ -66,8 +66,8 @@ public class NotValidator extends BaseJsonValidator {
 
         Set<ValidationMessage> errors = this.schema.walk(executionContext, node, rootNode, at, shouldValidateSchema);
         if (errors.isEmpty()) {
-            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
-                    this.schema.toString()));
+            return Collections.singleton(buildValidationMessage(null, at,
+                    executionContext.getExecutionConfig().getLocale(), this.schema.toString()));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/NotValidator.java
+++ b/src/main/java/com/networknt/schema/NotValidator.java
@@ -46,7 +46,8 @@ public class NotValidator extends BaseJsonValidator {
             debug(logger, node, rootNode, at);
             errors = this.schema.validate(executionContext, node, rootNode, at);
             if (errors.isEmpty()) {
-                return Collections.singleton(buildValidationMessage(at, this.schema.toString()));
+                return Collections.singleton(buildValidationMessage(at,
+                        executionContext.getExecutionConfig().getLocale(), this.schema.toString()));
             }
             return Collections.emptySet();
         } finally {
@@ -65,7 +66,8 @@ public class NotValidator extends BaseJsonValidator {
 
         Set<ValidationMessage> errors = this.schema.walk(executionContext, node, rootNode, at, shouldValidateSchema);
         if (errors.isEmpty()) {
-            return Collections.singleton(buildValidationMessage(at, this.schema.toString()));
+            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
+                    this.schema.toString()));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/OneOfValidator.java
+++ b/src/main/java/com/networknt/schema/OneOfValidator.java
@@ -95,7 +95,8 @@ public class OneOfValidator extends BaseJsonValidator {
 
             // ensure there is always an "OneOf" error reported if number of valid schemas is not equal to 1.
             if (numberOfValidSchema != 1) {
-                ValidationMessage message = buildValidationMessage(at, Integer.toString(numberOfValidSchema));
+                ValidationMessage message = buildValidationMessage(at,
+                        executionContext.getExecutionConfig().getLocale(), Integer.toString(numberOfValidSchema));
                 if (this.failFast) {
                     throw new JsonSchemaException(message);
                 }

--- a/src/main/java/com/networknt/schema/OneOfValidator.java
+++ b/src/main/java/com/networknt/schema/OneOfValidator.java
@@ -95,8 +95,8 @@ public class OneOfValidator extends BaseJsonValidator {
 
             // ensure there is always an "OneOf" error reported if number of valid schemas is not equal to 1.
             if (numberOfValidSchema != 1) {
-                ValidationMessage message = buildValidationMessage(at,
-                        executionContext.getExecutionConfig().getLocale(), Integer.toString(numberOfValidSchema));
+                ValidationMessage message = buildValidationMessage(null,
+                        at, executionContext.getExecutionConfig().getLocale(), Integer.toString(numberOfValidSchema));
                 if (this.failFast) {
                     throw new JsonSchemaException(message);
                 }

--- a/src/main/java/com/networknt/schema/PatternValidator.java
+++ b/src/main/java/com/networknt/schema/PatternValidator.java
@@ -60,7 +60,8 @@ public class PatternValidator extends BaseJsonValidator {
 
         try {
             if (!matches(node.asText())) {
-                return Collections.singleton(buildValidationMessage(at, this.pattern));
+                return Collections.singleton(
+                        buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), this.pattern));
             }
         } catch (JsonSchemaException e) {
             throw e;

--- a/src/main/java/com/networknt/schema/PatternValidator.java
+++ b/src/main/java/com/networknt/schema/PatternValidator.java
@@ -61,7 +61,7 @@ public class PatternValidator extends BaseJsonValidator {
         try {
             if (!matches(node.asText())) {
                 return Collections.singleton(
-                        buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), this.pattern));
+                        buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale(), this.pattern));
             }
         } catch (JsonSchemaException e) {
             throw e;

--- a/src/main/java/com/networknt/schema/PropertyNamesValidator.java
+++ b/src/main/java/com/networknt/schema/PropertyNamesValidator.java
@@ -48,8 +48,8 @@ public class PropertyNamesValidator extends BaseJsonValidator implements JsonVal
                 if (msg.startsWith(path))
                     msg = msg.substring(path.length()).replaceFirst("^:\\s*", "");
 
-                errors.add(buildValidationMessage(schemaError.getPath(),
-                        executionContext.getExecutionConfig().getLocale(), msg));
+                errors.add(buildValidationMessage(pname,
+                        schemaError.getPath(), executionContext.getExecutionConfig().getLocale(), msg));
             }
         }
         return Collections.unmodifiableSet(errors);

--- a/src/main/java/com/networknt/schema/PropertyNamesValidator.java
+++ b/src/main/java/com/networknt/schema/PropertyNamesValidator.java
@@ -48,7 +48,8 @@ public class PropertyNamesValidator extends BaseJsonValidator implements JsonVal
                 if (msg.startsWith(path))
                     msg = msg.substring(path.length()).replaceFirst("^:\\s*", "");
 
-                errors.add(buildValidationMessage(schemaError.getPath(), msg));
+                errors.add(buildValidationMessage(schemaError.getPath(),
+                        executionContext.getExecutionConfig().getLocale(), msg));
             }
         }
         return Collections.unmodifiableSet(errors);

--- a/src/main/java/com/networknt/schema/ReadOnlyValidator.java
+++ b/src/main/java/com/networknt/schema/ReadOnlyValidator.java
@@ -41,7 +41,7 @@ public class ReadOnlyValidator extends BaseJsonValidator {
     public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
         if (this.readOnly) {
-            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale()));
+            return Collections.singleton(buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale()));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/ReadOnlyValidator.java
+++ b/src/main/java/com/networknt/schema/ReadOnlyValidator.java
@@ -16,7 +16,7 @@
 
 package com.networknt.schema;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -40,11 +40,10 @@ public class ReadOnlyValidator extends BaseJsonValidator {
     @Override
     public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
-        Set<ValidationMessage> errors= new HashSet<>();
         if (this.readOnly) {
-        	errors.add(buildValidationMessage(at));
-        } 
-        return errors;
+            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale()));
+        }
+        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/RecursiveRefValidator.java
+++ b/src/main/java/com/networknt/schema/RecursiveRefValidator.java
@@ -21,7 +21,6 @@ import com.networknt.schema.CollectorContext.Scope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.text.MessageFormat;
 import java.util.*;
 
 public class RecursiveRefValidator extends BaseJsonValidator {
@@ -32,14 +31,11 @@ public class RecursiveRefValidator extends BaseJsonValidator {
 
         String refValue = schemaNode.asText();
         if (!"#".equals(refValue)) {
-            throw new JsonSchemaException(
-                ValidationMessage.of(
-                    ValidatorTypeCode.RECURSIVE_REF.getValue(),
-                    CustomErrorMessageType.of("internal.invalidRecursiveRef"),
-                    new MessageFormat("{0}: The value of a $recursiveRef must be '#' but is '{1}'"),
-                    schemaPath, schemaPath, refValue
-                )
-            );
+            ValidationMessage validationMessage = ValidationMessage.builder()
+                    .type(ValidatorTypeCode.RECURSIVE_REF.getValue()).code("internal.invalidRecursiveRef")
+                    .message("{0}: The value of a $recursiveRef must be '#' but is '{1}'").path(schemaPath)
+                    .schemaPath(schemaPath).arguments(refValue).build();
+            throw new JsonSchemaException(validationMessage);
         }
     }
 

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
-import java.text.MessageFormat;
 import java.util.*;
 
 public class RefValidator extends BaseJsonValidator {
@@ -44,12 +43,10 @@ public class RefValidator extends BaseJsonValidator {
         this.parentSchema = parentSchema;
         this.schema = getRefSchema(parentSchema, validationContext, refValue);
         if (this.schema == null) {
-            throw new JsonSchemaException(
-                    ValidationMessage.of(
-                            ValidatorTypeCode.REF.getValue(),
-                            CustomErrorMessageType.of("internal.unresolvedRef"),
-                            new MessageFormat("{0}: Reference {1} cannot be resolved"),
-                            schemaPath, schemaPath, refValue));
+            ValidationMessage validationMessage = ValidationMessage.builder().type(ValidatorTypeCode.REF.getValue())
+                    .code("internal.unresolvedRef").message("{0}: Reference {1} cannot be resolved")
+                    .path(schemaPath).schemaPath(schemaPath).arguments(refValue).build();
+            throw new JsonSchemaException(validationMessage);
         }
     }
 

--- a/src/main/java/com/networknt/schema/RequiredValidator.java
+++ b/src/main/java/com/networknt/schema/RequiredValidator.java
@@ -52,7 +52,7 @@ public class RequiredValidator extends BaseJsonValidator implements JsonValidato
             JsonNode propertyNode = node.get(fieldName);
 
             if (propertyNode == null) {
-                errors.add(buildValidationMessage(at, fieldName));
+                errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), fieldName));
             }
         }
 

--- a/src/main/java/com/networknt/schema/RequiredValidator.java
+++ b/src/main/java/com/networknt/schema/RequiredValidator.java
@@ -52,7 +52,7 @@ public class RequiredValidator extends BaseJsonValidator implements JsonValidato
             JsonNode propertyNode = node.get(fieldName);
 
             if (propertyNode == null) {
-                errors.add(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), fieldName));
+                errors.add(buildValidationMessage(fieldName, at, executionContext.getExecutionConfig().getLocale(), fieldName));
             }
         }
 

--- a/src/main/java/com/networknt/schema/TypeValidator.java
+++ b/src/main/java/com/networknt/schema/TypeValidator.java
@@ -60,7 +60,8 @@ public class TypeValidator extends BaseJsonValidator {
 
         if (!equalsToSchemaType(node)) {
             JsonType nodeType = TypeFactory.getValueNodeType(node, this.validationContext.getConfig());
-            return Collections.singleton(buildValidationMessage(at, nodeType.toString(), this.schemaType.toString()));
+            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
+                    nodeType.toString(), this.schemaType.toString()));
         }
 
         // TODO: Is this really necessary?

--- a/src/main/java/com/networknt/schema/TypeValidator.java
+++ b/src/main/java/com/networknt/schema/TypeValidator.java
@@ -60,8 +60,8 @@ public class TypeValidator extends BaseJsonValidator {
 
         if (!equalsToSchemaType(node)) {
             JsonType nodeType = TypeFactory.getValueNodeType(node, this.validationContext.getConfig());
-            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
-                    nodeType.toString(), this.schemaType.toString()));
+            return Collections.singleton(buildValidationMessage(null, at,
+                    executionContext.getExecutionConfig().getLocale(), nodeType.toString(), this.schemaType.toString()));
         }
 
         // TODO: Is this really necessary?

--- a/src/main/java/com/networknt/schema/UnevaluatedItemsValidator.java
+++ b/src/main/java/com/networknt/schema/UnevaluatedItemsValidator.java
@@ -60,7 +60,7 @@ public class UnevaluatedItemsValidator extends BaseJsonValidator {
 
             // Short-circuit since schema is 'false'
             if (super.schemaNode.isBoolean() && !super.schemaNode.asBoolean() && !unevaluatedPaths.isEmpty()) {
-                return reportUnevaluatedPaths(unevaluatedPaths);
+                return reportUnevaluatedPaths(unevaluatedPaths, executionContext);
             }
 
             Set<String> failingPaths = new HashSet<>();
@@ -75,7 +75,7 @@ public class UnevaluatedItemsValidator extends BaseJsonValidator {
             if (failingPaths.isEmpty()) {
                 collectorContext.getEvaluatedItems().addAll(allPaths);
             } else {
-                return reportUnevaluatedPaths(failingPaths);
+                return reportUnevaluatedPaths(failingPaths, executionContext);
             }
 
             return Collections.emptySet();
@@ -86,7 +86,7 @@ public class UnevaluatedItemsValidator extends BaseJsonValidator {
 
     private Set<String> allPaths(JsonNode node, String at) {
         PathType pathType = getPathType();
-        Set<String> collector = new HashSet<>();
+        Set<String> collector = new LinkedHashSet<>();
         int size = node.size();
         for (int i = 0; i < size; ++i) {
             String path = pathType.append(at, i);
@@ -95,10 +95,10 @@ public class UnevaluatedItemsValidator extends BaseJsonValidator {
         return collector;
     }
 
-    private Set<ValidationMessage> reportUnevaluatedPaths(Set<String> unevaluatedPaths) {
+    private Set<ValidationMessage> reportUnevaluatedPaths(Set<String> unevaluatedPaths, ExecutionContext executionContext) {
         List<String> paths = new ArrayList<>(unevaluatedPaths);
         paths.sort(String.CASE_INSENSITIVE_ORDER);
-        return Collections.singleton(buildValidationMessage(String.join("\n  ", paths)));
+        return Collections.singleton(buildValidationMessage(String.join("\n  ", paths), executionContext.getExecutionConfig().getLocale()));
     }
 
     private static Set<String> unevaluatedPaths(CollectorContext collectorContext, Set<String> allPaths) {

--- a/src/main/java/com/networknt/schema/UnevaluatedItemsValidator.java
+++ b/src/main/java/com/networknt/schema/UnevaluatedItemsValidator.java
@@ -98,7 +98,7 @@ public class UnevaluatedItemsValidator extends BaseJsonValidator {
     private Set<ValidationMessage> reportUnevaluatedPaths(Set<String> unevaluatedPaths, ExecutionContext executionContext) {
         List<String> paths = new ArrayList<>(unevaluatedPaths);
         paths.sort(String.CASE_INSENSITIVE_ORDER);
-        return Collections.singleton(buildValidationMessage(String.join("\n  ", paths), executionContext.getExecutionConfig().getLocale()));
+        return Collections.singleton(buildValidationMessage(null, String.join("\n  ", paths), executionContext.getExecutionConfig().getLocale()));
     }
 
     private static Set<String> unevaluatedPaths(CollectorContext collectorContext, Set<String> allPaths) {

--- a/src/main/java/com/networknt/schema/UnevaluatedPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/UnevaluatedPropertiesValidator.java
@@ -60,7 +60,7 @@ public class UnevaluatedPropertiesValidator extends BaseJsonValidator {
 
             // Short-circuit since schema is 'false'
             if (super.schemaNode.isBoolean() && !super.schemaNode.asBoolean() && !unevaluatedPaths.isEmpty()) {
-                return reportUnevaluatedPaths(unevaluatedPaths);
+                return reportUnevaluatedPaths(unevaluatedPaths, executionContext);
             }
 
             Set<String> failingPaths = new HashSet<>();
@@ -75,7 +75,7 @@ public class UnevaluatedPropertiesValidator extends BaseJsonValidator {
             if (failingPaths.isEmpty()) {
                 collectorContext.getEvaluatedProperties().addAll(allPaths);
             } else {
-                return reportUnevaluatedPaths(failingPaths);
+                return reportUnevaluatedPaths(failingPaths, executionContext);
             }
 
             return Collections.emptySet();
@@ -94,10 +94,10 @@ public class UnevaluatedPropertiesValidator extends BaseJsonValidator {
         return collector;
     }
 
-    private Set<ValidationMessage> reportUnevaluatedPaths(Set<String> unevaluatedPaths) {
+    private Set<ValidationMessage> reportUnevaluatedPaths(Set<String> unevaluatedPaths, ExecutionContext executionContext) {
         List<String> paths = new ArrayList<>(unevaluatedPaths);
         paths.sort(String.CASE_INSENSITIVE_ORDER);
-        return Collections.singleton(buildValidationMessage(String.join("\n  ", paths)));
+        return Collections.singleton(buildValidationMessage(String.join("\n  ", paths), executionContext.getExecutionConfig().getLocale()));
     }
 
     private static Set<String> unevaluatedPaths(CollectorContext collectorContext, Set<String> allPaths) {

--- a/src/main/java/com/networknt/schema/UnevaluatedPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/UnevaluatedPropertiesValidator.java
@@ -97,7 +97,7 @@ public class UnevaluatedPropertiesValidator extends BaseJsonValidator {
     private Set<ValidationMessage> reportUnevaluatedPaths(Set<String> unevaluatedPaths, ExecutionContext executionContext) {
         List<String> paths = new ArrayList<>(unevaluatedPaths);
         paths.sort(String.CASE_INSENSITIVE_ORDER);
-        return Collections.singleton(buildValidationMessage(String.join("\n  ", paths), executionContext.getExecutionConfig().getLocale()));
+        return Collections.singleton(buildValidationMessage(null, String.join("\n  ", paths), executionContext.getExecutionConfig().getLocale()));
     }
 
     private static Set<String> unevaluatedPaths(CollectorContext collectorContext, Set<String> allPaths) {

--- a/src/main/java/com/networknt/schema/UnionTypeValidator.java
+++ b/src/main/java/com/networknt/schema/UnionTypeValidator.java
@@ -78,7 +78,8 @@ public class UnionTypeValidator extends BaseJsonValidator implements JsonValidat
         }
 
         if (!valid) {
-            return Collections.singleton(buildValidationMessage(at, nodeType.toString(), error));
+            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
+                    nodeType.toString(), error));
         }
 
         return Collections.emptySet();

--- a/src/main/java/com/networknt/schema/UnionTypeValidator.java
+++ b/src/main/java/com/networknt/schema/UnionTypeValidator.java
@@ -78,8 +78,8 @@ public class UnionTypeValidator extends BaseJsonValidator implements JsonValidat
         }
 
         if (!valid) {
-            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(),
-                    nodeType.toString(), error));
+            return Collections.singleton(buildValidationMessage(null, at,
+                    executionContext.getExecutionConfig().getLocale(), nodeType.toString(), error));
         }
 
         return Collections.emptySet();

--- a/src/main/java/com/networknt/schema/UniqueItemsValidator.java
+++ b/src/main/java/com/networknt/schema/UniqueItemsValidator.java
@@ -45,7 +45,7 @@ public class UniqueItemsValidator extends BaseJsonValidator implements JsonValid
             Set<JsonNode> set = new HashSet<JsonNode>();
             for (JsonNode n : node) {
                 if (!set.add(n)) {
-                    return Collections.singleton(buildValidationMessage(at));
+                    return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale()));
                 }
             }
         }

--- a/src/main/java/com/networknt/schema/UniqueItemsValidator.java
+++ b/src/main/java/com/networknt/schema/UniqueItemsValidator.java
@@ -45,7 +45,7 @@ public class UniqueItemsValidator extends BaseJsonValidator implements JsonValid
             Set<JsonNode> set = new HashSet<JsonNode>();
             for (JsonNode n : node) {
                 if (!set.add(n)) {
-                    return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale()));
+                    return Collections.singleton(buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale()));
                 }
             }
         }

--- a/src/main/java/com/networknt/schema/ValidationContext.java
+++ b/src/main/java/com/networknt/schema/ValidationContext.java
@@ -59,7 +59,7 @@ public class ValidationContext {
     }
 
     public JsonValidator newValidator(String schemaPath, String keyword /* keyword */, JsonNode schemaNode,
-                                      JsonSchema parentSchema, String customMessage) {
+                                      JsonSchema parentSchema, Map<String, String> customMessage) {
         return this.metaSchema.newValidator(this, schemaPath, keyword, schemaNode, parentSchema, customMessage);
     }
 

--- a/src/main/java/com/networknt/schema/ValidationMessage.java
+++ b/src/main/java/com/networknt/schema/ValidationMessage.java
@@ -131,7 +131,7 @@ public class ValidationMessage {
 
     @Deprecated // Use the builder
     public static ValidationMessage of(String type, ErrorMessageType errorMessageType, MessageFormat messageFormat, String at, String schemaPath, Object... arguments) {
-        return ofWithCustom(type, errorMessageType, messageFormat, errorMessageType.getCustomMessage(), at, schemaPath, arguments);
+        return ofWithCustom(type, errorMessageType, messageFormat, errorMessageType.getCustomMessage().get(""), at, schemaPath, arguments);
     }
 
     @Deprecated // Use the builder

--- a/src/main/java/com/networknt/schema/ValidationMessageHandler.java
+++ b/src/main/java/com/networknt/schema/ValidationMessageHandler.java
@@ -1,15 +1,15 @@
 package com.networknt.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.networknt.schema.i18n.MessageSource;
 import com.networknt.schema.utils.StringUtils;
 
-import java.text.MessageFormat;
-import java.util.ResourceBundle;
+import java.util.Locale;
 
 public abstract class ValidationMessageHandler {
     protected final boolean failFast;
     protected final String customMessage;
-    protected final ResourceBundle resourceBundle;
+    protected final MessageSource messageSource;
     protected ValidatorTypeCode validatorType;
     protected ErrorMessageType errorMessageType;
 
@@ -17,36 +17,30 @@ public abstract class ValidationMessageHandler {
 
     protected JsonSchema parentSchema;
 
-    protected ValidationMessageHandler(boolean failFast, ErrorMessageType errorMessageType, String customMessage, ResourceBundle resourceBundle, ValidatorTypeCode validatorType, JsonSchema parentSchema, String schemaPath) {
+    protected ValidationMessageHandler(boolean failFast, ErrorMessageType errorMessageType, String customMessage, MessageSource messageSource, ValidatorTypeCode validatorType, JsonSchema parentSchema, String schemaPath) {
         this.failFast = failFast;
         this.errorMessageType = errorMessageType;
         this.customMessage = customMessage;
-        this.resourceBundle = resourceBundle;
+        this.messageSource = messageSource;
         this.validatorType = validatorType;
         this.schemaPath = schemaPath;
         this.parentSchema = parentSchema;
     }
 
-
-    protected ValidationMessage buildValidationMessage(String at, String... arguments) {
-        MessageFormat messageFormat = new MessageFormat(this.resourceBundle.getString(getErrorMessageType().getErrorCodeValue()));
-        final ValidationMessage message = ValidationMessage.ofWithCustom(getValidatorType().getValue(), getErrorMessageType(), messageFormat, this.customMessage, at, this.schemaPath, arguments);
-        if (this.failFast && isApplicator()) {
-            throw new JsonSchemaException(message);
-        }
-        return message;
+    protected ValidationMessage buildValidationMessage(String at, Locale locale, Object... arguments) {
+        return buildValidationMessage(at, getErrorMessageType().getErrorCodeValue(), locale, arguments);
     }
 
-    protected ValidationMessage constructValidationMessage(String messageKey, String at, String... arguments) {
-        MessageFormat messageFormat = new MessageFormat(this.resourceBundle.getString(messageKey));
-        final ValidationMessage message = new ValidationMessage.Builder()
+    protected ValidationMessage buildValidationMessage(String at, String messageKey, Locale locale, Object... arguments) {
+        final ValidationMessage message = ValidationMessage.builder()
                 .code(getErrorMessageType().getErrorCode())
                 .path(at)
                 .schemaPath(this.schemaPath)
                 .arguments(arguments)
-                .format(messageFormat)
+                .messageKey(messageKey)
+                .messageFormatter(args -> this.messageSource.getMessage(messageKey, locale, args))
                 .type(getValidatorType().getValue())
-                .customMessage(this.customMessage)
+                .message(this.customMessage)
                 .build();
         if (this.failFast && isApplicator()) {
             throw new JsonSchemaException(message);

--- a/src/main/java/com/networknt/schema/ValidatorTypeCode.java
+++ b/src/main/java/com/networknt/schema/ValidatorTypeCode.java
@@ -117,7 +117,7 @@ public enum ValidatorTypeCode implements Keyword, ErrorMessageType {
 
     private final String value;
     private final String errorCode;
-    private String customMessage;
+    private Map<String, String> customMessage;
     private final String errorCodeKey;
     private final Class<?> validator;
     private final VersionCode versionCode;
@@ -178,12 +178,12 @@ public enum ValidatorTypeCode implements Keyword, ErrorMessageType {
     }
 
     @Override
-    public void setCustomMessage(String message) {
+    public void setCustomMessage(Map<String, String> message) {
         this.customMessage = message;
     }
 
     @Override
-    public String getCustomMessage() {
+    public Map<String, String> getCustomMessage() {
         return this.customMessage;
     }
 

--- a/src/main/java/com/networknt/schema/WriteOnlyValidator.java
+++ b/src/main/java/com/networknt/schema/WriteOnlyValidator.java
@@ -25,7 +25,7 @@ public class WriteOnlyValidator extends BaseJsonValidator {
     public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
         if (this.writeOnly) {
-            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale()));
+            return Collections.singleton(buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale()));
         } 
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/WriteOnlyValidator.java
+++ b/src/main/java/com/networknt/schema/WriteOnlyValidator.java
@@ -1,6 +1,6 @@
 package com.networknt.schema;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -24,11 +24,10 @@ public class WriteOnlyValidator extends BaseJsonValidator {
     @Override
     public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
-        Set<ValidationMessage> errors= new HashSet<>();
         if (this.writeOnly) {
-            errors.add(buildValidationMessage(at));
+            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale()));
         } 
-        return errors;
+        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/format/DateTimeValidator.java
+++ b/src/main/java/com/networknt/schema/format/DateTimeValidator.java
@@ -32,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class DateTimeValidator extends BaseJsonValidator {
@@ -50,16 +49,15 @@ public class DateTimeValidator extends BaseJsonValidator {
     public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, String at) {
         debug(logger, node, rootNode, at);
 
-        Set<ValidationMessage> errors = new LinkedHashSet<>();
-
         JsonType nodeType = TypeFactory.getValueNodeType(node, this.validationContext.getConfig());
         if (nodeType != JsonType.STRING) {
-            return errors;
+            return Collections.emptySet();
         }
         if (!isLegalDateTime(node.textValue())) {
-            errors.add(buildValidationMessage(at, node.textValue(), DATETIME));
+            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), node.textValue(),
+                    DATETIME));
         }
-        return Collections.unmodifiableSet(errors);
+        return Collections.emptySet();
     }
 
     private static boolean isLegalDateTime(String string) {

--- a/src/main/java/com/networknt/schema/format/DateTimeValidator.java
+++ b/src/main/java/com/networknt/schema/format/DateTimeValidator.java
@@ -54,8 +54,8 @@ public class DateTimeValidator extends BaseJsonValidator {
             return Collections.emptySet();
         }
         if (!isLegalDateTime(node.textValue())) {
-            return Collections.singleton(buildValidationMessage(at, executionContext.getExecutionConfig().getLocale(), node.textValue(),
-                    DATETIME));
+            return Collections.singleton(buildValidationMessage(null, at, executionContext.getExecutionConfig().getLocale(),
+                    node.textValue(), DATETIME));
         }
         return Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/i18n/DefaultMessageSource.java
+++ b/src/main/java/com/networknt/schema/i18n/DefaultMessageSource.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.i18n;
+
+/**
+ * The default {@link MessageSource} singleton.
+ */
+public class DefaultMessageSource {
+    public static final String BUNDLE_BASE_NAME = "jsv-messages";
+
+    public static class Holder {
+        private static final MessageSource INSTANCE = new ResourceBundleMessageSource(BUNDLE_BASE_NAME);
+    }
+
+    /**
+     * Gets the default {@link MessageSource} using the jsv-messages bundle.
+     * 
+     * @return the message source of the resource bundle
+     */
+    public static MessageSource getInstance() {
+        return Holder.INSTANCE;
+    }
+}

--- a/src/main/java/com/networknt/schema/i18n/Locales.java
+++ b/src/main/java/com/networknt/schema/i18n/Locales.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.i18n;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Locale.FilteringMode;
+import java.util.Locale.LanguageRange;
+import java.util.stream.Collectors;
+
+/**
+ * Functions for working with Locales.
+ */
+public class Locales {
+    /**
+     * The list of locale resource bundles.
+     */
+    public static final String[] SUPPORTED_LANGUAGE_TAGS = new String[] { "ar-EG", "cs-CZ", "da-DK", "de", "fa-IR",
+            "fi-FI", "fr-CA", "fr", "he-IL", "hr-HR", "hu-HU", "it", "ja-JP", "ko-KR", "nb-NO", "nl-NL", "pl-PL",
+            "pt-BR", "ro-RO", "ru-RU", "sk-SK", "sv-SE", "th-TH", "tr-TR", "uk-UA", "vi-VN", "zh-CN", "zh-TW" };
+
+    /**
+     * The supported locales.
+     */
+    public static final List<Locale> SUPPORTED_LOCALES = of(SUPPORTED_LANGUAGE_TAGS);
+
+    /**
+     * Gets the supported locales.
+     * 
+     * @return the supported locales
+     */
+    public static List<Locale> getSupportedLocales() {
+        return SUPPORTED_LOCALES;
+    }
+
+    /**
+     * Gets a list of {@link Locale} by language tags.
+     * 
+     * @param languageTags for the locales
+     * @return the locales
+     */
+    public static List<Locale> of(String... languageTags) {
+        return Arrays.asList(languageTags).stream().map(Locale::forLanguageTag).collect(Collectors.toList());
+    }
+
+    /**
+     * Determine the best matching {@link Locale} with respect to the priority list.
+     * 
+     * @param priorityList the language tag priority list
+     * @return the best matching locale
+     */
+    public static Locale findSupported(String priorityList) {
+        return findSupported(priorityList, getSupportedLocales());
+    }
+
+    /**
+     * Determine the best matching {@link Locale} with respect to the priority list.
+     * 
+     * @param priorityList the language tag priority list
+     * @param locales      the supported locales
+     * @return the best matching locale
+     */
+    public static Locale findSupported(String priorityList, Collection<Locale> locales) {
+        return findSupported(LanguageRange.parse(priorityList), locales, FilteringMode.AUTOSELECT_FILTERING);
+    }
+
+    /**
+     * Determine the best matching {@link Locale} with respect to the priority list.
+     * 
+     * @param priorityList  the language tag priority list
+     * @param locales       the supported locales
+     * @param filteringMode the filtering mode
+     * @return the best matching locale
+     */
+    public static Locale findSupported(List<LanguageRange> priorityList, Collection<Locale> locales,
+            FilteringMode filteringMode) {
+        Locale result = Locale.lookup(priorityList, locales);
+        if (result != null) {
+            return result;
+        }
+        List<Locale> matching = Locale.filter(priorityList, locales, filteringMode);
+        if (!matching.isEmpty()) {
+            return matching.get(0);
+        }
+        return Locale.ROOT;
+    }
+}

--- a/src/main/java/com/networknt/schema/i18n/MessageFormatter.java
+++ b/src/main/java/com/networknt/schema/i18n/MessageFormatter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.i18n;
+
+/**
+ * Formats messages with arguments.
+ */
+@FunctionalInterface
+public interface MessageFormatter {
+    /**
+     * Formats a message with arguments.
+     * 
+     * @param args the arguments
+     * @return the message
+     */
+    String format(Object... args);
+}

--- a/src/main/java/com/networknt/schema/i18n/MessageSource.java
+++ b/src/main/java/com/networknt/schema/i18n/MessageSource.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.i18n;
+
+import java.util.Locale;
+import java.util.function.Supplier;
+
+/**
+ * Resolves locale specific messages.
+ */
+@FunctionalInterface
+public interface MessageSource {
+    /**
+     * Gets the message.
+     *
+     * @param key                    to look up the message
+     * @param defaultMessageSupplier the default message
+     * @param locale                 the locale to use
+     * @param args                   the message arguments
+     * @return the message
+     */
+    String getMessage(String key, Supplier<String> defaultMessageSupplier, Locale locale, Object... args);
+
+    /**
+     * Gets the message.
+     *
+     * @param key            to look up the message
+     * @param defaultMessage the default message
+     * @param locale         the locale to use
+     * @param args           the message arguments
+     * @return the message
+     */
+    default String getMessage(String key, String defaultMessage, Locale locale, Object... args) {
+        return getMessage(key, defaultMessage::toString, locale, args);
+    }
+
+    /**
+     * Gets the message.
+     *
+     * @param key    to look up the message
+     * @param locale the locale to use
+     * @param args   the message arguments
+     * @return the message
+     */
+    default String getMessage(String key, Locale locale, Object... args) {
+        return getMessage(key, (Supplier<String>) null, locale, args);
+    }
+}

--- a/src/main/java/com/networknt/schema/i18n/ResourceBundleMessageSource.java
+++ b/src/main/java/com/networknt/schema/i18n/ResourceBundleMessageSource.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.i18n;
+
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.ResourceBundle;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * {@link MessageSource} that retrieves messages from a {@link ResourceBundle}.
+ */
+public class ResourceBundleMessageSource implements MessageSource {
+    /**
+     * Resource Bundle Cache. baseName -> locale -> resourceBundle.
+     */
+    private Map<String, Map<Locale, ResourceBundle>> resourceBundleMap = new ConcurrentHashMap<>();
+
+    /**
+     * Message Cache. locale -> key -> message.
+     */
+    private Map<Locale, Map<String, String>> messageMap = new ConcurrentHashMap<>();
+
+    /**
+     * Message Format Cache. locale -> message -> messageFormat.
+     * <p>
+     * Note that Message Format is not threadsafe.
+     */
+    private Map<Locale, Map<String, MessageFormat>> messageFormatMap = new ConcurrentHashMap<>();
+
+    private final List<String> baseNames;
+
+    public ResourceBundleMessageSource(String... baseName) {
+        this.baseNames = Arrays.asList(baseName);
+    }
+
+    @Override
+    public String getMessage(String key, Supplier<String> defaultMessage, Locale locale, Object... arguments) {
+        String message = getMessageFromCache(locale, key);
+        if (message.isEmpty() && defaultMessage != null) {
+            message = defaultMessage.get();
+        }
+        if (message.isEmpty()) {
+            // Fallback on message key
+            message = key;
+        }
+        if (arguments == null || arguments.length == 0) {
+            // When no arguments just return the message without formatting
+            return message;
+        }
+        MessageFormat messageFormat = getMessageFormat(locale, message);
+        synchronized (messageFormat) {
+            // Synchronized block on messageFormat as it is not threadsafe
+            return messageFormat.format(arguments, new StringBuffer(), null).toString();
+        }
+    }
+
+    protected MessageFormat getMessageFormat(Locale locale, String message) {
+        Map<String, MessageFormat> map = messageFormatMap.computeIfAbsent(locale, l -> {
+            return new ConcurrentHashMap<>();
+        });
+        return map.computeIfAbsent(message, m -> {
+            return new MessageFormat(m, locale);
+        });
+    }
+
+    /**
+     * Gets the message from cache or the resource bundles. Returns an empty string
+     * if not found.
+     *
+     * @param locale the locale
+     * @param key    the message key
+     * @return the message
+     */
+    protected String getMessageFromCache(Locale locale, String key) {
+        Map<String, String> map = messageMap.computeIfAbsent(locale, l -> new ConcurrentHashMap<>());
+        return map.computeIfAbsent(key, k -> {
+            return resolveMessage(locale, k);
+        });
+    }
+
+    /**
+     * Gets the message from the resource bundles. Returns an empty string if not
+     * found.
+     *
+     * @param locale the locale
+     * @param key    the message key
+     * @return the message
+     */
+    protected String resolveMessage(Locale locale, String key) {
+        Optional<String> optionalPattern = this.baseNames.stream().map(baseName -> getResourceBundle(baseName, locale))
+                .filter(Objects::nonNull).map(resourceBundle -> {
+                    try {
+                        return resourceBundle.getString(key);
+                    } catch (MissingResourceException e) {
+                        return null;
+                    }
+                }).filter(Objects::nonNull).findFirst();
+        return optionalPattern.orElse("");
+    }
+
+    protected Map<Locale, ResourceBundle> getResourceBundle(String baseName) {
+        return resourceBundleMap.computeIfAbsent(baseName, key -> {
+            return new ConcurrentHashMap<>();
+        });
+    }
+
+    protected ResourceBundle getResourceBundle(String baseName, Locale locale) {
+        return getResourceBundle(baseName).computeIfAbsent(locale, key -> {
+            try {
+                return ResourceBundle.getBundle(baseName, key);
+            } catch (MissingResourceException e) {
+                return null;
+            }
+        });
+    }
+}

--- a/src/main/java/com/networknt/schema/utils/CachingSupplier.java
+++ b/src/main/java/com/networknt/schema/utils/CachingSupplier.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.networknt.schema.utils;
+
+import java.util.function.Supplier;
+
+/**
+ * {@link Supplier} that caches the value.
+ * <p>
+ * This is not threadsafe.
+ * 
+ * @param <T> the type of results supplied by this supplier
+ */
+public class CachingSupplier<T> implements Supplier<T> {
+    private final Supplier<T> delegate;
+    private T cached = null;
+
+    public CachingSupplier(Supplier<T> supplier) {
+        this.delegate = supplier;
+    }
+
+    @Override
+    public T get() {
+        if (this.cached == null) {
+            this.cached = this.delegate.get();
+        }
+        return this.cached;
+    }
+}

--- a/src/test/java/com/networknt/schema/CustomMetaSchemaTest.java
+++ b/src/test/java/com/networknt/schema/CustomMetaSchemaTest.java
@@ -68,7 +68,10 @@ public class CustomMetaSchemaTest {
                 }
                 String valueName = enumNames.get(idx);
                 Set<ValidationMessage> messages = new HashSet<>();
-                messages.add(ValidationMessage.of(keyword, CustomErrorMessageType.of("tests.example.enumNames"), new MessageFormat("{0}: enumName is {1}"), at, null, valueName));
+                ValidationMessage validationMessage = ValidationMessage.builder().type(keyword)
+                        .code("tests.example.enumNames").message("{0}: enumName is {1}").path(at)
+                        .arguments(valueName).build();
+                messages.add(validationMessage);
                 return messages;
             }
         }

--- a/src/test/java/com/networknt/schema/Issue686Test.java
+++ b/src/test/java/com/networknt/schema/Issue686Test.java
@@ -2,6 +2,9 @@ package com.networknt.schema;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.i18n.DefaultMessageSource;
+import com.networknt.schema.i18n.ResourceBundleMessageSource;
+
 import org.junit.jupiter.api.Test;
 
 import java.text.MessageFormat;
@@ -16,37 +19,14 @@ public class Issue686Test {
     @Test
     void testDefaults() {
         SchemaValidatorsConfig config = new SchemaValidatorsConfig();
-        assertEquals(I18nSupport.DEFAULT_RESOURCE_BUNDLE, config.getResourceBundle());
-    }
-
-    @Test
-    void testCustomLocale() {
-        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
-        config.setLocale(Locale.FRENCH);
-        assertEquals(Locale.FRENCH.getLanguage(), config.getResourceBundle().getLocale().getLanguage());
-    }
-
-    @Test
-    void testLocaleDoesNotOverrideCustomResourceBundle() {
-        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
-        config.setLocale(Locale.FRENCH);
-        ResourceBundle bundle = ResourceBundle.getBundle("issue686/translations", Locale.GERMAN);
-        assertEquals(Locale.GERMAN.getLanguage(), bundle.getLocale().getLanguage());
-    }
-
-    @Test
-    void testBundleResetAfterChangingLocale() {
-        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
-        config.setLocale(Locale.FRENCH);
-        assertEquals(Locale.FRENCH.getLanguage(), config.getResourceBundle().getLocale().getLanguage());
-        config.setLocale(Locale.GERMAN);
-        assertEquals(Locale.GERMAN.getLanguage(), config.getResourceBundle().getLocale().getLanguage());
+        assertEquals(DefaultMessageSource.getInstance(), config.getMessageSource());
     }
 
     @Test
     void testValidationWithDefaultBundleAndLocale() throws JsonProcessingException {
         SchemaValidatorsConfig config = new SchemaValidatorsConfig();
-        String expectedMessage = new MessageFormat(I18nSupport.DEFAULT_RESOURCE_BUNDLE.getString("type")).format(new String[] {"$.foo", "integer", "string"});
+        ResourceBundle resourceBundle = ResourceBundle.getBundle(DefaultMessageSource.BUNDLE_BASE_NAME, Locale.getDefault());
+        String expectedMessage = new MessageFormat(resourceBundle.getString("type")).format(new String[] {"$.foo", "integer", "string"});
         verify(config, expectedMessage);
     }
 
@@ -60,7 +40,8 @@ public class Issue686Test {
     @Test
     void testValidationWithCustomBundle() throws JsonProcessingException {
         SchemaValidatorsConfig config = new SchemaValidatorsConfig();
-        config.setResourceBundle(ResourceBundle.getBundle("issue686/translations", Locale.FRENCH));
+        config.setMessageSource(new ResourceBundleMessageSource("issue686/translations"));
+        config.setLocale(Locale.FRENCH);
         verify(config, "$.foo: integer found, string expected (TEST) (FR)");
     }
 

--- a/src/test/java/com/networknt/schema/Issue898Test.java
+++ b/src/test/java/com/networknt/schema/Issue898Test.java
@@ -17,9 +17,8 @@ class Issue898Test extends BaseJsonSchemaValidatorTest {
 
     @Test
     void testMessagesWithSingleQuotes() throws Exception {
-        ResourceBundle bundle = ResourceBundle.getBundle(I18nSupport.DEFAULT_BUNDLE_BASE_NAME, Locale.FRENCH);
         SchemaValidatorsConfig config = new SchemaValidatorsConfig();
-        config.setResourceBundle(bundle);
+        config.setLocale(Locale.FRENCH);
 
         JsonSchema schema = getJsonSchemaFromClasspath("schema/issue898.json", SpecVersion.VersionFlag.V202012, config);
         JsonNode node = getJsonNodeFromClasspath("data/issue898.json");

--- a/src/test/java/com/networknt/schema/LocaleTest.java
+++ b/src/test/java/com/networknt/schema/LocaleTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Locale;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.i18n.Locales;
+
+public class LocaleTest {
+    private JsonSchema getSchema(SchemaValidatorsConfig config) {
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909);
+        return factory.getSchema(
+                "{ \"$schema\": \"https://json-schema.org/draft/2019-09/schema\", \"$id\": \"https://json-schema.org/draft/2019-09/schema\", \"type\": \"object\", \"properties\": { \"foo\": { \"type\": \"string\" } } } }",
+                config);
+    }
+
+    /**
+     * Tests that the validation messages are generated based on the execution
+     * context locale.
+     * 
+     * @throws JsonMappingException    the error
+     * @throws JsonProcessingException the error
+     */
+    @Test
+    void executionContextLocale() throws JsonMappingException, JsonProcessingException {
+        JsonNode rootNode = new ObjectMapper().readTree(" { \"foo\": 123 } ");
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        JsonSchema jsonSchema = getSchema(config);
+
+        Locale locale = Locales.findSupported("it;q=0.9,fr;q=1.0"); // fr
+        ExecutionContext executionContext = jsonSchema.createExecutionContext();
+        assertEquals(config.getLocale(), executionContext.getExecutionConfig().getLocale());
+        executionContext.getExecutionConfig().setLocale(locale);
+        Set<ValidationMessage> messages = jsonSchema.validate(executionContext, rootNode);
+        assertEquals(1, messages.size());
+        assertEquals("$.foo: integer a été trouvé, mais string est attendu", messages.iterator().next().getMessage());
+
+        locale = Locales.findSupported("it;q=1.0,fr;q=0.9"); // it
+        executionContext = jsonSchema.createExecutionContext();
+        assertEquals(config.getLocale(), executionContext.getExecutionConfig().getLocale());
+        executionContext.getExecutionConfig().setLocale(locale);
+        messages = jsonSchema.validate(executionContext, rootNode);
+        assertEquals(1, messages.size());
+        assertEquals("$.foo: integer trovato, string atteso", messages.iterator().next().getMessage());
+    }
+}

--- a/src/test/java/com/networknt/schema/OverwritingCustomMessageBugTest.java
+++ b/src/test/java/com/networknt/schema/OverwritingCustomMessageBugTest.java
@@ -27,8 +27,8 @@ public class OverwritingCustomMessageBugTest {
     Map<String, String> errorMsgMap = transferErrorMsg(errors);
     Assertions.assertTrue(errorMsgMap.containsKey("$.toplevel[1].foos"), "error message must contains key: $.foos");
     Assertions.assertTrue(errorMsgMap.containsKey("$.toplevel[1].bars"), "error message must contains key: $.bars");
-    Assertions.assertEquals("{0}: Must be a string with the a shape foofoofoofoo... with at least one foo", errorMsgMap.get("$.toplevel[1].foos"));
-    Assertions.assertEquals("{0}: Must be a string with the a shape barbarbar... with at least one bar", errorMsgMap.get("$.toplevel[1].bars"));
+    Assertions.assertEquals("$.toplevel[1].foos: Must be a string with the a shape foofoofoofoo... with at least one foo", errorMsgMap.get("$.toplevel[1].foos"));
+    Assertions.assertEquals("$.toplevel[1].bars: Must be a string with the a shape barbarbar... with at least one bar", errorMsgMap.get("$.toplevel[1].bars"));
   }
 
 

--- a/src/test/java/com/networknt/schema/i18n/LocalesTest.java
+++ b/src/test/java/com/networknt/schema/i18n/LocalesTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+class LocalesTest {
+
+    @Test
+    void unsupportedShouldReturnLocaleRoot() {
+        Locale result = Locales.findSupported("en-US;q=0.9,en-GB;q=1.0");
+        assertEquals("", result.getLanguage());
+    }
+
+    @Test
+    void shouldReturnHigherPriority() {
+        Locale result = Locales.findSupported("zh-CN;q=0.9,zh-TW;q=1.0");
+        assertEquals("zh-TW", result.toLanguageTag());
+    }
+
+    @Test
+    void shouldReturnHigherPriorityToo() {
+        Locale result = Locales.findSupported("zh-CN;q=1.0,zh-TW;q=0.9");
+        assertEquals("zh-CN", result.toLanguageTag());
+    }
+
+    @Test
+    void shouldReturnFound() {
+        Locale result = Locales.findSupported("zh-SG;q=1.0,zh-TW;q=0.9");
+        assertEquals("zh-TW", result.toLanguageTag());
+    }
+
+    @Test
+    void shouldReturnFounds() {
+        Locale result = Locales.findSupported("zh;q=1.0");
+        assertEquals("zh", result.getLanguage());
+    }
+}

--- a/src/test/java/com/networknt/schema/i18n/ResourceBundleMessageSourceTest.java
+++ b/src/test/java/com/networknt/schema/i18n/ResourceBundleMessageSourceTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+class ResourceBundleMessageSourceTest {
+
+    ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource("jsv-messages", "test-messages");
+
+    @Test
+    void messageNoDefault() {
+        String message = messageSource.getMessage("unknown.key", Locale.getDefault());
+        assertEquals("unknown.key", message);
+    }
+
+    @Test
+    void messageDefaultSupplier() {
+        String message = messageSource.getMessage("unknown.key", "default", Locale.getDefault());
+        assertEquals("default", message);
+    }
+
+    @Test
+    void messageDefaultSupplierArguments() {
+        String message = messageSource.getMessage("unknown.key", "An error {0}", Locale.getDefault(), "argument");
+        assertEquals("An error argument", message);
+    }
+
+    @Test
+    void messageFound() {
+        String message = messageSource.getMessage("atmostOne", Locale.getDefault());
+        assertEquals("english", message);
+    }
+
+    @Test
+    void messageFallbackOnDefaultLocale() {
+        String message = messageSource.getMessage("atmostOne", Locale.SIMPLIFIED_CHINESE);
+        assertEquals("english", message);
+    }
+
+    @Test
+    void messageFrench() {
+        String message = messageSource.getMessage("atmostOne", Locale.FRANCE);
+        assertEquals("french", message);
+    }
+
+    @Test
+    void messageMaxItems() {
+        String message = messageSource.getMessage("maxItems", Locale.getDefault(), "item", 5);
+        assertEquals("item: there must be a maximum of 5 items in the array", message);
+    }
+
+    @Test
+    void missingBundleShouldNotThrow() {
+        MessageSource messageSource = new ResourceBundleMessageSource("missing-bundle");
+        assertEquals("missing", messageSource.getMessage("missing", Locale.getDefault()));
+    }
+
+    @Test
+    void overrideMessage() {
+        MessageSource messageSource = new ResourceBundleMessageSource("jsv-messages-override", "jsv-messages");
+        assertEquals("path: overridden message value", messageSource.getMessage("allOf", Locale.ROOT, "path", "value"));
+        assertEquals("path: overridden message value", messageSource.getMessage("allOf", Locale.FRENCH, "path", "value"));
+        assertEquals("path: should be valid to any of the schemas value", messageSource.getMessage("anyOf", Locale.ROOT, "path", "value"));
+    }
+}

--- a/src/test/resources/jsv-messages-override.properties
+++ b/src/test/resources/jsv-messages-override.properties
@@ -1,0 +1,1 @@
+allOf = {0}: overridden message {1}

--- a/src/test/resources/schema/customMessageTests/custom-message-tests.json
+++ b/src/test/resources/schema/customMessageTests/custom-message-tests.json
@@ -99,5 +99,98 @@
         ]
       }
     ]
+  },
+  {
+    "description": "messages for keywords for different properties",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "type": "number"
+        },
+        "bar": {
+          "type": "string"
+        }
+      },
+      "required": ["foo", "bar"],
+      "message": {
+        "type" : "should be an object",
+        "required": {
+          "foo" : "{0}: ''foo'' is required",
+          "bar" : "{0}: ''bar'' is required"
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "bar is required",
+        "data": {
+          "foo": 1
+        },
+        "valid": false,
+        "validationMessages": [
+          "$: 'bar' is required"
+        ]
+      },
+      {
+        "description": "foo is required",
+        "data": {
+          "bar": "bar"
+        },
+        "valid": false,
+        "validationMessages": [
+          "$: 'foo' is required"
+        ]
+      },
+      {
+        "description": "both foo and bar are required",
+        "data": {
+        },
+        "valid": false,
+        "validationMessages": [
+          "$: 'foo' is required",
+          "$: 'bar' is required"
+        ]
+      }
+   ]
+  },
+  {
+    "description": "messages for keywords with arguments",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "requestedItems": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "properties": {
+              "item": {
+                "type": "string",
+                "minLength": 1,
+                "message": {
+                  "minLength": "{0}: Item should not be empty"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "should not be empty",
+        "data": {
+          "requestedItems": [
+          {
+            "item": ""
+          }
+          ]
+        },
+        "valid": false,
+        "validationMessages": [
+          "$.requestedItems[0].item: Item should not be empty"
+        ]
+      }
+   ]
   }
 ]

--- a/src/test/resources/test-messages.properties
+++ b/src/test/resources/test-messages.properties
@@ -1,0 +1,1 @@
+atmostOne = english

--- a/src/test/resources/test-messages_fr.properties
+++ b/src/test/resources/test-messages_fr.properties
@@ -1,0 +1,1 @@
+atmostOne = french


### PR DESCRIPTION
Resolves #908, resolves #903, resolves #839, resolves #803, resolves #744

This makes the following changes
* Add `MessageSource` interface for deriving localised messages
* Add `ExecutionConfig` to store `Locale` and use it for per-execution localised messages
* Add `Locales` to determine the supported language tags for the default resource bundle and for determining the best matching `Locale`
* Support custom messages for keywords with different properties
* Use `MessageFormat` for formatting custom messages with arguments