### PR TITLE
Make ethlo excludable

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,21 @@ The YAML dependency can be excluded if this is not required. Attempting to proce
 </dependency>
 ```
 
+The Ethlo Time dependency can be excluded if accurate validation of the `date-time` format is not required. The `date-time` format will then use `java.time.OffsetDateTime` to determine if the `date-time` is valid .
+
+```xml
+<dependency>
+    <groupId>com.networknt</groupId>
+    <artifactId>json-schema-validator</artifactId>
+    <exclusions>
+        <exclusion>
+            <groupId>com.ethlo.time</groupId>
+            <artifactId>itu</artifactId>
+        </exclusion>
+    </exclusions>
+</dependency>
+```
+
 #### Community
 
 This library is very active with a lot of contributors. New features and bug fixes are handled quickly by the team members. Because it is an essential dependency of the [light-4j](https://github.com/networknt/light-4j) framework in the same GitHub organization, it will be evolved and maintained along with the framework. 
@@ -199,7 +214,7 @@ This package is available on Maven central.
 <dependency>
     <groupId>com.networknt</groupId>
     <artifactId>json-schema-validator</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.3</version>
 </dependency>
 ```
 

--- a/src/main/java/com/networknt/schema/format/DateTimeFormat.java
+++ b/src/main/java/com/networknt/schema/format/DateTimeFormat.java
@@ -1,5 +1,9 @@
 package com.networknt.schema.format;
 
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.function.Predicate;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -7,12 +11,50 @@ import com.ethlo.time.ITU;
 import com.ethlo.time.LeapSecondException;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.Format;
+import com.networknt.schema.utils.Classes;
 
 /**
  * Format for date-time.
  */
 public class DateTimeFormat implements Format {
     private static final Logger logger = LoggerFactory.getLogger(DateTimeFormat.class);
+
+    private static final boolean ETHLO_PRESENT = Classes.isPresent("com.ethlo.time.ITU", DateTimeFormat.class.getClassLoader());
+
+    /**
+     * Uses etho.
+     * <p> 
+     * This needs to be in a holder class otherwise a ClassNotFoundException will be
+     * thrown when the DateTimeFormat is instantiated.
+     */
+    public static class Ethlo {
+        public static boolean isValid(String value) {
+            try {
+                ITU.parseDateTime(value);
+            } catch (LeapSecondException ex) {
+                if (!ex.isVerifiedValidLeapYearMonth()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    /**
+     * Uses java time. 
+     */
+    public static class JavaTimeOffsetDateTime {
+        public static boolean isValid(String value) {
+            try {
+                OffsetDateTime.parse(value);
+                return true;
+            } catch (DateTimeParseException e) {
+                return false;
+            }
+        }
+    }
+    
+    private static final Predicate<String> VALIDATE = ETHLO_PRESENT ? Ethlo::isValid : JavaTimeOffsetDateTime::isValid;
 
     @Override
     public String getName() {
@@ -26,20 +68,12 @@ public class DateTimeFormat implements Format {
 
     @Override
     public boolean matches(ExecutionContext executionContext, String value) {
-        return isLegalDateTime(value);
+        return isValid(value);
     }
 
-    private static boolean isLegalDateTime(String string) {
+    private static boolean isValid(String value) {
         try {
-            try {
-                ITU.parseDateTime(string);
-            } catch (LeapSecondException ex) {
-                if (!ex.isVerifiedValidLeapYearMonth()) {
-                    return false;
-                }
-            }
-
-            return true;
+            return VALIDATE.test(value);
         } catch (Exception ex) {
             logger.debug("Invalid {}: {}", "date-time", ex.getMessage());
             return false;

--- a/src/main/java/com/networknt/schema/utils/Classes.java
+++ b/src/main/java/com/networknt/schema/utils/Classes.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.utils;
+
+/**
+ * Utility methods for classes.
+ */
+public class Classes {
+    /**
+     * Determines if a class is present.
+     * 
+     * @param name the name of the class
+     * @param classLoader the class loader
+     * @return true if present
+     */
+    public static boolean isPresent(String name, ClassLoader classLoader) {
+        try {
+            Class.forName(name, false, classLoader);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Closes #973

This makes the ethlo dependency excludable. This isn't the same as making it optional as optional dependencies need to be explicitly added, while excludable needs to be explicitly excluded.