### PR TITLE
[Issue 928]: Fix getSchema() anchor fragment lookup.

### DIFF
--- a/src/main/java/com/networknt/schema/JsonSchemaFactory.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaFactory.java
@@ -467,7 +467,7 @@ public class JsonSchemaFactory {
                 URI documentUri = "".equals(schemaUri.getSchemeSpecificPart()) ? new URI(schemaUri.getScheme(), schemaUri.getUserInfo(), schemaUri.getHost(), schemaUri.getPort(), schemaUri.getPath(), schemaUri.getQuery(), null) : new URI(schemaUri.getScheme(), schemaUri.getSchemeSpecificPart(), null);
                 SchemaLocation documentLocation = new SchemaLocation(schemaLocation.getAbsoluteIri());
                 JsonSchema document = doCreate(validationContext, documentLocation, evaluationPath, documentUri, schemaNode, null, false);
-                JsonNode subSchemaNode = document.getRefSchemaNode(schemaLocation.getFragment().toString());
+                JsonNode subSchemaNode = document.getRefSchemaNode("#" + schemaLocation.getFragment().toString());
                 if (subSchemaNode != null) {
                     jsonSchema = doCreate(validationContext, schemaLocation, evaluationPath, mappedUri, subSchemaNode, document, false);
                 } else {

--- a/src/test/java/com/networknt/schema/Issue928Test.java
+++ b/src/test/java/com/networknt/schema/Issue928Test.java
@@ -1,0 +1,63 @@
+package com.networknt.schema;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.uri.URITranslator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+public class Issue928Test {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private JsonSchemaFactory factoryFor(SpecVersion.VersionFlag version) {
+        return JsonSchemaFactory
+                .builder(JsonSchemaFactory.getInstance(version))
+                .objectMapper(mapper)
+                .addUriTranslator(
+                        URITranslator.prefix("https://example.org", "resource:")
+                )
+                .build();
+    }
+
+    @Test
+    public void test_07() {
+        test_spec(SpecVersion.VersionFlag.V7);
+    }
+
+    @Test
+    public void test_201909() {
+        test_spec(SpecVersion.VersionFlag.V201909);
+    }
+
+    @Test
+    public void test_202012() {
+        test_spec(SpecVersion.VersionFlag.V202012);
+    }
+
+    public void test_spec(SpecVersion.VersionFlag specVersion) {
+        JsonSchemaFactory schemaFactory = factoryFor(specVersion);
+
+        String versionId = specVersion.getId();
+        String versionStr = versionId.substring(versionId.indexOf("draft") + 6, versionId.indexOf("/schema"));
+
+        String baseUrl = String.format("https://example.org/schema/issue928-v%s.json", versionStr);
+        System.out.println("baseUrl: " + baseUrl);
+
+        JsonSchema byPointer = schemaFactory.getSchema(
+                URI.create(baseUrl + "#/definitions/example"));
+
+        Assertions.assertEquals(byPointer.validate(mapper.valueToTree("A")).size(), 0);
+        Assertions.assertEquals(byPointer.validate(mapper.valueToTree("Z")).size(), 1);
+
+        JsonSchema byAnchor = schemaFactory.getSchema(
+                URI.create(baseUrl + "#example"));
+
+        Assertions.assertEquals(
+                byPointer.getSchemaNode(),
+                byAnchor.getSchemaNode());
+
+        Assertions.assertEquals(byAnchor.validate(mapper.valueToTree("A")).size(), 0);
+        Assertions.assertEquals(byAnchor.validate(mapper.valueToTree("Z")).size(), 1);
+    }
+}

--- a/src/test/resources/schema/issue928-v07.json
+++ b/src/test/resources/schema/issue928-v07.json
@@ -1,0 +1,14 @@
+{
+  "$id": "https://example.com/person.schema.json",
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "definitions": {
+    "example": {
+      "$id": "#example",
+      "type": "string",
+      "enum": [
+        "A", "B"
+      ]
+    }
+  }
+}

--- a/src/test/resources/schema/issue928-v2019-09.json
+++ b/src/test/resources/schema/issue928-v2019-09.json
@@ -1,0 +1,14 @@
+{
+  "$id": "https://example.com/person.schema.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema#",
+  "type": "object",
+  "definitions": {
+    "example": {
+      "$anchor": "example",
+      "type": "string",
+      "enum": [
+        "A", "B"
+      ]
+    }
+  }
+}

--- a/src/test/resources/schema/issue928-v2020-12.json
+++ b/src/test/resources/schema/issue928-v2020-12.json
@@ -1,0 +1,14 @@
+{
+  "$id": "https://example.com/person.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
+  "type": "object",
+  "definitions": {
+    "example": {
+      "$anchor": "example",
+      "type": "string",
+      "enum": [
+        "A", "B"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/networknt/json-schema-validator/issues/928

this makes `JsonSchemaFactory.getSchema("...#anchor")` work.