### PR TITLE
Add test for type loose for array and update doc for behavior

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -22,7 +22,7 @@ JsonSchema jsonSchema = JsonSchemaFactory.getInstance().getSchema(schema, config
 
 * typeLoose
 
-When typeLoose is true, the validator will convert strings to different types to match the type defined in the schema. This is mostly used to validate the JSON request or response for headers, query parameters, path parameters, and cookies. For the HTTP protocol, these are all strings and might be defined as other types in the schema. For example, the page number might be an integer in the schema but passed as a query parameter in string. 
+When typeLoose is true, the validator will convert strings to different types to match the type defined in the schema. This is mostly used to validate the JSON request or response for headers, query parameters, path parameters, and cookies. For the HTTP protocol, these are all strings and might be defined as other types in the schema. For example, the page number might be an integer in the schema but passed as a query parameter in string. When it comes to validating arrays note that any item can also be interpreted as a size 1 array of that item so the item will be validated against the type defined for the array.
 
 * strictness
 This is a map of keywords to whether the keyword's validators should perform a strict or permissive analysis. When strict is true, validators will perform strict checking against the schema.

--- a/src/test/java/com/networknt/schema/StringCheckerTest.java
+++ b/src/test/java/com/networknt/schema/StringCheckerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.networknt.schema;
+
+import org.junit.jupiter.api.Test;
+
+import static com.networknt.schema.utils.StringChecker.isNumeric;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StringCheckerTest {
+
+    private static final String[] validNumericValues = {
+            "1", "-1", "1.1", "-1.1", "0E+1", "0E-1", "0E1", "-0E+1", "-0E-1", "-0E1", "0.1E+1", "0.1E-1", "0.1E1",
+            "-0.1E+1", "-0.1E-1", "-0.1E1", "10.1", "-10.1", "10E+1", "10E-1", "10E1", "-10E+1", "-10E-1", "-10E1",
+            "10.1E+1", "10.1E-1", "10.1E1", "-10.1E+1", "-10.1E-1", "-10.1E1", "1E+0", "1E-0", "1E0",
+            "1E00000000000000000000"
+    };
+    private static final String[] invalidNumericValues = {
+            "01.1", "1.", ".1", "0.1.1", "E1", "E+1", "E-1", ".E1", ".E+1", ".E-1", ".1E1", ".1E+1", ".1E-1", "1E-",
+            "1E+", "1E", "+", "-", "1a", "0.1a", "0E1a", "0E-1a", "1.0a", "1.0aE1"
+            //, "+0", "+1" // for backward compatibility, in violation of JSON spec
+    };
+
+    @Test
+    void testNumericValues() {
+        for (String validValue : validNumericValues) {
+            assertTrue(isNumeric(validValue), validValue);
+        }
+    }
+
+    @Test
+    void testNonNumericValues() {
+        for (String invalidValue : invalidNumericValues) {
+            assertFalse(isNumeric(invalidValue), invalidValue);
+        }
+    }
+}


### PR DESCRIPTION
Closes #415

Add test for type validator type loose behavior for arrays and update documentation accordingly that type loose will interpret an item as an array of size 1 and that it will then only validate that that item matches the type defined for the array.

Not sure if there is supposed to be a spec which defines what type loose behavior is supposed to be.