### PR TITLE
Support schema resource

### DIFF
--- a/src/main/java/com/networknt/schema/AbsoluteIri.java
+++ b/src/main/java/com/networknt/schema/AbsoluteIri.java
@@ -105,13 +105,22 @@ public class AbsoluteIri {
                 } else {
                     scheme = scheme + 3;
                 }
-                int slash = parent.lastIndexOf('/');
-                if (slash != -1 && slash > scheme) {
-                    base = parent.substring(0, slash);
+                base = parent(base, scheme);
+                while (iri.startsWith("../")) {
+                    base = parent(base, scheme);
+                    iri = iri.substring(3);
                 }
                 return base + "/" + iri;
             }
         }
+    }
+    
+    protected static String parent(String iri, int scheme) {
+        int slash = iri.lastIndexOf('/');
+        if (slash != -1 && slash > scheme) {
+            return iri.substring(0, slash);
+        }
+        return iri;
     }
 
     /**

--- a/src/main/java/com/networknt/schema/AllOfValidator.java
+++ b/src/main/java/com/networknt/schema/AllOfValidator.java
@@ -38,11 +38,6 @@ public class AllOfValidator extends BaseJsonValidator {
             this.schemas.add(validationContext.newSchema(schemaLocation.append(i), evaluationPath.append(i),
                     schemaNode.get(i), parentSchema));
         }
-        for (JsonSchema schema : this.schemas) {
-            // Load the validators to parse the schema so that schema resources with $id can
-            // be identified
-            schema.getValidators();
-        }
     }
 
     @Override

--- a/src/main/java/com/networknt/schema/AllOfValidator.java
+++ b/src/main/java/com/networknt/schema/AllOfValidator.java
@@ -38,6 +38,11 @@ public class AllOfValidator extends BaseJsonValidator {
             this.schemas.add(validationContext.newSchema(schemaLocation.append(i), evaluationPath.append(i),
                     schemaNode.get(i), parentSchema));
         }
+        for (JsonSchema schema : this.schemas) {
+            // Load the validators to parse the schema so that schema resources with $id can
+            // be identified
+            schema.getValidators();
+        }
     }
 
     @Override

--- a/src/main/java/com/networknt/schema/AllOfValidator.java
+++ b/src/main/java/com/networknt/schema/AllOfValidator.java
@@ -74,7 +74,7 @@ public class AllOfValidator extends BaseJsonValidator {
                         final ObjectNode allOfEntry = (ObjectNode) arrayElements.next();
                         final JsonNode $ref = allOfEntry.get("$ref");
                         if (null != $ref) {
-                            final ValidationContext.DiscriminatorContext currentDiscriminatorContext = this.validationContext
+                            final DiscriminatorContext currentDiscriminatorContext = executionContext
                                     .getCurrentDiscriminatorContext();
                             if (null != currentDiscriminatorContext) {
                                 final ObjectNode discriminator = currentDiscriminatorContext

--- a/src/main/java/com/networknt/schema/AnyOfValidator.java
+++ b/src/main/java/com/networknt/schema/AnyOfValidator.java
@@ -46,11 +46,6 @@ public class AnyOfValidator extends BaseJsonValidator {
         } else {
             this.discriminatorContext = null;
         }
-        for (JsonSchema schema : this.schemas) {
-            // Load the validators to parse the schema so that schema resources with $id can
-            // be identified
-            schema.getValidators();
-        }
     }
 
     @Override

--- a/src/main/java/com/networknt/schema/AnyOfValidator.java
+++ b/src/main/java/com/networknt/schema/AnyOfValidator.java
@@ -46,6 +46,11 @@ public class AnyOfValidator extends BaseJsonValidator {
         } else {
             this.discriminatorContext = null;
         }
+        for (JsonSchema schema : this.schemas) {
+            // Load the validators to parse the schema so that schema resources with $id can
+            // be identified
+            schema.getValidators();
+        }
     }
 
     @Override

--- a/src/main/java/com/networknt/schema/AnyOfValidator.java
+++ b/src/main/java/com/networknt/schema/AnyOfValidator.java
@@ -30,7 +30,7 @@ public class AnyOfValidator extends BaseJsonValidator {
     private static final String DISCRIMINATOR_REMARK = "and the discriminator-selected candidate schema didn't pass validation";
 
     private final List<JsonSchema> schemas = new ArrayList<>();
-    private final ValidationContext.DiscriminatorContext discriminatorContext;
+    private final DiscriminatorContext discriminatorContext;
 
     public AnyOfValidator(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaLocation, evaluationPath, schemaNode, parentSchema, ValidatorTypeCode.ANY_OF, validationContext);
@@ -42,7 +42,7 @@ public class AnyOfValidator extends BaseJsonValidator {
         }
 
         if (this.validationContext.getConfig().isOpenAPI3StyleDiscriminators()) {
-            this.discriminatorContext = new ValidationContext.DiscriminatorContext();
+            this.discriminatorContext = new DiscriminatorContext();
         } else {
             this.discriminatorContext = null;
         }
@@ -62,7 +62,7 @@ public class AnyOfValidator extends BaseJsonValidator {
         ValidatorState state = executionContext.getValidatorState();
 
         if (this.validationContext.getConfig().isOpenAPI3StyleDiscriminators()) {
-            this.validationContext.enterDiscriminatorContext(this.discriminatorContext, instanceLocation);
+            executionContext.enterDiscriminatorContext(this.discriminatorContext, instanceLocation);
         }
 
         boolean initialHasMatchedNode = state.hasMatchedNode();
@@ -153,7 +153,7 @@ public class AnyOfValidator extends BaseJsonValidator {
             }
         } finally {
             if (this.validationContext.getConfig().isOpenAPI3StyleDiscriminators()) {
-                this.validationContext.leaveDiscriminatorContextImmediately(instanceLocation);
+                executionContext.leaveDiscriminatorContextImmediately(instanceLocation);
             }
 
             Scope parentScope = collectorContext.exitDynamicScope();

--- a/src/main/java/com/networknt/schema/BaseJsonValidator.java
+++ b/src/main/java/com/networknt/schema/BaseJsonValidator.java
@@ -263,6 +263,13 @@ public abstract class BaseJsonValidator extends ValidationMessageHandler impleme
         return this.parentSchema;
     }
 
+    public JsonSchema getEvaluationParentSchema() {
+        if (this.evaluationParentSchema != null) {
+            return this.evaluationParentSchema;
+        }
+        return getParentSchema();
+    }
+
     protected JsonSchema fetchSubSchemaNode(ValidationContext validationContext) {
         return this.suppressSubSchemaRetrieval ? null : obtainSubSchemaNode(this.schemaNode, validationContext);
     }

--- a/src/main/java/com/networknt/schema/BaseJsonValidator.java
+++ b/src/main/java/com/networknt/schema/BaseJsonValidator.java
@@ -18,7 +18,6 @@ package com.networknt.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.networknt.schema.ValidationContext.DiscriminatorContext;
 import com.networknt.schema.i18n.DefaultMessageSource;
 
 import org.slf4j.Logger;
@@ -126,7 +125,7 @@ public abstract class BaseJsonValidator extends ValidationMessageHandler impleme
      * @param discriminatorPropertyValue  the value of the <code>discriminator/propertyName</code> field
      * @param jsonSchema                  the {@link JsonSchema} to check
      */
-    protected static void checkDiscriminatorMatch(final ValidationContext.DiscriminatorContext currentDiscriminatorContext,
+    protected static void checkDiscriminatorMatch(final DiscriminatorContext currentDiscriminatorContext,
                                                   final ObjectNode discriminator,
                                                   final String discriminatorPropertyValue,
                                                   final JsonSchema jsonSchema) {

--- a/src/main/java/com/networknt/schema/BaseJsonValidator.java
+++ b/src/main/java/com/networknt/schema/BaseJsonValidator.java
@@ -69,6 +69,20 @@ public abstract class BaseJsonValidator extends ValidationMessageHandler impleme
                         : PathType.DEFAULT;
     }
 
+    /**
+     * Copy constructor.
+     * 
+     * @param copy to copy from
+     */
+    protected BaseJsonValidator(BaseJsonValidator copy) {
+        super(copy);
+        this.suppressSubSchemaRetrieval = copy.suppressSubSchemaRetrieval;
+        this.applyDefaultsStrategy = copy.applyDefaultsStrategy;
+        this.pathType = copy.pathType;
+        this.schemaNode = copy.schemaNode;
+        this.validationContext = copy.validationContext;
+    }
+
     private static JsonSchema obtainSubSchemaNode(final JsonNode schemaNode, final ValidationContext validationContext) {
         final JsonNode node = schemaNode.get("id");
 

--- a/src/main/java/com/networknt/schema/CachedSupplier.java
+++ b/src/main/java/com/networknt/schema/CachedSupplier.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema;
+
+import java.util.function.Supplier;
+
+/**
+ * Supplier that caches the output.
+ * 
+ * @param <T> the type cached
+ */
+public class CachedSupplier<T> implements Supplier<T> {
+    private final Supplier<T> delegate;
+    private T cache = null;
+
+    public CachedSupplier(Supplier<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public T get() {
+        if (cache == null) {
+            cache = delegate.get();
+        }
+        return cache;
+    }
+
+}

--- a/src/main/java/com/networknt/schema/DiscriminatorContext.java
+++ b/src/main/java/com/networknt/schema/DiscriminatorContext.java
@@ -1,0 +1,41 @@
+package com.networknt.schema;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class DiscriminatorContext {
+    private final Map<String, ObjectNode> discriminators = new HashMap<>();
+
+    private boolean discriminatorMatchFound = false;
+
+    public void registerDiscriminator(final SchemaLocation schemaLocation, final ObjectNode discriminator) {
+        this.discriminators.put("#" + schemaLocation.getFragment().toString(), discriminator);
+    }
+
+    public ObjectNode getDiscriminatorForPath(final SchemaLocation schemaLocation) {
+        return this.discriminators.get("#" + schemaLocation.getFragment().toString());
+    }
+
+    public ObjectNode getDiscriminatorForPath(final String schemaLocation) {
+        return this.discriminators.get(schemaLocation);
+    }
+
+    public void markMatch() {
+        this.discriminatorMatchFound = true;
+    }
+
+    public boolean isDiscriminatorMatchFound() {
+        return this.discriminatorMatchFound;
+    }
+
+    /**
+     * Returns true if we have a discriminator active. In this case no valid match in anyOf should lead to validation failure
+     *
+     * @return true in case there are discriminator candidates
+     */
+    public boolean isActive() {
+        return !this.discriminators.isEmpty();
+    }
+}

--- a/src/main/java/com/networknt/schema/ExecutionContext.java
+++ b/src/main/java/com/networknt/schema/ExecutionContext.java
@@ -16,6 +16,8 @@
 
 package com.networknt.schema;
 
+import java.util.Stack;
+
 /**
  * Stores the execution context for the validation run.
  */
@@ -23,6 +25,7 @@ public class ExecutionContext {
     private ExecutionConfig executionConfig;
     private CollectorContext collectorContext;
     private ValidatorState validatorState = null;
+    private Stack<DiscriminatorContext> discriminatorContexts = new Stack<>();
 
     /**
      * Creates an execution context.
@@ -112,5 +115,20 @@ public class ExecutionContext {
      */
     public void setValidatorState(ValidatorState validatorState) {
         this.validatorState = validatorState;
+    }
+
+    public DiscriminatorContext getCurrentDiscriminatorContext() {
+        if (!this.discriminatorContexts.empty()) {
+            return this.discriminatorContexts.peek();
+        }
+        return null; // this is the case when we get on a schema that has a discriminator, but it's not used in anyOf
+    }
+
+    public void enterDiscriminatorContext(final DiscriminatorContext ctx, @SuppressWarnings("unused") JsonNodePath instanceLocation) {
+        this.discriminatorContexts.push(ctx);
+    }
+
+    public void leaveDiscriminatorContextImmediately(@SuppressWarnings("unused") JsonNodePath instanceLocation) {
+        this.discriminatorContexts.pop();
     }
 }

--- a/src/main/java/com/networknt/schema/JsonMetaSchema.java
+++ b/src/main/java/com/networknt/schema/JsonMetaSchema.java
@@ -226,6 +226,14 @@ public class JsonMetaSchema {
         return readText(schemaNode, this.idKeyword);
     }
 
+    public String readAnchor(JsonNode schemaNode) {
+        boolean supportsAnchor = this.keywords.containsKey("$anchor");
+        if (supportsAnchor) {
+            return readText(schemaNode, "$anchor");
+        }
+        return null;
+    }
+
     public JsonNode getNodeByFragmentRef(String ref, JsonNode node) {
         boolean supportsAnchor = this.keywords.containsKey("$anchor");
         String refName = supportsAnchor ? ref.substring(1) : ref;

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -243,7 +243,7 @@ public class JsonSchema extends BaseJsonValidator {
         JsonNode definitionsNode = schemaNode.get(definitionsKeyword);
         if (definitionsNode != null) {
             readSchemaResources(idKeyword, definitionsKeyword, definitionsNode,
-                    this.schemaLocation.resolve(definitionsKeyword), this.evaluationPath.resolve(definitionsKeyword),
+                    this.schemaLocation.append(definitionsKeyword), this.evaluationPath.append(definitionsKeyword),
                     this.currentUri);
         }
     }
@@ -268,7 +268,7 @@ public class JsonSchema extends BaseJsonValidator {
         while (pnames.hasNext()) {
             String pname = pnames.next();
             JsonNode nodeToUse = schemaNode.get(pname);
-            readSchemaResources(idKeyword, definitionsKeyword, nodeToUse, schemaLocation.resolve(pname), evaluationPath.resolve(pname), currentIdUri);
+            readSchemaResources(idKeyword, definitionsKeyword, nodeToUse, schemaLocation.append(pname), evaluationPath.append(pname), currentIdUri);
         }
     }
 

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -128,15 +128,15 @@ public class JsonSchema extends BaseJsonValidator {
      * This is typically used if this schema is a schema resource that can be
      * pointed to by various references.
      *
-     * @param refParent         the parent ref
+     * @param refEvaluationParentSchema the parent ref
      * @param refEvaluationPath the ref evaluation path
      * @return the schema
      */
-    public JsonSchema fromRef(JsonSchema refParent, JsonNodePath refEvaluationPath) {
+    public JsonSchema fromRef(JsonSchema refEvaluationParentSchema, JsonNodePath refEvaluationPath) {
         JsonSchema copy = new JsonSchema(this);
-        copy.validationContext.setConfig(refParent.validationContext.getConfig());
+        copy.validationContext.setConfig(refEvaluationParentSchema.validationContext.getConfig());
         copy.evaluationPath = refEvaluationPath;
-        copy.parentSchema = refParent;
+        copy.evaluationParentSchema = refEvaluationParentSchema;
         // Validator state is reset due to the changes in evaluation path
         copy.validatorsLoaded = false;
         copy.requiredValidator = null;

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -255,6 +255,20 @@ public class JsonSchema extends BaseJsonValidator {
         JsonSchema ancestor = this;
         while (ancestor.getId() == null) {
             if (null == ancestor.getParentSchema()) break;
+            // The lexical root should not cross
+            if (ancestor.currentUri != null && ancestor.parentSchema.currentUri == null) break;
+            if (ancestor.currentUri == null && ancestor.parentSchema.currentUri != null) break;
+            if (ancestor.getCurrentUri() != null && ancestor.getParentSchema().getCurrentUri() != null) {
+                if (!Objects.equals(ancestor.getCurrentUri().getScheme(), ancestor.getParentSchema().getCurrentUri().getScheme())) {
+                    break;
+                }
+                if (!Objects.equals(ancestor.getCurrentUri().getHost(), ancestor.getParentSchema().getCurrentUri().getHost())) {
+                    break;
+                }
+                if (!Objects.equals(ancestor.getCurrentUri().getPath(), ancestor.getParentSchema().getCurrentUri().getPath())) {
+                    break;
+                }
+            }
             ancestor = ancestor.getParentSchema();
         }
         return ancestor;

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -126,7 +126,11 @@ public class JsonSchema extends BaseJsonValidator {
      */
     public JsonSchema fromRef(JsonSchema refEvaluationParentSchema, JsonNodePath refEvaluationPath) {
         JsonSchema copy = new JsonSchema(this);
-        copy.validationContext.setConfig(refEvaluationParentSchema.validationContext.getConfig());
+        copy.validationContext = new ValidationContext(copy.validationContext.getURIFactory(),
+                copy.getValidationContext().getURNFactory(), copy.getValidationContext().getMetaSchema(),
+                copy.getValidationContext().getJsonSchemaFactory(),
+                refEvaluationParentSchema.validationContext.getConfig(),
+                copy.getValidationContext().getSchemaReferences(), copy.getValidationContext().getSchemaResources());
         copy.evaluationPath = refEvaluationPath;
         copy.evaluationParentSchema = refEvaluationParentSchema;
         // Validator state is reset due to the changes in evaluation path
@@ -136,6 +140,24 @@ public class JsonSchema extends BaseJsonValidator {
         copy.validators = null;
         copy.initializeConfig();
         return copy;
+    }
+
+    public JsonSchema withConfig(SchemaValidatorsConfig config) {
+        if (!this.getValidationContext().getConfig().equals(config)) {
+            JsonSchema copy = new JsonSchema(this);
+            copy.validationContext = new ValidationContext(copy.validationContext.getURIFactory(),
+                    copy.getValidationContext().getURNFactory(), copy.getValidationContext().getMetaSchema(),
+                    copy.getValidationContext().getJsonSchemaFactory(), config,
+                    copy.getValidationContext().getSchemaReferences(),
+                    copy.getValidationContext().getSchemaResources());
+            copy.validatorsLoaded = false;
+            copy.requiredValidator = null;
+            copy.typeValidator = null;
+            copy.validators = null;
+            copy.initializeConfig();
+            return copy;
+        }
+        return this;
     }
 
     public JsonSchema createChildSchema(SchemaLocation schemaLocation, JsonNode schemaNode) {

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -79,9 +79,6 @@ public class JsonSchema extends BaseJsonValidator {
         if (uriRefersToSubschema(currentUri, schemaLocation)) {
             updateThisAsSubschema(currentUri);
         }
-        if (this.currentUri != null) {
-            this.validationContext.getSchemaResources().putIfAbsent(this.currentUri.toString(), this);
-        }
         String idKeyword = this.validationContext.getMetaSchema().getIdKeyword();
         if (idKeyword != null) {
             readDefinitions(idKeyword, "definitions");
@@ -98,6 +95,10 @@ public class JsonSchema extends BaseJsonValidator {
             }
         }
         this.id = validationContext.resolveSchemaId(this.schemaNode);
+        if (this.id != null) {
+            this.validationContext.getSchemaResources()
+                    .putIfAbsent(this.currentUri != null ? this.currentUri.toString() : this.id, this);
+        }
     }
 
     public JsonSchema createChildSchema(SchemaLocation schemaLocation, JsonNode schemaNode) {

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -80,15 +80,7 @@ public class JsonSchema extends BaseJsonValidator {
         if (uriRefersToSubschema(currentUri, schemaLocation)) {
             updateThisAsSubschema(currentUri);
         }
-        if (validationContext.getConfig() != null) {
-            this.keywordWalkListenerRunner = new DefaultKeywordWalkListenerRunner(this.validationContext.getConfig().getKeywordWalkListenersMap());
-            if (validationContext.getConfig().isOpenAPI3StyleDiscriminators()) {
-                ObjectNode discriminator = (ObjectNode) schemaNode.get("discriminator");
-                if (null != discriminator && null != validationContext.getCurrentDiscriminatorContext()) {
-                    validationContext.getCurrentDiscriminatorContext().registerDiscriminator(schemaLocation, discriminator);
-                }
-            }
-        }
+        initializeConfig();
         this.id = validationContext.resolveSchemaId(this.schemaNode);
         this.anchor = validationContext.getMetaSchema().readAnchor(this.schemaNode);
         readDefinitions("definitions");
@@ -99,6 +91,20 @@ public class JsonSchema extends BaseJsonValidator {
         }
         if (this.anchor != null) {
             this.validationContext.getSchemaResources().putIfAbsent(this.currentUri.toString() + "#" + anchor, this);
+        }
+    }
+    
+    private void initializeConfig() {
+        if (validationContext.getConfig() != null) {
+            this.keywordWalkListenerRunner = new DefaultKeywordWalkListenerRunner(
+                    this.validationContext.getConfig().getKeywordWalkListenersMap());
+            if (validationContext.getConfig().isOpenAPI3StyleDiscriminators()) {
+                ObjectNode discriminator = (ObjectNode) schemaNode.get("discriminator");
+                if (null != discriminator && null != validationContext.getCurrentDiscriminatorContext()) {
+                    validationContext.getCurrentDiscriminatorContext().registerDiscriminator(schemaLocation,
+                            discriminator);
+                }
+            }
         }
     }
 
@@ -142,6 +148,7 @@ public class JsonSchema extends BaseJsonValidator {
         copy.requiredValidator = null;
         copy.typeValidator = null;
         copy.validators = null;
+        copy.initializeConfig();
         return copy;
     }
 

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -76,8 +76,6 @@ public class JsonSchema extends BaseJsonValidator {
         initializeConfig();
         this.id = validationContext.resolveSchemaId(this.schemaNode);
         this.anchor = validationContext.getMetaSchema().readAnchor(this.schemaNode);
-        readDefinitions("definitions");
-        readDefinitions("$defs");
         if (this.id != null) {
             this.validationContext.getSchemaResources()
                     .putIfAbsent(this.currentUri != null ? this.currentUri.toString() : this.id, this);
@@ -85,6 +83,7 @@ public class JsonSchema extends BaseJsonValidator {
         if (this.anchor != null) {
             this.validationContext.getSchemaResources().putIfAbsent(this.currentUri.toString() + "#" + anchor, this);
         }
+        getValidators();
     }
     
     private void initializeConfig() {
@@ -158,10 +157,6 @@ public class JsonSchema extends BaseJsonValidator {
             return copy;
         }
         return this;
-    }
-
-    public JsonSchema createChildSchema(SchemaLocation schemaLocation, JsonNode schemaNode) {
-        return getValidationContext().newSchema(schemaLocation, evaluationPath, schemaNode, this);
     }
 
     ValidationContext getValidationContext() {
@@ -318,28 +313,6 @@ public class JsonSchema extends BaseJsonValidator {
         return null;
     }
     
-    private void readDefinitions(String definitionsKeyword) {
-        JsonNode definitionsNode = schemaNode.get(definitionsKeyword);
-        if (definitionsNode != null) {
-            readSchemaResources(definitionsNode, this.schemaLocation.append(definitionsKeyword),
-                    this.evaluationPath.append(definitionsKeyword));
-        }
-    }
-
-    private void readSchemaResources(JsonNode definitionsNode, SchemaLocation schemaLocation, JsonNodePath evaluationPath) {
-        Iterator<String> pnames = definitionsNode.fieldNames();
-        while (pnames.hasNext()) {
-            String pname = pnames.next();
-            JsonNode nodeToUse = definitionsNode.get(pname);
-            // The schema resources with id or anchor will be stored during the constructor
-            // call of JsonSchema
-            JsonSchema schema = this.validationContext.newSchema(schemaLocation.append(pname), evaluationPath.append(pname), nodeToUse,
-                    this);
-            schema.getValidators();
-        }
-    }
-
-
     /**
      * Please note that the key in {@link #validators} map is the evaluation path.
      */

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -101,14 +101,22 @@ public class JsonSchema extends BaseJsonValidator {
         }
     }
 
-    private JsonSchema(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode,
-            JsonSchema parentSchema, ErrorMessageType errorMessageType, Keyword keyword,
-            ValidationContext validationContext, boolean suppressSubSchemaRetrieval) {
-        super(schemaLocation, evaluationPath, schemaNode, parentSchema, null, null, validationContext,
-                suppressSubSchemaRetrieval);
-        this.validationContext = validationContext;
-        this.metaSchema = validationContext.getMetaSchema();
-        this.id = validationContext.resolveSchemaId(this.schemaNode);
+    /**
+     * Copy constructor.
+     * 
+     * @param copy to copy from
+     */
+    protected JsonSchema(JsonSchema copy) {
+        super(copy);
+        this.validators = copy.validators;
+        this.metaSchema = copy.metaSchema;
+        this.validatorsLoaded = copy.validatorsLoaded;
+        this.dynamicAnchor = copy.dynamicAnchor;
+        this.currentUri = copy.currentUri;
+        this.requiredValidator = copy.requiredValidator;
+        this.typeValidator = copy.typeValidator;
+        this.keywordWalkListenerRunner = copy.keywordWalkListenerRunner;
+        this.id = copy.id;
     }
 
     /**
@@ -123,9 +131,14 @@ public class JsonSchema extends BaseJsonValidator {
      * @return the schema
      */
     public JsonSchema fromRef(JsonSchema refParent, JsonNodePath refEvaluationPath) {
-        JsonSchema copy = new JsonSchema(this.schemaLocation, refEvaluationPath, this.schemaNode, refParent, null, null, this.validationContext, this.suppressSubSchemaRetrieval);
-        copy.currentUri = this.currentUri;
-        copy.keywordWalkListenerRunner = this.keywordWalkListenerRunner;
+        JsonSchema copy = new JsonSchema(this);
+        copy.evaluationPath = refEvaluationPath;
+        copy.parentSchema = refParent;
+        // Validator state is reset due to the changes in evaluation path
+        copy.validatorsLoaded = false;
+        copy.requiredValidator = null;
+        copy.typeValidator = null;
+        copy.validators = null;
         return copy;
     }
 
@@ -149,7 +162,8 @@ public class JsonSchema extends BaseJsonValidator {
             } catch (IllegalArgumentException e) {
                 SchemaLocation path = schemaLocation.append(this.metaSchema.getIdKeyword());
                 ValidationMessage validationMessage = ValidationMessage.builder().code(ValidatorTypeCode.ID.getValue())
-                        .type(ValidatorTypeCode.ID.getValue()).instanceLocation(path.getFragment()).evaluationPath(path.getFragment())
+                        .type(ValidatorTypeCode.ID.getValue()).instanceLocation(path.getFragment())
+                        .evaluationPath(path.getFragment())
                         .arguments(currentUri == null ? "null" : currentUri.toString(), id)
                         .messageFormatter(args -> this.validationContext.getConfig().getMessageSource().getMessage(
                                 ValidatorTypeCode.ID.getValue(), this.validationContext.getConfig().getLocale(), args))

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -256,21 +256,11 @@ public class JsonSchema extends BaseJsonValidator {
             // This is a schema resource
             // $id inside an unknown keyword is not a read identifier
             if (definitionsKeyword.equals(evaluationPath.getElement(evaluationPath.getNameCount() - 2))) {
-                String id = idNode.asText();
-                URI uri = null;
-                if (id.contains(":")) {
-                    uri = URI.create(id);
-                } else {
-                    uri = idUri;
-                    if (uri == null) {
-                        uri = URI.create("");
-                    }
-                    uri = uri.resolve(id);
-                }
-                currentIdUri = uri;
-                JsonSchema resource = new JsonSchema(validationContext, schemaLocation, evaluationPath, uri, schemaNode,
-                        this, true);
-                this.validationContext.getSchemaResources().put(uri.toString(), resource);
+                // The schema resource will be registered in the JsonSchema constructor
+                // The combineCurrentUriWithIds will combine the uri with the id to get the new currentIdUri
+                JsonSchema schemaResource = new JsonSchema(validationContext, schemaLocation, evaluationPath, idUri, schemaNode, this,
+                        true);
+                currentIdUri = schemaResource.getCurrentUri();
             }
         }
 

--- a/src/main/java/com/networknt/schema/JsonSchemaFactory.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaFactory.java
@@ -330,17 +330,21 @@ public class JsonSchemaFactory {
         return doCreate(validationContext, getSchemaLocation(schemaUri, schemaNode, validationContext),
                 new JsonNodePath(validationContext.getConfig().getPathType()), schemaUri, schemaNode, null, false);
     }
-    
-    public JsonSchema create(ValidationContext validationContext, SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode, JsonSchema parentSchema) {
+
+    public JsonSchema create(ValidationContext validationContext, SchemaLocation schemaLocation, JsonNodePath evaluationPath, URI currentUri, JsonNode schemaNode, JsonSchema parentSchema) {
         return doCreate(validationContext,
-                null == schemaLocation ? getSchemaLocation(null, schemaNode, validationContext) : schemaLocation,
-                evaluationPath, parentSchema.getCurrentUri(), schemaNode, parentSchema, false);
+                null == schemaLocation ? getSchemaLocation(currentUri, schemaNode, validationContext) : schemaLocation,
+                evaluationPath, currentUri, schemaNode, parentSchema, false);
+    }
+
+    public JsonSchema create(ValidationContext validationContext, SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode, JsonSchema parentSchema) {
+        return create(validationContext, schemaLocation, evaluationPath, parentSchema.getCurrentUri(), schemaNode, parentSchema);
     }
 
     private JsonSchema doCreate(ValidationContext validationContext, SchemaLocation schemaLocation, JsonNodePath evaluationPath, URI currentUri, JsonNode schemaNode, JsonSchema parentSchema, boolean suppressSubSchemaRetrieval) {
         return JsonSchema.from(validationContext, schemaLocation, evaluationPath, currentUri, schemaNode, parentSchema, suppressSubSchemaRetrieval);
     }
-    
+
     /**
      * Gets the schema location from the $id or retrieval uri.
      *

--- a/src/main/java/com/networknt/schema/JsonSchemaFactory.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaFactory.java
@@ -476,7 +476,7 @@ public class JsonSchemaFactory {
             }
             return jsonSchema;
         } catch (IOException | URISyntaxException e) {
-            logger.error("Failed to load json schema!", e);
+            logger.error("Failed to load json schema from {}", schemaUri, e);
             throw new JsonSchemaException(e);
         }
     }

--- a/src/main/java/com/networknt/schema/JsonSchemaFactory.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaFactory.java
@@ -212,7 +212,7 @@ public class JsonSchemaFactory {
     private final URNFactory urnFactory;
     private final Map<String, JsonMetaSchema> jsonMetaSchemas;
     private final Map<String, String> uriMap;
-    private final ConcurrentMap<URI, JsonSchema> uriSchemaCache = new ConcurrentHashMap<URI, JsonSchema>();
+    private final ConcurrentMap<URI, JsonSchema> uriSchemaCache = new ConcurrentHashMap<>();
     private final boolean enableUriSchemaCache;
 
 

--- a/src/main/java/com/networknt/schema/JsonSchemaFactory.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaFactory.java
@@ -472,6 +472,15 @@ public class JsonSchemaFactory {
                 ValidationContext validationContext = new ValidationContext(this.uriFactory, this.urnFactory, jsonMetaSchema, this, config);
                 jsonSchema = doCreate(validationContext, schemaLocation, evaluationPath, mappedUri, schemaNode, null, true /* retrieved via id, resolving will not change anything */);
             } else {
+                String schemaLocationValue = schemaUri.toString();
+                String id = jsonMetaSchema.readId(schemaNode);
+                if (id != null) {
+                    schemaLocationValue = id;
+                }
+                if(!schemaLocationValue.contains("#")) {
+                    schemaLocationValue = schemaLocationValue + "#";
+                }
+                SchemaLocation schemaLocation = SchemaLocation.of(schemaLocationValue);
                 final ValidationContext validationContext = createValidationContext(schemaNode);
                 validationContext.setConfig(config);
                 jsonSchema = doCreate(validationContext, SchemaLocation.of(""), evaluationPath, mappedUri, schemaNode, null, false);

--- a/src/main/java/com/networknt/schema/JsonSchemaFactory.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaFactory.java
@@ -477,13 +477,18 @@ public class JsonSchemaFactory {
                 if (id != null) {
                     schemaLocationValue = id;
                 }
-                if(!schemaLocationValue.contains("#")) {
+                if (schemaLocationValue.contains("#")) {
+                    // Schema location needs to strip off the fragment as the json schema for the constructor to detect
+                    // it is a subschema
+                    schemaLocationValue = schemaLocationValue.substring(0, schemaLocationValue.indexOf("#") + 1);
+                }
+                if (!schemaLocationValue.contains("#")) {
                     schemaLocationValue = schemaLocationValue + "#";
                 }
                 SchemaLocation schemaLocation = SchemaLocation.of(schemaLocationValue);
                 final ValidationContext validationContext = createValidationContext(schemaNode);
                 validationContext.setConfig(config);
-                jsonSchema = doCreate(validationContext, SchemaLocation.of(""), evaluationPath, mappedUri, schemaNode, null, false);
+                jsonSchema = doCreate(validationContext, schemaLocation, evaluationPath, mappedUri, schemaNode, null, false);
             }
             return jsonSchema;
         } catch (IOException e) {

--- a/src/main/java/com/networknt/schema/JsonSchemaRef.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaRef.java
@@ -18,6 +18,7 @@ package com.networknt.schema;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Use this object instead a JsonSchema for references.
@@ -28,23 +29,23 @@ import java.util.Set;
 
 public class JsonSchemaRef {
 
-    private final JsonSchema schema;
+    private final Supplier<JsonSchema> schemaSupplier;
 
-    public JsonSchemaRef(JsonSchema schema) {
-        this.schema = schema;
+    public JsonSchemaRef(Supplier<JsonSchema> schema) {
+        this.schemaSupplier = schema;
     }
 
     public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation) {
-        return schema.validate(executionContext, node, rootNode, instanceLocation);
+        return getSchema().validate(executionContext, node, rootNode, instanceLocation);
     }
 
     public JsonSchema getSchema() {
-        return schema;
+        return this.schemaSupplier.get();
     }
 
     public Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation, boolean shouldValidateSchema) {
-        return schema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
+        return getSchema().walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
     }
 }

--- a/src/main/java/com/networknt/schema/JsonSchemaRef.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaRef.java
@@ -15,9 +15,6 @@
  */
 package com.networknt.schema;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
-import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -31,17 +28,7 @@ public class JsonSchemaRef {
         this.schemaSupplier = schema;
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
-            JsonNodePath instanceLocation) {
-        return getSchema().validate(executionContext, node, rootNode, instanceLocation);
-    }
-
     public JsonSchema getSchema() {
         return this.schemaSupplier.get();
-    }
-
-    public Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
-            JsonNodePath instanceLocation, boolean shouldValidateSchema) {
-        return getSchema().walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
     }
 }

--- a/src/main/java/com/networknt/schema/JsonSchemaRef.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaRef.java
@@ -22,11 +22,7 @@ import java.util.function.Supplier;
 
 /**
  * Use this object instead a JsonSchema for references.
- * <p>
- * This reference may be empty (if the reference is being parsed) or with data (after the reference has been parsed),
- * helping to prevent recursive reference to cause an infinite loop.
  */
-
 public class JsonSchemaRef {
 
     private final Supplier<JsonSchema> schemaSupplier;

--- a/src/main/java/com/networknt/schema/NonValidationKeyword.java
+++ b/src/main/java/com/networknt/schema/NonValidationKeyword.java
@@ -27,8 +27,14 @@ import java.util.Set;
 public class NonValidationKeyword extends AbstractKeyword {
 
     private static final class Validator extends AbstractJsonValidator {
-        public Validator(SchemaLocation schemaLocation, JsonNodePath evaluationPath, Keyword keyword) {
+        public Validator(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode,
+                JsonSchema parentSchema, ValidationContext validationContext, Keyword keyword) {
             super(schemaLocation, evaluationPath, keyword);
+            String id = validationContext.resolveSchemaId(schemaNode);
+            if (id != null) {
+                // Used to register schema resources with $id
+                validationContext.newSchema(schemaLocation, evaluationPath, schemaNode, parentSchema);
+            }
         }
 
         @Override
@@ -44,6 +50,6 @@ public class NonValidationKeyword extends AbstractKeyword {
     @Override
     public JsonValidator newValidator(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode,
                                       JsonSchema parentSchema, ValidationContext validationContext) throws JsonSchemaException, Exception {
-        return new Validator(schemaLocation, evaluationPath, this);
+        return new Validator(schemaLocation, evaluationPath, schemaNode, parentSchema, validationContext, this);
     }
 }

--- a/src/main/java/com/networknt/schema/NonValidationKeyword.java
+++ b/src/main/java/com/networknt/schema/NonValidationKeyword.java
@@ -31,7 +31,8 @@ public class NonValidationKeyword extends AbstractKeyword {
                 JsonSchema parentSchema, ValidationContext validationContext, Keyword keyword) {
             super(schemaLocation, evaluationPath, keyword);
             String id = validationContext.resolveSchemaId(schemaNode);
-            if (id != null) {
+            String anchor = validationContext.getMetaSchema().readAnchor(schemaNode);
+            if (id != null || anchor != null) {
                 // Used to register schema resources with $id
                 validationContext.newSchema(schemaLocation, evaluationPath, schemaNode, parentSchema);
             }

--- a/src/main/java/com/networknt/schema/NonValidationKeyword.java
+++ b/src/main/java/com/networknt/schema/NonValidationKeyword.java
@@ -19,6 +19,8 @@ package com.networknt.schema;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map.Entry;
 import java.util.Set;
 
 /**
@@ -35,6 +37,13 @@ public class NonValidationKeyword extends AbstractKeyword {
             if (id != null || anchor != null) {
                 // Used to register schema resources with $id
                 validationContext.newSchema(schemaLocation, evaluationPath, schemaNode, parentSchema);
+            }
+            if ("$defs".equals(keyword.getValue()) || "definitions".equals(keyword.getValue())) {
+                for (Iterator<Entry<String, JsonNode>> field = schemaNode.fields(); field.hasNext(); ) {
+                    Entry<String, JsonNode> property = field.next();
+                    validationContext.newSchema(schemaLocation.append(property.getKey()),
+                            evaluationPath.append(property.getKey()), property.getValue(), parentSchema);
+                }
             }
         }
 

--- a/src/main/java/com/networknt/schema/NotValidator.java
+++ b/src/main/java/com/networknt/schema/NotValidator.java
@@ -32,10 +32,6 @@ public class NotValidator extends BaseJsonValidator {
     public NotValidator(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaLocation, evaluationPath, schemaNode, parentSchema, ValidatorTypeCode.NOT, validationContext);
         this.schema = validationContext.newSchema(schemaLocation, evaluationPath, schemaNode, parentSchema);
-
-        // Load the validators to parse the schema so that schema resources with $id can
-        // be identified
-        this.schema.getValidators();
     }
 
     @Override

--- a/src/main/java/com/networknt/schema/NotValidator.java
+++ b/src/main/java/com/networknt/schema/NotValidator.java
@@ -32,6 +32,10 @@ public class NotValidator extends BaseJsonValidator {
     public NotValidator(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaLocation, evaluationPath, schemaNode, parentSchema, ValidatorTypeCode.NOT, validationContext);
         this.schema = validationContext.newSchema(schemaLocation, evaluationPath, schemaNode, parentSchema);
+
+        // Load the validators to parse the schema so that schema resources with $id can
+        // be identified
+        this.schema.getValidators();
     }
 
     @Override

--- a/src/main/java/com/networknt/schema/OneOfValidator.java
+++ b/src/main/java/com/networknt/schema/OneOfValidator.java
@@ -36,11 +36,6 @@ public class OneOfValidator extends BaseJsonValidator {
             JsonNode childNode = schemaNode.get(i);
             this.schemas.add(validationContext.newSchema( schemaLocation.append(i), evaluationPath.append(i), childNode, parentSchema));
         }
-        for (JsonSchema schema : this.schemas) {
-            // Load the validators to parse the schema so that schema resources with $id can
-            // be identified
-            schema.getValidators();
-        }
     }
 
     @Override

--- a/src/main/java/com/networknt/schema/OneOfValidator.java
+++ b/src/main/java/com/networknt/schema/OneOfValidator.java
@@ -36,6 +36,11 @@ public class OneOfValidator extends BaseJsonValidator {
             JsonNode childNode = schemaNode.get(i);
             this.schemas.add(validationContext.newSchema( schemaLocation.append(i), evaluationPath.append(i), childNode, parentSchema));
         }
+        for (JsonSchema schema : this.schemas) {
+            // Load the validators to parse the schema so that schema resources with $id can
+            // be identified
+            schema.getValidators();
+        }
     }
 
     @Override

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -119,8 +119,7 @@ public class RefValidator extends BaseJsonValidator {
         JsonSchema parent = parentSupplier.get();
         JsonNode node = parent.getRefSchemaNode(refValue);
         if (node != null) {
-            JsonSchemaRef ref = validationContext.getReferenceParsingInProgress(refValueOriginal);
-            if (ref == null) {
+            return validationContext.getSchemaReferences().computeIfAbsent(refValueOriginal, key -> {
                 SchemaLocation path = null;
                 if (refValue.startsWith(REF_CURRENT)) {
                     // relative to document
@@ -143,10 +142,8 @@ public class RefValidator extends BaseJsonValidator {
                     }
                 }
                 final JsonSchema schema = validationContext.newSchema(path, evaluationPath, node, parent);
-                ref = new JsonSchemaRef(() -> schema);
-                validationContext.setReferenceParsingInProgress(refValueOriginal, ref);
-            }
-            return ref;
+                return new JsonSchemaRef(() -> schema);
+            });
         }
         return null;
     }

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -127,7 +127,7 @@ public class RefValidator extends BaseJsonValidator {
         }
         if (refValue.equals(REF_CURRENT)) {
             Supplier<JsonSchema> supplier = parent;
-            return new JsonSchemaRef(() -> supplier.get().findLexicalRoot());
+            return new JsonSchemaRef(() -> supplier.get().findSchemaResourceRoot());
         }
         return getJsonSchemaRef(parent, validationContext, refValue, refValueOriginal, evaluationPath);
     }
@@ -177,7 +177,7 @@ public class RefValidator extends BaseJsonValidator {
                     path = SchemaLocation.of(refValue); 
                 } else {
                     // relative to lexical root
-                    String id = parent.findLexicalRoot().getId();
+                    String id = parent.findSchemaResourceRoot().getId();
                     path = SchemaLocation.of(id);
                     String[] parts = refValue.split("/");
                     for (int x = 1; x < parts.length; x++) {

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -31,8 +31,6 @@ public class RefValidator extends BaseJsonValidator {
 
     protected JsonSchemaRef schema;
 
-    private JsonSchema parentSchema;
-
     private static final String REF_CURRENT = "#";
 
     public RefValidator(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
@@ -232,7 +230,6 @@ public class RefValidator extends BaseJsonValidator {
             if (refSchema == null) {
                 throw new JsonSchemaException("Unable to resolve ref");
             }
-            refSchema.getValidationContext().setConfig(this.parentSchema.getValidationContext().getConfig());
             if (this.schema != null) {
                 errors =  this.schema.validate(executionContext, node, rootNode, instanceLocation);
             } else {
@@ -263,7 +260,6 @@ public class RefValidator extends BaseJsonValidator {
             if (refSchema == null) {
                 throw new JsonSchemaException("Unable to resolve ref");
             }
-            refSchema.getValidationContext().setConfig(this.parentSchema.getValidationContext().getConfig());
             if (refSchema != null) {
                 errors = refSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
             }

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -94,7 +94,8 @@ public class RefValidator extends BaseJsonValidator {
             parent = new CachedSupplier<>(() -> {
                 JsonSchema schemaResource = validationContext.getSchemaResources().get(schemaUriFinal.toString());
                 if (schemaResource != null) {
-                    return schemaResource;
+                    // Schema resource needs to update the parent and evaluation path
+                    return schemaResource.fromRef(parentSchema, evaluationPath);
                 }
                 return validationContext.getJsonSchemaFactory().getSchema(schemaUriFinal, validationContext.getConfig())
                         .findAncestor();

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -139,11 +139,12 @@ public class RefValidator extends BaseJsonValidator {
                             if (id.contains(":")) {
                                 // absolute
                                 currentUri = URI.create(id);
-                                path = SchemaLocation.of(id + "#");
+                                path = SchemaLocation.of(id);
                             } else {
                                 // relative
-                                currentUri = URI.create(path.append(id).toString());
-                                path = path.append(id + "#");
+                                String absoluteUri = path.getAbsoluteIri().resolve(id).toString();
+                                currentUri = URI.create(absoluteUri);
+                                path = SchemaLocation.of(absoluteUri);
                             }
                         }
                     }

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -54,6 +54,26 @@ public class RefValidator extends BaseJsonValidator {
 
     static JsonSchemaRef getRefSchema(JsonSchema parentSchema, ValidationContext validationContext, String refValue,
             JsonNodePath evaluationPath) {
+        // $ref prevents a sibling $id from changing the base uri
+        JsonSchema base = parentSchema;
+        if (parentSchema.getId() != null && parentSchema.parentSchema != null) {
+            base = parentSchema.parentSchema;
+        }
+        if (base.getCurrentUri() != null) {
+            SchemaLocation schemaLocation = SchemaLocation.of(base.getCurrentUri().toString());
+            JsonNodePath fragment = new JsonNodePath(PathType.JSON_POINTER);
+            if (refValue.startsWith("#")) {
+                schemaLocation = SchemaLocation.of(schemaLocation.getAbsoluteIri() + refValue);
+            } else {
+                schemaLocation = new SchemaLocation(schemaLocation.getAbsoluteIri().resolve(refValue),
+                        fragment);
+            }
+            JsonSchema schemaResource = validationContext.getSchemaResources().get(schemaLocation.toString());
+            if (schemaResource != null) {
+                // Schema resource needs to update the parent and evaluation path
+                return new JsonSchemaRef(() -> schemaResource.fromRef(parentSchema, evaluationPath));
+            }
+        }
         // The evaluationPath is used to derive the keywordLocation
         final String refValueOriginal = refValue;
 

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -98,7 +98,7 @@ public class RefValidator extends BaseJsonValidator {
                     return schemaResource.fromRef(parentSchema, evaluationPath);
                 }
                 return validationContext.getJsonSchemaFactory().getSchema(schemaUriFinal, validationContext.getConfig())
-                        .findAncestor();
+                        .findAncestor().fromRef(null, evaluationPath); // Setting the parent affects the lexical root
             });
             if (index < 0) {
                 return new JsonSchemaRef(parent);

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -98,7 +98,7 @@ public class RefValidator extends BaseJsonValidator {
                     return schemaResource.fromRef(parentSchema, evaluationPath);
                 }
                 return validationContext.getJsonSchemaFactory().getSchema(schemaUriFinal, validationContext.getConfig())
-                        .findAncestor().fromRef(null, evaluationPath); // Setting the parent affects the lexical root
+                        .findAncestor().fromRef(parentSchema, evaluationPath); // Setting the parent affects the lexical root
             });
             if (index < 0) {
                 return new JsonSchemaRef(parent);
@@ -107,7 +107,7 @@ public class RefValidator extends BaseJsonValidator {
         }
         if (refValue.equals(REF_CURRENT)) {
             Supplier<JsonSchema> supplier = parent;
-            return new JsonSchemaRef(() -> supplier.get().findAncestor());
+            return new JsonSchemaRef(() -> supplier.get().findLexicalRoot());
         }
         return getJsonSchemaRef(parent, validationContext, refValue, refValueOriginal, evaluationPath);
     }

--- a/src/main/java/com/networknt/schema/ValidationContext.java
+++ b/src/main/java/com/networknt/schema/ValidationContext.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Stack;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -34,9 +35,9 @@ public class ValidationContext {
     private final JsonMetaSchema metaSchema;
     private final JsonSchemaFactory jsonSchemaFactory;
     private SchemaValidatorsConfig config;
-    private final Map<String, JsonSchemaRef> refParsingInProgress = new HashMap<>();
     private final Stack<DiscriminatorContext> discriminatorContexts = new Stack<>();
-    private final Map<String, JsonSchema> schemaResources = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, JsonSchemaRef> schemaReferences = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, JsonSchema> schemaResources = new ConcurrentHashMap<>();
 
     public ValidationContext(URIFactory uriFactory, URNFactory urnFactory, JsonMetaSchema metaSchema,
                              JsonSchemaFactory jsonSchemaFactory, SchemaValidatorsConfig config) {
@@ -92,15 +93,21 @@ public class ValidationContext {
         this.config = config;
     }
 
-    public void setReferenceParsingInProgress(String refValue, JsonSchemaRef ref) {
-        this.refParsingInProgress.put(refValue, ref);
+    /**
+     * Gets the schema references identified by the ref uri.
+     *
+     * @return the schema references
+     */
+    public ConcurrentMap<String, JsonSchemaRef> getSchemaReferences() {
+        return this.schemaReferences;
     }
 
-    public JsonSchemaRef getReferenceParsingInProgress(String refValue) {
-        return this.refParsingInProgress.get(refValue);
-    }
-
-    public Map<String, JsonSchema> getSchemaResources() {
+    /**
+     * Gets the schema resources identified by id.
+     *
+     * @return the schema resources
+     */
+    public ConcurrentMap<String, JsonSchema> getSchemaResources() {
         return this.schemaResources;
     }
 

--- a/src/main/java/com/networknt/schema/ValidationContext.java
+++ b/src/main/java/com/networknt/schema/ValidationContext.java
@@ -16,6 +16,7 @@
 
 package com.networknt.schema;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -59,6 +60,10 @@ public class ValidationContext {
 
     public JsonSchema newSchema(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode, JsonSchema parentSchema) {
         return getJsonSchemaFactory().create(this, schemaLocation, evaluationPath, schemaNode, parentSchema);
+    }
+
+    public JsonSchema newSchema(SchemaLocation schemaLocation, JsonNodePath evaluationPath, URI currentUri, JsonNode schemaNode, JsonSchema parentSchema) {
+        return getJsonSchemaFactory().create(this, schemaLocation, evaluationPath, currentUri, schemaNode, parentSchema);
     }
 
     public JsonValidator newValidator(SchemaLocation schemaLocation, JsonNodePath evaluationPath,

--- a/src/main/java/com/networknt/schema/ValidationContext.java
+++ b/src/main/java/com/networknt/schema/ValidationContext.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Stack;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -35,6 +36,7 @@ public class ValidationContext {
     private SchemaValidatorsConfig config;
     private final Map<String, JsonSchemaRef> refParsingInProgress = new HashMap<>();
     private final Stack<DiscriminatorContext> discriminatorContexts = new Stack<>();
+    private final Map<String, JsonSchema> schemaResources = new ConcurrentHashMap<>();
 
     public ValidationContext(URIFactory uriFactory, URNFactory urnFactory, JsonMetaSchema metaSchema,
                              JsonSchemaFactory jsonSchemaFactory, SchemaValidatorsConfig config) {
@@ -96,6 +98,10 @@ public class ValidationContext {
 
     public JsonSchemaRef getReferenceParsingInProgress(String refValue) {
         return this.refParsingInProgress.get(refValue);
+    }
+
+    public Map<String, JsonSchema> getSchemaResources() {
+        return this.schemaResources;
     }
 
     public DiscriminatorContext getCurrentDiscriminatorContext() {

--- a/src/main/java/com/networknt/schema/ValidationContext.java
+++ b/src/main/java/com/networknt/schema/ValidationContext.java
@@ -31,12 +31,19 @@ public class ValidationContext {
     private final URNFactory urnFactory;
     private final JsonMetaSchema metaSchema;
     private final JsonSchemaFactory jsonSchemaFactory;
-    private SchemaValidatorsConfig config;
-    private final ConcurrentMap<String, JsonSchema> schemaReferences = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String, JsonSchema> schemaResources = new ConcurrentHashMap<>();
+    private final SchemaValidatorsConfig config;
+    private final ConcurrentMap<String, JsonSchema> schemaReferences;
+    private final ConcurrentMap<String, JsonSchema> schemaResources;
 
     public ValidationContext(URIFactory uriFactory, URNFactory urnFactory, JsonMetaSchema metaSchema,
-                             JsonSchemaFactory jsonSchemaFactory, SchemaValidatorsConfig config) {
+            JsonSchemaFactory jsonSchemaFactory, SchemaValidatorsConfig config) {
+        this(uriFactory, urnFactory, metaSchema, jsonSchemaFactory, config, new ConcurrentHashMap<>(),
+                new ConcurrentHashMap<>());
+    }
+
+    public ValidationContext(URIFactory uriFactory, URNFactory urnFactory, JsonMetaSchema metaSchema,
+            JsonSchemaFactory jsonSchemaFactory, SchemaValidatorsConfig config,
+            ConcurrentMap<String, JsonSchema> schemaReferences, ConcurrentMap<String, JsonSchema> schemaResources) {
         if (uriFactory == null) {
             throw new IllegalArgumentException("URIFactory must not be null");
         }
@@ -50,7 +57,9 @@ public class ValidationContext {
         this.urnFactory = urnFactory;
         this.metaSchema = metaSchema;
         this.jsonSchemaFactory = jsonSchemaFactory;
-        this.config = config;
+        this.config = config == null ? new SchemaValidatorsConfig() : config;
+        this.schemaReferences = schemaReferences;
+        this.schemaResources = schemaResources;
     }
 
     public JsonSchema newSchema(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode, JsonSchema parentSchema) {
@@ -83,14 +92,7 @@ public class ValidationContext {
     }
 
     public SchemaValidatorsConfig getConfig() {
-        if (this.config == null) {
-            this.config = new SchemaValidatorsConfig();
-        }
         return this.config;
-    }
-
-    public void setConfig(SchemaValidatorsConfig config) {
-        this.config = config;
     }
 
     /**

--- a/src/main/java/com/networknt/schema/ValidationContext.java
+++ b/src/main/java/com/networknt/schema/ValidationContext.java
@@ -37,7 +37,7 @@ public class ValidationContext {
     private final JsonSchemaFactory jsonSchemaFactory;
     private SchemaValidatorsConfig config;
     private final Stack<DiscriminatorContext> discriminatorContexts = new Stack<>();
-    private final ConcurrentMap<String, JsonSchemaRef> schemaReferences = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, JsonSchema> schemaReferences = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, JsonSchema> schemaResources = new ConcurrentHashMap<>();
 
     public ValidationContext(URIFactory uriFactory, URNFactory urnFactory, JsonMetaSchema metaSchema,
@@ -103,7 +103,7 @@ public class ValidationContext {
      *
      * @return the schema references
      */
-    public ConcurrentMap<String, JsonSchemaRef> getSchemaReferences() {
+    public ConcurrentMap<String, JsonSchema> getSchemaReferences() {
         return this.schemaReferences;
     }
 

--- a/src/main/java/com/networknt/schema/ValidationMessageHandler.java
+++ b/src/main/java/com/networknt/schema/ValidationMessageHandler.java
@@ -16,6 +16,7 @@ public abstract class ValidationMessageHandler {
 
     protected SchemaLocation schemaLocation;
     protected JsonNodePath evaluationPath;
+    protected JsonSchema evaluationParentSchema;
 
     protected JsonSchema parentSchema;
 
@@ -49,6 +50,7 @@ public abstract class ValidationMessageHandler {
         this.schemaLocation = copy.schemaLocation;
         this.evaluationPath = copy.evaluationPath;
         this.parentSchema = copy.parentSchema;
+        this.evaluationParentSchema = copy.evaluationParentSchema;
         this.customErrorMessagesEnabled = copy.customErrorMessagesEnabled;
         this.errorMessage = copy.errorMessage;
         this.keyword = copy.keyword;

--- a/src/main/java/com/networknt/schema/ValidationMessageHandler.java
+++ b/src/main/java/com/networknt/schema/ValidationMessageHandler.java
@@ -37,6 +37,23 @@ public abstract class ValidationMessageHandler {
         updateKeyword(keyword);
     }
 
+    /**
+     * Copy constructor.
+     *
+     * @param copy to copy from
+     */
+    protected ValidationMessageHandler(ValidationMessageHandler copy) {
+        this.failFast = copy.failFast;
+        this.messageSource = copy.messageSource;
+        this.errorMessageType = copy.errorMessageType;
+        this.schemaLocation = copy.schemaLocation;
+        this.evaluationPath = copy.evaluationPath;
+        this.parentSchema = copy.parentSchema;
+        this.customErrorMessagesEnabled = copy.customErrorMessagesEnabled;
+        this.errorMessage = copy.errorMessage;
+        this.keyword = copy.keyword;
+    }
+
     protected MessageSourceValidationMessage.Builder message() {
         return MessageSourceValidationMessage.builder(this.messageSource, this.errorMessage, message -> {
             if (this.failFast && isApplicator()) {

--- a/src/test/java/com/networknt/schema/AbsoluteIriTest.java
+++ b/src/test/java/com/networknt/schema/AbsoluteIriTest.java
@@ -64,6 +64,12 @@ class AbsoluteIriTest {
     }
 
     @Test
+    void relativeParentWithSchemeSpecificPart() {
+        AbsoluteIri iri = new AbsoluteIri("classpath:resource/hello/world/testing.json");
+        assertEquals("classpath:resource/test.json", iri.resolve("../../test.json").toString());
+    }
+
+    @Test
     void rootAbsoluteAtDocument() {
         AbsoluteIri iri = new AbsoluteIri("http://www.example.org/foo/bar.json");
         assertEquals("http://www.example.org/test.json", iri.resolve("/test.json").toString());

--- a/src/test/java/com/networknt/schema/PrefixItemsValidatorTest.java
+++ b/src/test/java/com/networknt/schema/PrefixItemsValidatorTest.java
@@ -2,7 +2,6 @@ package com.networknt.schema;
 
 import org.junit.jupiter.api.DynamicContainer;
 import org.junit.jupiter.api.DynamicNode;
-import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.stream.Stream;
@@ -22,12 +21,9 @@ public class PrefixItemsValidatorTest extends AbstractJsonSchemaTestSuite {
         Stream<DynamicNode> dynamicNodeStream = createTests(SpecVersion.VersionFlag.V7, "src/test/suite/tests/prefixItemsException");
         dynamicNodeStream.forEach(
                 dynamicNode -> {
-                    ((DynamicContainer) dynamicNode).getChildren().forEach(dynamicNode1 -> {
-                        if (dynamicNode1 instanceof DynamicTest) {
-                            assertThrows(JsonSchemaException.class, () -> {
-                                ((DynamicTest) dynamicNode1).getExecutable().execute();
-                            });
-                        }
+                    assertThrows(JsonSchemaException.class, () -> {
+                        ((DynamicContainer) dynamicNode).getChildren().forEach(dynamicNode1 -> {
+                        });
                     });
                 }
         );

--- a/src/test/java/com/networknt/schema/SharedConfigTest.java
+++ b/src/test/java/com/networknt/schema/SharedConfigTest.java
@@ -1,0 +1,54 @@
+package com.networknt.schema;
+
+import java.net.URI;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.walk.JsonSchemaWalkListener;
+import com.networknt.schema.walk.WalkEvent;
+import com.networknt.schema.walk.WalkFlow;
+
+/**
+ * Issue 918.
+ */
+public class SharedConfigTest {
+    private static class AllKeywordListener implements JsonSchemaWalkListener {
+        public boolean wasCalled = false;
+
+        @Override
+        public WalkFlow onWalkStart(WalkEvent walkEvent) {
+            wasCalled = true;
+            return WalkFlow.CONTINUE;
+        }
+
+        @Override
+        public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+        }
+    }
+
+    @Test
+    public void shouldCallAllKeywordListenerOnWalkStart() throws Exception {
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
+
+        SchemaValidatorsConfig schemaValidatorsConfig = new SchemaValidatorsConfig();
+        AllKeywordListener allKeywordListener = new AllKeywordListener();
+        schemaValidatorsConfig.addKeywordWalkListener(allKeywordListener);
+
+        URI draft07Schema = new URI("resource:/draft-07/schema#");
+
+        // depending on this line the test either passes or fails:
+        // - if this line is executed, then it passes
+        // - if this line is not executed (just comment it) - it fails
+        JsonSchema firstSchema = factory.getSchema(draft07Schema);
+        firstSchema.walk(new ObjectMapper().readTree("{ \"id\": 123 }"), true);
+
+        // note that only second schema takes overridden schemaValidatorsConfig
+        JsonSchema secondSchema = factory.getSchema(draft07Schema, schemaValidatorsConfig);
+
+        secondSchema.walk(new ObjectMapper().readTree("{ \"id\": 123 }"), true);
+        Assertions.assertTrue(allKeywordListener.wasCalled);
+    }
+}

--- a/src/test/suite/tests/draft-next/enum.json
+++ b/src/test/suite/tests/draft-next/enum.json
@@ -169,6 +169,30 @@
         ]
     },
     {
+        "description": "enum with [false] does not match [0]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [[false]]
+        },
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "enum with true does not match 1",
         "schema": {
             "$schema": "https://json-schema.org/draft/next/schema",
@@ -188,6 +212,30 @@
             {
                 "description": "float one is invalid",
                 "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with [true] does not match [1]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [[true]]
+        },
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
                 "valid": false
             }
         ]
@@ -217,6 +265,30 @@
         ]
     },
     {
+        "description": "enum with [0] does not match [false]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [[0]]
+        },
+        "tests": [
+            {
+                "description": "[false] is invalid",
+                "data": [false],
+                "valid": false
+            },
+            {
+                "description": "[0] is valid",
+                "data": [0],
+                "valid": true
+            },
+            {
+                "description": "[0.0] is valid",
+                "data": [0.0],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "enum with 1 does not match true",
         "schema": {
             "$schema": "https://json-schema.org/draft/next/schema",
@@ -236,6 +308,30 @@
             {
                 "description": "float one is valid",
                 "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with [1] does not match [true]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [[1]]
+        },
+        "tests": [
+            {
+                "description": "[true] is invalid",
+                "data": [true],
+                "valid": false
+            },
+            {
+                "description": "[1] is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "[1.0] is valid",
+                "data": [1.0],
                 "valid": true
             }
         ]

--- a/src/test/suite/tests/draft2019-09/enum.json
+++ b/src/test/suite/tests/draft2019-09/enum.json
@@ -169,6 +169,30 @@
         ]
     },
     {
+        "description": "enum with [false] does not match [0]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [[false]]
+        },
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "enum with true does not match 1",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
@@ -188,6 +212,30 @@
             {
                 "description": "float one is invalid",
                 "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with [true] does not match [1]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [[true]]
+        },
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
                 "valid": false
             }
         ]
@@ -217,6 +265,30 @@
         ]
     },
     {
+        "description": "enum with [0] does not match [false]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [[0]]
+        },
+        "tests": [
+            {
+                "description": "[false] is invalid",
+                "data": [false],
+                "valid": false
+            },
+            {
+                "description": "[0] is valid",
+                "data": [0],
+                "valid": true
+            },
+            {
+                "description": "[0.0] is valid",
+                "data": [0.0],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "enum with 1 does not match true",
         "schema": {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
@@ -236,6 +308,30 @@
             {
                 "description": "float one is valid",
                 "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with [1] does not match [true]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [[1]]
+        },
+        "tests": [
+            {
+                "description": "[true] is invalid",
+                "data": [true],
+                "valid": false
+            },
+            {
+                "description": "[1] is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "[1.0] is valid",
+                "data": [1.0],
                 "valid": true
             }
         ]

--- a/src/test/suite/tests/draft2019-09/ref.json
+++ b/src/test/suite/tests/draft2019-09/ref.json
@@ -309,7 +309,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -475,7 +475,7 @@
             },
             "$ref": "schema-relative-uri-defs2.json"
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -530,7 +530,7 @@
             },
             "$ref": "schema-refs-absolute-uris-defs2.json"
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -589,7 +589,7 @@
                 }
             ]
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -624,7 +624,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -684,7 +684,7 @@
                 "foo": {"$ref": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed"}
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -830,7 +830,7 @@
                 "bar": {"type": "string"}
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -860,7 +860,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -887,7 +887,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -911,7 +911,7 @@
                 "type": "integer"
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -935,7 +935,7 @@
                 "type": "integer"
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -959,7 +959,7 @@
                 "type": "integer"
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -990,7 +990,7 @@
             },
             "$ref": "/absref/foobar.json"
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {

--- a/src/test/suite/tests/draft2019-09/refRemote.json
+++ b/src/test/suite/tests/draft2019-09/refRemote.json
@@ -113,7 +113,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "URI resolution does not account for identifiers that are not at the root schema",
         "tests": [
             {

--- a/src/test/suite/tests/draft2020-12/enum.json
+++ b/src/test/suite/tests/draft2020-12/enum.json
@@ -169,6 +169,30 @@
         ]
     },
     {
+        "description": "enum with [false] does not match [0]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [[false]]
+        },
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "enum with true does not match 1",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -188,6 +212,30 @@
             {
                 "description": "float one is invalid",
                 "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with [true] does not match [1]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [[true]]
+        },
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
                 "valid": false
             }
         ]
@@ -217,6 +265,30 @@
         ]
     },
     {
+        "description": "enum with [0] does not match [false]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [[0]]
+        },
+        "tests": [
+            {
+                "description": "[false] is invalid",
+                "data": [false],
+                "valid": false
+            },
+            {
+                "description": "[0] is valid",
+                "data": [0],
+                "valid": true
+            },
+            {
+                "description": "[0.0] is valid",
+                "data": [0.0],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "enum with 1 does not match true",
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -236,6 +308,30 @@
             {
                 "description": "float one is valid",
                 "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with [1] does not match [true]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [[1]]
+        },
+        "tests": [
+            {
+                "description": "[true] is invalid",
+                "data": [true],
+                "valid": false
+            },
+            {
+                "description": "[1] is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "[1.0] is valid",
+                "data": [1.0],
                 "valid": true
             }
         ]

--- a/src/test/suite/tests/draft2020-12/ref.json
+++ b/src/test/suite/tests/draft2020-12/ref.json
@@ -309,7 +309,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -475,7 +475,7 @@
             },
             "$ref": "schema-relative-uri-defs2.json"
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -530,7 +530,7 @@
             },
             "$ref": "schema-refs-absolute-uris-defs2.json"
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -589,7 +589,7 @@
                 }
             ]
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -624,7 +624,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -684,7 +684,7 @@
                 "foo": {"$ref": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed"}
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -830,7 +830,7 @@
                 "bar": {"type": "string"}
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -860,7 +860,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -887,7 +887,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -911,7 +911,7 @@
                 "type": "integer"
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -935,7 +935,7 @@
                 "type": "integer"
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -959,7 +959,7 @@
                 "type": "integer"
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -990,7 +990,7 @@
             },
             "$ref": "/absref/foobar.json"
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {

--- a/src/test/suite/tests/draft2020-12/refRemote.json
+++ b/src/test/suite/tests/draft2020-12/refRemote.json
@@ -113,7 +113,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "URI resolution does not account for identifiers that are not at the root schema",
         "tests": [
             {

--- a/src/test/suite/tests/draft4/enum.json
+++ b/src/test/suite/tests/draft4/enum.json
@@ -155,6 +155,27 @@
         ]
     },
     {
+        "description": "enum with [false] does not match [0]",
+        "schema": {"enum": [[false]]},
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "enum with true does not match 1",
         "schema": {"enum": [true]},
         "tests": [
@@ -171,6 +192,27 @@
             {
                 "description": "float one is invalid",
                 "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with [true] does not match [1]",
+        "schema": {"enum": [[true]]},
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
                 "valid": false
             }
         ]
@@ -197,6 +239,27 @@
         ]
     },
     {
+        "description": "enum with [0] does not match [false]",
+        "schema": {"enum": [[0]]},
+        "tests": [
+            {
+                "description": "[false] is invalid",
+                "data": [false],
+                "valid": false
+            },
+            {
+                "description": "[0] is valid",
+                "data": [0],
+                "valid": true
+            },
+            {
+                "description": "[0.0] is valid",
+                "data": [0.0],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "enum with 1 does not match true",
         "schema": {"enum": [1]},
         "tests": [
@@ -213,6 +276,27 @@
             {
                 "description": "float one is valid",
                 "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with [1] does not match [true]",
+        "schema": {"enum": [[1]]},
+        "tests": [
+            {
+                "description": "[true] is invalid",
+                "data": [true],
+                "valid": false
+            },
+            {
+                "description": "[1] is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "[1.0] is valid",
+                "data": [1.0],
                 "valid": true
             }
         ]

--- a/src/test/suite/tests/draft4/ref.json
+++ b/src/test/suite/tests/draft4/ref.json
@@ -198,7 +198,7 @@
                 }
             ]
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -301,7 +301,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -436,7 +436,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -497,7 +497,7 @@
                 }
             ]
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {

--- a/src/test/suite/tests/draft4/refRemote.json
+++ b/src/test/suite/tests/draft4/refRemote.json
@@ -120,7 +120,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "URI resolution does not account for identifiers that are not at the root schema",
         "tests": [
             {

--- a/src/test/suite/tests/draft6/enum.json
+++ b/src/test/suite/tests/draft6/enum.json
@@ -155,6 +155,27 @@
         ]
     },
     {
+        "description": "enum with [false] does not match [0]",
+        "schema": {"enum": [[false]]},
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "enum with true does not match 1",
         "schema": {"enum": [true]},
         "tests": [
@@ -171,6 +192,27 @@
             {
                 "description": "float one is invalid",
                 "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with [true] does not match [1]",
+        "schema": {"enum": [[true]]},
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
                 "valid": false
             }
         ]
@@ -197,6 +239,27 @@
         ]
     },
     {
+        "description": "enum with [0] does not match [false]",
+        "schema": {"enum": [[0]]},
+        "tests": [
+            {
+                "description": "[false] is invalid",
+                "data": [false],
+                "valid": false
+            },
+            {
+                "description": "[0] is valid",
+                "data": [0],
+                "valid": true
+            },
+            {
+                "description": "[0.0] is valid",
+                "data": [0.0],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "enum with 1 does not match true",
         "schema": {"enum": [1]},
         "tests": [
@@ -213,6 +276,27 @@
             {
                 "description": "float one is valid",
                 "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with [1] does not match [true]",
+        "schema": {"enum": [[1]]},
+        "tests": [
+            {
+                "description": "[true] is invalid",
+                "data": [true],
+                "valid": false
+            },
+            {
+                "description": "[1] is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "[1.0] is valid",
+                "data": [1.0],
                 "valid": true
             }
         ]

--- a/src/test/suite/tests/draft6/ref.json
+++ b/src/test/suite/tests/draft6/ref.json
@@ -198,7 +198,7 @@
                 }
             ]
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -333,7 +333,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -468,7 +468,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -530,7 +530,7 @@
             },
             "allOf": [ { "$ref": "schema-relative-uri-defs2.json" } ]
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -584,7 +584,7 @@
             },
             "allOf": [ { "$ref": "schema-refs-absolute-uris-defs2.json" } ]
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -629,7 +629,7 @@
                 "foo": {"$ref": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed"}
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -755,7 +755,7 @@
                 "bar": {"type": "string"}
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -784,7 +784,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -817,7 +817,7 @@
                  { "$ref": "/absref/foobar.json" }
              ]
          },
-         "disabled": true,
+         "disabled": false,
          "reason": "Schema resources are currently unsupported. See #503",
          "tests": [
              {

--- a/src/test/suite/tests/draft6/refRemote.json
+++ b/src/test/suite/tests/draft6/refRemote.json
@@ -120,7 +120,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "URI resolution does not account for identifiers that are not at the root schema",
         "tests": [
             {

--- a/src/test/suite/tests/draft7/enum.json
+++ b/src/test/suite/tests/draft7/enum.json
@@ -155,6 +155,27 @@
         ]
     },
     {
+        "description": "enum with [false] does not match [0]",
+        "schema": {"enum": [[false]]},
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "enum with true does not match 1",
         "schema": {"enum": [true]},
         "tests": [
@@ -171,6 +192,27 @@
             {
                 "description": "float one is invalid",
                 "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with [true] does not match [1]",
+        "schema": {"enum": [[true]]},
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
                 "valid": false
             }
         ]
@@ -197,6 +239,27 @@
         ]
     },
     {
+        "description": "enum with [0] does not match [false]",
+        "schema": {"enum": [[0]]},
+        "tests": [
+            {
+                "description": "[false] is invalid",
+                "data": [false],
+                "valid": false
+            },
+            {
+                "description": "[0] is valid",
+                "data": [0],
+                "valid": true
+            },
+            {
+                "description": "[0.0] is valid",
+                "data": [0.0],
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "enum with 1 does not match true",
         "schema": {"enum": [1]},
         "tests": [
@@ -213,6 +276,27 @@
             {
                 "description": "float one is valid",
                 "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with [1] does not match [true]",
+        "schema": {"enum": [[1]]},
+        "tests": [
+            {
+                "description": "[true] is invalid",
+                "data": [true],
+                "valid": false
+            },
+            {
+                "description": "[1] is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "[1.0] is valid",
+                "data": [1.0],
                 "valid": true
             }
         ]

--- a/src/test/suite/tests/draft7/ref.json
+++ b/src/test/suite/tests/draft7/ref.json
@@ -198,7 +198,7 @@
                 }
             ]
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -333,7 +333,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -468,7 +468,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -530,7 +530,7 @@
             },
             "allOf": [ { "$ref": "schema-relative-uri-defs2.json" } ]
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -584,7 +584,7 @@
             },
             "allOf": [ { "$ref": "schema-refs-absolute-uris-defs2.json" } ]
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -642,7 +642,7 @@
                 }
             ]
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -667,7 +667,7 @@
                 "foo": {"$ref": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed"}
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -793,7 +793,7 @@
                 "bar": {"type": "string"}
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -822,7 +822,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -850,7 +850,7 @@
                 }
             ]
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -878,7 +878,7 @@
                 }
             ]
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -906,7 +906,7 @@
                 }
             ]
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {
@@ -939,7 +939,7 @@
                 { "$ref": "/absref/foobar.json" }
             ]
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "Schema resources are currently unsupported. See #503",
         "tests": [
             {

--- a/src/test/suite/tests/draft7/refRemote.json
+++ b/src/test/suite/tests/draft7/refRemote.json
@@ -120,7 +120,7 @@
                 }
             }
         },
-        "disabled": true,
+        "disabled": false,
         "reason": "URI resolution does not account for identifiers that are not at the root schema",
         "tests": [
             {


### PR DESCRIPTION
Closes #503, closes #526, closes #918

This adds support for using schema resources in schema bundling. These changes make all required tests in the [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite) from Draft 4 to 7 pass.

This also fixes some issues with the validation context, refs and enum validator.

The following comparisons are obtained using https://github.com/creek-service/json-schema-validation-comparison

### Functional Comparison
**Existing**
| Implementations | Overall                                                                 | DRAFT_03                                                          | DRAFT_04                                                            | DRAFT_06                                                           | DRAFT_07                                                               | DRAFT_2019_09                                                        | DRAFT_2020_12                                                          |
|-----------------|-------------------------------------------------------------------------|-------------------------------------------------------------------|---------------------------------------------------------------------|--------------------------------------------------------------------|------------------------------------------------------------------------|----------------------------------------------------------------------|------------------------------------------------------------------------|
| NetworkNt       | pass: r:4544 (96.6%) o:2235 (94.3%)<br>fail: r:159 (3.4%) o:135 (5.7%)  |                                                                   | pass: r:593 (98.8%) o:231 (92.0%)<br>fail: r:7 (1.2%) o:20 (8.0%)   | pass: r:779 (97.9%) o:297 (93.4%)<br>fail: r:17 (2.1%) o:21 (6.6%) | pass: r:859 (97.6%) o:510 (94.3%)<br>fail: r:21 (2.4%) o:31 (5.7%)     | pass: r:1166 (97.1%) o:595 (95.2%)<br>fail: r:35 (2.9%) o:30 (4.8%)  | pass: r:1147 (93.6%) o:602 (94.8%)<br>fail: r:79 (6.4%) o:33 (5.2%)   

**With Changes**
| Implementations | Overall                                                                 | DRAFT_03                                                          | DRAFT_04                                                            | DRAFT_06                                                           | DRAFT_07                                                               | DRAFT_2019_09                                                        | DRAFT_2020_12                                                          |
|-----------------|-------------------------------------------------------------------------|-------------------------------------------------------------------|---------------------------------------------------------------------|--------------------------------------------------------------------|------------------------------------------------------------------------|----------------------------------------------------------------------|------------------------------------------------------------------------|
| NetworkNt       | pass: r:4637 (98.6%) o:2242 (94.6%)<br>fail: r:66 (1.4%) o:128 (5.4%)   |                                                                   | pass: r:600 (100.0%) o:232 (92.4%)<br>fail: r:0 (0.0%) o:19 (7.6%)  | pass: r:796 (100.0%) o:299 (94.0%)<br>fail: r:0 (0.0%) o:19 (6.0%) | pass: r:880 (100.0%) o:512 (94.6%)<br>fail: r:0 (0.0%) o:29 (5.4%)     | pass: r:1192 (99.3%) o:596 (95.4%)<br>fail: r:9 (0.7%) o:29 (4.6%)   | pass: r:1169 (95.4%) o:603 (95.0%)<br>fail: r:57 (4.6%) o:32 (5.0%)    |

### Performance Comparison
**Existing**
| Benchmark | Mode | Score | Score Error (99.9%) | Unit |
|-----------|------|-------|---------------------|------|
| measureDraft_03_SchemaFriend | avgt | 1.8363 |  | ms/op |
| measureDraft_04_Everit | avgt | 1.4306 |  | ms/op |
| measureDraft_04_Justify | avgt | 2.2475 |  | ms/op |
| measureDraft_04_Medeia | avgt | 1.4881 |  | ms/op |
| measureDraft_04_NetworkNt | avgt | 2.2286 |  | ms/op |
| measureDraft_04_SchemaFriend | avgt | 2.3453 |  | ms/op |
| measureDraft_04_Vertx | avgt | 2.8329 |  | ms/op |
| measureDraft_06_Everit | avgt | 1.4255 |  | ms/op |
| measureDraft_06_Justify | avgt | 2.0254 |  | ms/op |
| measureDraft_06_Medeia | avgt | 1.0577 |  | ms/op |
| measureDraft_06_NetworkNt | avgt | 1.9621 |  | ms/op |
| measureDraft_06_SchemaFriend | avgt | 2.8577 |  | ms/op |
| measureDraft_06_Snow | avgt | 10.563 |  | ms/op |
| measureDraft_07_Everit | avgt | 1.5842 |  | ms/op |
| measureDraft_07_Justify | avgt | 2.8854 |  | ms/op |
| measureDraft_07_Medeia | avgt | 1.7953 |  | ms/op |
| measureDraft_07_NetworkNt | avgt | 2.5196 |  | ms/op |
| measureDraft_07_SchemaFriend | avgt | 5.8124 |  | ms/op |
| measureDraft_07_Snow | avgt | 7.5770 |  | ms/op |
| measureDraft_07_Vertx | avgt | 3.9631 |  | ms/op |
| measureDraft_2019_09_DevHarrel | avgt | 6.7369 |  | ms/op |
| measureDraft_2019_09_NetworkNt | avgt | 4.1106 |  | ms/op |
| measureDraft_2019_09_SchemaFriend | avgt | 4.5364 |  | ms/op |
| measureDraft_2019_09_Snow | avgt | 20.029 |  | ms/op |
| measureDraft_2019_09_Vertx | avgt | 7.2882 |  | ms/op |
| measureDraft_2020_12_DevHarrel | avgt | 4.7750 |  | ms/op |
| measureDraft_2020_12_NetworkNt | avgt | 4.0334 |  | ms/op |
| measureDraft_2020_12_SchemaFriend | avgt | 4.0378 |  | ms/op |
| measureDraft_2020_12_Skema | avgt | 5.9661 |  | ms/op |
| measureDraft_2020_12_Vertx | avgt | 7.0690 |  | ms/op |

**With Changes**
| Benchmark | Mode | Score | Score Error (99.9%) | Unit |
|-----------|------|-------|---------------------|------|
| measureDraft_03_SchemaFriend | avgt | 1.8594 |  | ms/op |
| measureDraft_04_Everit | avgt | 1.6637 |  | ms/op |
| measureDraft_04_Justify | avgt | 2.1567 |  | ms/op |
| measureDraft_04_Medeia | avgt | 1.6925 |  | ms/op |
| measureDraft_04_NetworkNt | avgt | 1.1802 |  | ms/op |
| measureDraft_04_SchemaFriend | avgt | 2.2723 |  | ms/op |
| measureDraft_04_Vertx | avgt | 2.7232 |  | ms/op |
| measureDraft_06_Everit | avgt | 1.3924 |  | ms/op |
| measureDraft_06_Justify | avgt | 1.8758 |  | ms/op |
| measureDraft_06_Medeia | avgt | 1.1751 |  | ms/op |
| measureDraft_06_NetworkNt | avgt | 1.0751 |  | ms/op |
| measureDraft_06_SchemaFriend | avgt | 3.4659 |  | ms/op |
| measureDraft_06_Snow | avgt | 10.816 |  | ms/op |
| measureDraft_07_Everit | avgt | 1.5002 |  | ms/op |
| measureDraft_07_Justify | avgt | 2.6362 |  | ms/op |
| measureDraft_07_Medeia | avgt | 1.6215 |  | ms/op |
| measureDraft_07_NetworkNt | avgt | 1.4285 |  | ms/op |
| measureDraft_07_SchemaFriend | avgt | 4.8130 |  | ms/op |
| measureDraft_07_Snow | avgt | 7.7367 |  | ms/op |
| measureDraft_07_Vertx | avgt | 3.8086 |  | ms/op |
| measureDraft_2019_09_DevHarrel | avgt | 5.4298 |  | ms/op |
| measureDraft_2019_09_NetworkNt | avgt | 2.3978 |  | ms/op |
| measureDraft_2019_09_SchemaFriend | avgt | 3.9927 |  | ms/op |
| measureDraft_2019_09_Snow | avgt | 20.068 |  | ms/op |
| measureDraft_2019_09_Vertx | avgt | 6.9539 |  | ms/op |
| measureDraft_2020_12_DevHarrel | avgt | 4.7589 |  | ms/op |
| measureDraft_2020_12_NetworkNt | avgt | 2.5706 |  | ms/op |
| measureDraft_2020_12_SchemaFriend | avgt | 4.0046 |  | ms/op |
| measureDraft_2020_12_Skema | avgt | 6.5409 |  | ms/op |
| measureDraft_2020_12_Vertx | avgt | 6.7753 |  | ms/op |