### PR TITLE
Refactor walk

### DIFF
--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -10,15 +10,14 @@ This contains breaking changes
 - to those using the walk functionality
 - in how custom meta-schemas are created
 
-The following are the breaking changes to those using the walk functionality.
-
 When using the walker with defaults the `default` across a `$ref` are properly resolved and used.
 
 The behavior for the property listener is now more consistent whether or not validation is enabled. Previously if validation is enabled but the property is `null` the property listener is not called while if validation is not enabled it will be called. Now the property listener will be called in both scenarios.
 
+The following are the breaking changes to those using the walk functionality.
 
 `WalkEvent`
-| Field                    | Change       | Details
+| Field                    | Change       | Notes
 |--------------------------|--------------|----------
 | `schemaLocation`         | Removed      | For keywords: `getValidator().getSchemaLocation()`. For items and properties: `getSchema().getSchemaLocation()`
 | `evaluationPath`         | Removed      | For keywords: `getValidator().getEvaluationPath()`. For items and properties: `getSchema().getEvaluationPath()`

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -6,7 +6,31 @@ This contains information on the notable or breaking changes in each version.
 
 ### 1.4.0
 
-This contains breaking changes in how custom meta-schemas are created.
+This contains breaking changes 
+- to those using the walk functionality
+- in how custom meta-schemas are created
+
+The following are the breaking changes to those using the walk functionality.
+
+When using the walker with defaults the `default` across a `$ref` are properly resolved and used.
+
+The behavior for the property listener is now more consistent whether or not validation is enabled. Previously if validation is enabled but the property is `null` the property listener is not called while if validation is not enabled it will be called. Now the property listener will be called in both scenarios.
+
+
+`WalkEvent`
+| Field                    | Change       | Details
+|--------------------------|--------------|----------
+| `schemaLocation`         | Removed      | For keywords: `getValidator().getSchemaLocation()`. For items and properties: `getSchema().getSchemaLocation()`
+| `evaluationPath`         | Removed      | For keywords: `getValidator().getEvaluationPath()`. For items and properties: `getSchema().getEvaluationPath()`
+| `schemaNode`             | Removed      | `getSchema().getSchemaNode()`
+| `parentSchema`           | Removed      | `getSchema().getParentSchema()`
+| `schema`                 | New          | For keywords this is the parent schema of the validator. For items and properties this is the item or property schema being evaluated.
+| `node`                   | Renamed      | `instanceNode`
+| `currentJsonSchemaFactory`| Removed     | `getSchema().getValidationContext().getJsonSchemaFactory()`
+| `validator`              | New          | The validator indicated by the keyword.
+
+
+The following are the breaking changes in how custom meta-schemas are created.
 
 `JsonSchemaFactory`
 * The following were renamed on `JsonSchemaFactory` builder

--- a/doc/walkers.md
+++ b/doc/walkers.md
@@ -38,20 +38,16 @@ public interface JsonSchemaWalker {
 The JSONValidator interface extends this new interface thus allowing all the validator's defined in library to implement this new interface. BaseJsonValidator class provides a default implementation of the walk method. In this case the walk method does nothing but validating based on shouldValidateSchema parameter.
 
 ```java
-/**
+    /**
      * This is default implementation of walk method. Its job is to call the
      * validate method if shouldValidateSchema is enabled.
      */
     @Override
-    public Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
-            JsonNodePath instanceLocation, boolean shouldValidateSchema);
-        Set<ValidationMessage> validationMessages = new LinkedHashSet<ValidationMessage>();
-        if (shouldValidateSchema) {
-            validationMessages = validate(executionContext, node, rootNode, instanceLocation);
-        }
-        return validationMessages;
+    default Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+            JsonNodePath instanceLocation, boolean shouldValidateSchema) {
+        return shouldValidateSchema ? validate(executionContext, node, rootNode, instanceLocation)
+                : Collections.emptySet();
     }
-    
 ```
 
 A new walk method added to the JSONSchema class allows us to walk through the JSONSchema.
@@ -95,7 +91,7 @@ A new walk method added to the JSONSchema class allows us to walk through the JS
 ```
 Following code snippet shows how to call the walk method on a JsonSchema instance.
 
-```
+```java
 ValidationResult result = jsonSchema.walk(data,false);
 
 ```
@@ -122,7 +118,7 @@ private static class PropertiesKeywordListener implements JsonSchemaWalkListener
 
         @Override
         public WalkFlow onWalkStart(WalkEvent keywordWalkEvent) {
-            JsonNode schemaNode = keywordWalkEvent.getSchemaNode();
+            JsonNode schemaNode = keywordWalkEvent.getSchema().getSchemaNode();
             if (schemaNode.get("title").textValue().equals("Property3")) {
                 return WalkFlow.SKIP;
             }
@@ -146,7 +142,7 @@ SchemaValidatorsConfig schemaValidatorsConfig = new SchemaValidatorsConfig();
     schemaValidatorsConfig.addKeywordWalkListener(ValidatorTypeCode.PROPERTIES.getValue(),
             new PropertiesKeywordListener());
 final JsonSchemaFactory schemaFactory = JsonSchemaFactory
-        .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909)).addMetaSchema(metaSchema)
+        .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909)).metaSchema(metaSchema)
         .build();
 this.jsonSchema = schemaFactory.getSchema(getSchema(), schemaValidatorsConfig);
                 
@@ -160,7 +156,7 @@ Both property walk listeners and keyword walk listener can be modeled by using t
 SchemaValidatorsConfig schemaValidatorsConfig = new SchemaValidatorsConfig();
 schemaValidatorsConfig.addPropertyWalkListener(new ExamplePropertyWalkListener());
 final JsonSchemaFactory schemaFactory = JsonSchemaFactory
-                .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909)).addMetaSchema(metaSchema)
+                .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909)).metaSchema(metaSchema)
                 .build();
 this.jsonSchema = schemaFactory.getSchema(getSchema(), schemaValidatorsConfig);
                 
@@ -176,16 +172,15 @@ Following snippet shows the details captured by WalkEvent instance.
 
 ```java
 public class WalkEvent {
-
     private ExecutionContext executionContext;
-    private SchemaLocation schemaLocation;
-    private JsonNodePath evaluationPath;
-    private JsonNode schemaNode;
-    private JsonSchema parentSchema;
+    private JsonSchema schema;
     private String keyword;
-    private JsonNode node;
     private JsonNode rootNode;
+    private JsonNode instanceNode;
     private JsonNodePath instanceLocation;
+    private JsonValidator validator;
+    ...
+}
 ```
 
 ### Sample Flow
@@ -285,7 +280,7 @@ But if we apply defaults while walking, then required validation passes, and the
         JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4);
         SchemaValidatorsConfig schemaValidatorsConfig = new SchemaValidatorsConfig();
         schemaValidatorsConfig.setApplyDefaultsStrategy(new ApplyDefaultsStrategy(true, true, true));
-        JsonSchema jsonSchema =  schemaFactory.getSchema(getClass().getClassLoader().getResourceAsStream("schema.json"), schemaValidatorsConfig);
+        JsonSchema jsonSchema =  schemaFactory.getSchema(SchemaLocation.of("classpath:schema.json"), schemaValidatorsConfig);
 
         JsonNode inputNode = objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("data.json"));
         ValidationResult result = jsonSchema.walk(inputNode, true);

--- a/src/main/java/com/networknt/schema/ConstValidator.java
+++ b/src/main/java/com/networknt/schema/ConstValidator.java
@@ -27,11 +27,10 @@ import java.util.Set;
  */
 public class ConstValidator extends BaseJsonValidator implements JsonValidator {
     private static final Logger logger = LoggerFactory.getLogger(ConstValidator.class);
-    JsonNode schemaNode;
 
-    public ConstValidator(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
+    public ConstValidator(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode,
+            JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaLocation, evaluationPath, schemaNode, parentSchema, ValidatorTypeCode.CONST, validationContext);
-        this.schemaNode = schemaNode;
     }
 
     public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {

--- a/src/main/java/com/networknt/schema/DynamicRefValidator.java
+++ b/src/main/java/com/networknt/schema/DynamicRefValidator.java
@@ -28,7 +28,7 @@ import java.util.*;
 public class DynamicRefValidator extends BaseJsonValidator {
     private static final Logger logger = LoggerFactory.getLogger(DynamicRefValidator.class);
 
-    protected JsonSchemaRef schema;
+    protected final JsonSchemaRef schema;
 
     public DynamicRefValidator(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaLocation, evaluationPath, schemaNode, parentSchema, ValidatorTypeCode.DYNAMIC_REF, validationContext);

--- a/src/main/java/com/networknt/schema/ItemsValidator.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator.java
@@ -248,13 +248,13 @@ public class ItemsValidator extends BaseJsonValidator {
             JsonNodePath instanceLocation, boolean shouldValidateSchema, Set<ValidationMessage> validationMessages) {
         boolean executeWalk = this.validationContext.getConfig().getItemWalkListenerRunner().runPreWalkListeners(executionContext, ValidatorTypeCode.ITEMS.getValue(),
                 node, rootNode, instanceLocation, walkSchema.getEvaluationPath(), walkSchema.getSchemaLocation(),
-                walkSchema.getSchemaNode(), walkSchema.getParentSchema(), this.validationContext, this.validationContext.getJsonSchemaFactory());
+                walkSchema.getSchemaNode(), walkSchema, walkSchema.getParentSchema(), this.validationContext);
         if (executeWalk) {
             validationMessages.addAll(walkSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema));
         }
         this.validationContext.getConfig().getItemWalkListenerRunner().runPostWalkListeners(executionContext, ValidatorTypeCode.ITEMS.getValue(), node, rootNode,
                 instanceLocation, this.evaluationPath, walkSchema.getSchemaLocation(),
-                walkSchema.getSchemaNode(), walkSchema.getParentSchema(), this.validationContext, this.validationContext.getJsonSchemaFactory(), validationMessages);
+                walkSchema.getSchemaNode(), walkSchema, walkSchema.getParentSchema(), this.validationContext, validationMessages);
 
     }
 

--- a/src/main/java/com/networknt/schema/ItemsValidator.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator.java
@@ -36,7 +36,7 @@ public class ItemsValidator extends BaseJsonValidator {
 
     private final JsonSchema schema;
     private final List<JsonSchema> tupleSchema;
-    private Boolean additionalItems;
+    private final Boolean additionalItems;
     private final JsonSchema additionalSchema;
 
     private Boolean hasUnevaluatedItemsValidator = null;
@@ -47,6 +47,8 @@ public class ItemsValidator extends BaseJsonValidator {
 
     public ItemsValidator(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaLocation, evaluationPath, schemaNode, parentSchema, ValidatorTypeCode.ITEMS, validationContext);
+
+        Boolean additionalItems = null;
 
         this.tupleSchema = new ArrayList<>();
         JsonSchema foundSchema = null;
@@ -67,7 +69,7 @@ public class ItemsValidator extends BaseJsonValidator {
             if (addItemNode != null) {
                 additionalItemsSchemaNode = addItemNode;
                 if (addItemNode.isBoolean()) {
-                    this.additionalItems = addItemNode.asBoolean();
+                    additionalItems = addItemNode.asBoolean();
                 } else if (addItemNode.isObject()) {
                     foundAdditionalSchema = validationContext.newSchema(
                             parentSchema.schemaLocation.append(PROPERTY_ADDITIONAL_ITEMS),
@@ -75,6 +77,7 @@ public class ItemsValidator extends BaseJsonValidator {
                 }
             }
         }
+        this.additionalItems = additionalItems;
         this.schema = foundSchema;
         this.additionalSchema = foundAdditionalSchema;
         this.additionalItemsEvaluationPath = parentSchema.evaluationPath.append(PROPERTY_ADDITIONAL_ITEMS);

--- a/src/main/java/com/networknt/schema/ItemsValidator.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator.java
@@ -259,12 +259,12 @@ public class ItemsValidator extends BaseJsonValidator {
     private void walkSchema(ExecutionContext executionContext, JsonSchema walkSchema, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation, boolean shouldValidateSchema, Set<ValidationMessage> validationMessages) {
         boolean executeWalk = this.validationContext.getConfig().getItemWalkListenerRunner().runPreWalkListeners(executionContext, ValidatorTypeCode.ITEMS.getValue(),
-                node, rootNode, instanceLocation, walkSchema);
+                node, rootNode, instanceLocation, walkSchema, this);
         if (executeWalk) {
             validationMessages.addAll(walkSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema));
         }
         this.validationContext.getConfig().getItemWalkListenerRunner().runPostWalkListeners(executionContext, ValidatorTypeCode.ITEMS.getValue(), node, rootNode,
-                instanceLocation, walkSchema, validationMessages);
+                instanceLocation, walkSchema, this, validationMessages);
 
     }
 

--- a/src/main/java/com/networknt/schema/ItemsValidator202012.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator202012.java
@@ -151,7 +151,7 @@ public class ItemsValidator202012 extends BaseJsonValidator {
             walkSchema.getEvaluationPath(),
             walkSchema.getSchemaLocation(),
             walkSchema.getSchemaNode(),
-            walkSchema.getParentSchema(), this.validationContext, this.validationContext.getJsonSchemaFactory()
+            walkSchema, walkSchema.getParentSchema(), this.validationContext
         );
         if (executeWalk) {
             validationMessages.addAll(walkSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema));
@@ -165,8 +165,8 @@ public class ItemsValidator202012 extends BaseJsonValidator {
             this.evaluationPath,
             walkSchema.getSchemaLocation(),
             walkSchema.getSchemaNode(),
-            walkSchema.getParentSchema(),
-            this.validationContext, this.validationContext.getJsonSchemaFactory(), validationMessages
+            walkSchema,
+            walkSchema.getParentSchema(), this.validationContext, validationMessages
         );
         //@formatter:on
     }

--- a/src/main/java/com/networknt/schema/ItemsValidator202012.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator202012.java
@@ -160,7 +160,7 @@ public class ItemsValidator202012 extends BaseJsonValidator {
             node,
             rootNode,
             instanceLocation,
-            walkSchema
+            walkSchema, this
         );
         if (executeWalk) {
             validationMessages.addAll(walkSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema));
@@ -172,7 +172,7 @@ public class ItemsValidator202012 extends BaseJsonValidator {
             rootNode,
             instanceLocation,
             walkSchema,
-            validationMessages
+            this, validationMessages
         );
         //@formatter:on
     }

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -543,9 +543,7 @@ public class JsonSchema extends BaseJsonValidator {
             try {
                 results = v.validate(executionContext, jsonNode, rootNode, instanceLocation);
             } finally {
-                if (results == null || results.isEmpty()) {
-                    // Do nothing if valid
-                } else {
+                if (results != null && !results.isEmpty()) {
                     if (errors == null) {
                         errors = new SetView<>();
                     }

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -1022,7 +1022,7 @@ public class JsonSchema extends BaseJsonValidator {
                 // returns SKIP, then skip the walk.
                 if (this.validationContext.getConfig().getKeywordWalkListenerRunner().runPreWalkListeners(executionContext,
                         evaluationPathWithKeyword.getName(-1), node, rootNode, instanceLocation,
-                        this)) {
+                        this, v)) {
                     Set<ValidationMessage> results = null;
                     try {
                         results = v.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
@@ -1037,7 +1037,7 @@ public class JsonSchema extends BaseJsonValidator {
                 // Call all the post-walk listeners.
                 this.validationContext.getConfig().getKeywordWalkListenerRunner().runPostWalkListeners(executionContext,
                         evaluationPathWithKeyword.getName(-1), node, rootNode, instanceLocation,
-                        this, errors);
+                        this, v, errors);
             }
         }
         return errors;

--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -1043,7 +1043,7 @@ public class JsonSchema extends BaseJsonValidator {
                 if (this.validationContext.getConfig().getKeywordWalkListenerRunner().runPreWalkListeners(executionContext,
                         evaluationPathWithKeyword.getName(-1), node, rootNode, instanceLocation,
                         v.getEvaluationPath(), v.getSchemaLocation(), this.schemaNode,
-                        this.parentSchema, this.validationContext, this.validationContext.getJsonSchemaFactory())) {
+                        this, this.parentSchema, this.validationContext)) {
                     Set<ValidationMessage> results = null;
                     try {
                         results = v.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
@@ -1059,8 +1059,7 @@ public class JsonSchema extends BaseJsonValidator {
                 this.validationContext.getConfig().getKeywordWalkListenerRunner().runPostWalkListeners(executionContext,
                         evaluationPathWithKeyword.getName(-1), node, rootNode, instanceLocation,
                         v.getEvaluationPath(), v.getSchemaLocation(), this.schemaNode,
-                        this.parentSchema, this.validationContext, this.validationContext.getJsonSchemaFactory(),
-                        errors);
+                        this, this.parentSchema, this.validationContext, errors);
             }
         }
         return errors;

--- a/src/main/java/com/networknt/schema/MaxPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/MaxPropertiesValidator.java
@@ -29,13 +29,15 @@ import java.util.Set;
 public class MaxPropertiesValidator extends BaseJsonValidator implements JsonValidator {
     private static final Logger logger = LoggerFactory.getLogger(MaxPropertiesValidator.class);
 
-    private int max;
+    private final int max;
 
     public MaxPropertiesValidator(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode, JsonSchema parentSchema,
                                   ValidationContext validationContext) {
         super(schemaLocation, evaluationPath, schemaNode, parentSchema, ValidatorTypeCode.MAX_PROPERTIES, validationContext);
         if (schemaNode.canConvertToExactIntegral()) {
             max = schemaNode.intValue();
+        } else {
+            max = Integer.MAX_VALUE;
         }
     }
 

--- a/src/main/java/com/networknt/schema/MinPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/MinPropertiesValidator.java
@@ -29,13 +29,15 @@ import java.util.Set;
 public class MinPropertiesValidator extends BaseJsonValidator implements JsonValidator {
     private static final Logger logger = LoggerFactory.getLogger(MinPropertiesValidator.class);
 
-    protected int min;
+    protected final int min;
 
     public MinPropertiesValidator(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode, JsonSchema parentSchema,
                                   ValidationContext validationContext) {
         super(schemaLocation, evaluationPath, schemaNode, parentSchema, ValidatorTypeCode.MIN_PROPERTIES, validationContext);
         if (schemaNode.canConvertToExactIntegral()) {
             min = schemaNode.intValue();
+        } else {
+            min = 0;
         }
     }
 

--- a/src/main/java/com/networknt/schema/PrefixItemsValidator.java
+++ b/src/main/java/com/networknt/schema/PrefixItemsValidator.java
@@ -146,7 +146,7 @@ public class PrefixItemsValidator extends BaseJsonValidator {
             node,
             rootNode,
             instanceLocation,
-            walkSchema
+            walkSchema, this
         );
         if (executeWalk) {
             validationMessages.addAll(walkSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema));
@@ -158,7 +158,7 @@ public class PrefixItemsValidator extends BaseJsonValidator {
             rootNode,
             instanceLocation,
             walkSchema,
-            validationMessages
+            this, validationMessages
         );
         //@formatter:on
     }

--- a/src/main/java/com/networknt/schema/PrefixItemsValidator.java
+++ b/src/main/java/com/networknt/schema/PrefixItemsValidator.java
@@ -137,7 +137,7 @@ public class PrefixItemsValidator extends BaseJsonValidator {
             walkSchema.getEvaluationPath(),
             walkSchema.getSchemaLocation(),
             walkSchema.getSchemaNode(),
-            walkSchema.getParentSchema(), this.validationContext, this.validationContext.getJsonSchemaFactory()
+            walkSchema, walkSchema.getParentSchema(), this.validationContext
         );
         if (executeWalk) {
             validationMessages.addAll(walkSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema));
@@ -151,8 +151,8 @@ public class PrefixItemsValidator extends BaseJsonValidator {
             this.evaluationPath,
             walkSchema.getSchemaLocation(),
             walkSchema.getSchemaNode(),
-            walkSchema.getParentSchema(),
-            this.validationContext, this.validationContext.getJsonSchemaFactory(), validationMessages
+            walkSchema,
+            walkSchema.getParentSchema(), this.validationContext, validationMessages
         );
         //@formatter:on
     }

--- a/src/main/java/com/networknt/schema/PropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/PropertiesValidator.java
@@ -233,7 +233,6 @@ public class PropertiesValidator extends BaseJsonValidator {
         propertyWalkListenerRunner.runPostWalkListeners(executionContext, ValidatorTypeCode.PROPERTIES.getValue(), propertyNode,
                 rootNode, path, propertySchema,
                 this, validationMessages);
-
     }
 
     public Map<String, JsonSchema> getSchemas() {

--- a/src/main/java/com/networknt/schema/PropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/PropertiesValidator.java
@@ -221,7 +221,7 @@ public class PropertiesValidator extends BaseJsonValidator {
         JsonNodePath path = instanceLocation.append(entry.getKey());
         boolean executeWalk = propertyWalkListenerRunner.runPreWalkListeners(executionContext,
                 ValidatorTypeCode.PROPERTIES.getValue(), propertyNode, rootNode, path,
-                propertySchema);
+                propertySchema, this);
         if (propertyNode == null && node != null) {
             // Attempt to get the property node again in case the propertyNode was updated
             propertyNode = node.get(entry.getKey());
@@ -232,7 +232,7 @@ public class PropertiesValidator extends BaseJsonValidator {
         }
         propertyWalkListenerRunner.runPostWalkListeners(executionContext, ValidatorTypeCode.PROPERTIES.getValue(), propertyNode,
                 rootNode, path, propertySchema,
-                validationMessages);
+                this, validationMessages);
 
     }
 

--- a/src/main/java/com/networknt/schema/PropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/PropertiesValidator.java
@@ -222,7 +222,11 @@ public class PropertiesValidator extends BaseJsonValidator {
         boolean executeWalk = propertyWalkListenerRunner.runPreWalkListeners(executionContext,
                 ValidatorTypeCode.PROPERTIES.getValue(), propertyNode, rootNode, path,
                 propertySchema);
-        if (executeWalk && !skipWalk) {
+        if (propertyNode == null && node != null) {
+            // Attempt to get the property node again in case the propertyNode was updated
+            propertyNode = node.get(entry.getKey());
+        }
+        if (executeWalk && !(skipWalk && propertyNode == null)) {
             validationMessages.union(
                     propertySchema.walk(executionContext, propertyNode, rootNode, path, shouldValidateSchema));
         }

--- a/src/main/java/com/networknt/schema/RecursiveRefValidator.java
+++ b/src/main/java/com/networknt/schema/RecursiveRefValidator.java
@@ -28,7 +28,7 @@ import java.util.*;
 public class RecursiveRefValidator extends BaseJsonValidator {
     private static final Logger logger = LoggerFactory.getLogger(RecursiveRefValidator.class);
 
-    protected JsonSchemaRef schema;
+    protected final JsonSchemaRef schema;
 
     public RecursiveRefValidator(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaLocation, evaluationPath, schemaNode, parentSchema, ValidatorTypeCode.RECURSIVE_REF, validationContext);

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -28,7 +28,7 @@ import java.util.*;
 public class RefValidator extends BaseJsonValidator {
     private static final Logger logger = LoggerFactory.getLogger(RefValidator.class);
 
-    protected JsonSchemaRef schema;
+    protected final JsonSchemaRef schema;
 
     private static final String REF_CURRENT = "#";
 

--- a/src/main/java/com/networknt/schema/TypeValidator.java
+++ b/src/main/java/com/networknt/schema/TypeValidator.java
@@ -29,16 +29,16 @@ import java.util.*;
 public class TypeValidator extends BaseJsonValidator {
     private static final Logger logger = LoggerFactory.getLogger(TypeValidator.class);
 
-    private JsonType schemaType;
-    private JsonSchema parentSchema;
-    private UnionTypeValidator unionTypeValidator;
+    private final JsonType schemaType;
+    private final UnionTypeValidator unionTypeValidator;
 
     public TypeValidator(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaLocation, evaluationPath, schemaNode, parentSchema, ValidatorTypeCode.TYPE, validationContext);
         this.schemaType = TypeFactory.getSchemaNodeType(schemaNode);
-        this.parentSchema = parentSchema;
         if (this.schemaType == JsonType.UNION) {
             this.unionTypeValidator = new UnionTypeValidator(schemaLocation, evaluationPath, schemaNode, parentSchema, validationContext);
+        } else {
+            this.unionTypeValidator = null;
         }
     }
 
@@ -47,7 +47,7 @@ public class TypeValidator extends BaseJsonValidator {
     }
 
     public boolean equalsToSchemaType(JsonNode node) {
-        return JsonNodeUtil.equalsToSchemaType(node,this.schemaType, this.parentSchema, this.validationContext);
+        return JsonNodeUtil.equalsToSchemaType(node, this.schemaType, this.parentSchema, this.validationContext);
     }
 
     @Override

--- a/src/main/java/com/networknt/schema/UniqueItemsValidator.java
+++ b/src/main/java/com/networknt/schema/UniqueItemsValidator.java
@@ -30,12 +30,14 @@ import java.util.Set;
 public class UniqueItemsValidator extends BaseJsonValidator implements JsonValidator {
     private static final Logger logger = LoggerFactory.getLogger(UniqueItemsValidator.class);
 
-    private boolean unique = false;
+    private final boolean unique;
 
     public UniqueItemsValidator(SchemaLocation schemaLocation, JsonNodePath evaluationPath, JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaLocation, evaluationPath, schemaNode, parentSchema, ValidatorTypeCode.UNIQUE_ITEMS, validationContext);
         if (schemaNode.isBoolean()) {
             unique = schemaNode.booleanValue();
+        } else {
+            unique = false;
         }
     }
 

--- a/src/main/java/com/networknt/schema/utils/JsonNodes.java
+++ b/src/main/java/com/networknt/schema/utils/JsonNodes.java
@@ -33,7 +33,8 @@ public class JsonNodes {
      * @param path the path
      * @return the node found at the path or null
      */
-    public static JsonNode get(JsonNode node, JsonNodePath path) {
+    @SuppressWarnings("unchecked")
+    public static <T extends JsonNode> T get(JsonNode node, JsonNodePath path) {
         int nameCount = path.getNameCount();
         JsonNode current = node;
         for (int x = 0; x < nameCount; x++) {
@@ -44,7 +45,7 @@ public class JsonNodes {
             }
             current = result;
         }
-        return current;
+        return (T) current;
     }
 
     /**
@@ -54,7 +55,8 @@ public class JsonNodes {
      * @param propertyOrIndex the property or index
      * @return the node given the property or index
      */
-    public static JsonNode get(JsonNode node, Object propertyOrIndex) {
+    @SuppressWarnings("unchecked")
+    public static <T extends JsonNode> T get(JsonNode node, Object propertyOrIndex) {
         JsonNode value = null;
         if (propertyOrIndex instanceof Number) {
             value = node.get(((Number) propertyOrIndex).intValue());
@@ -75,6 +77,6 @@ public class JsonNodes {
             
             value = node.get(unescaped);
         }
-        return value;
+        return (T) value;
     }
 }

--- a/src/main/java/com/networknt/schema/utils/JsonNodes.java
+++ b/src/main/java/com/networknt/schema/utils/JsonNodes.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.utils;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.networknt.schema.JsonNodePath;
+
+/**
+ * Utility methods for JsonNode.
+ */
+public class JsonNodes {
+    /**
+     * Gets the node found at the path.
+     * 
+     * @param node the node
+     * @param path the path
+     * @return the node found at the path or null
+     */
+    public static JsonNode get(JsonNode node, JsonNodePath path) {
+        int nameCount = path.getNameCount();
+        JsonNode current = node;
+        for (int x = 0; x < nameCount; x++) {
+            Object segment = path.getElement(x);
+            JsonNode result = get(current, segment);
+            if (result == null) {
+                return null;
+            }
+            current = result;
+        }
+        return current;
+    }
+
+    /**
+     * Gets the node given the property or index.
+     * 
+     * @param node the node
+     * @param propertyOrIndex the property or index
+     * @return the node given the property or index
+     */
+    public static JsonNode get(JsonNode node, Object propertyOrIndex) {
+        JsonNode value = null;
+        if (propertyOrIndex instanceof Number) {
+            value = node.get(((Number) propertyOrIndex).intValue());
+        } else {
+            // In the case of string this represents an escaped json pointer and thus does not reflect the property directly
+            String unescaped = propertyOrIndex.toString();
+            if (unescaped.contains("~")) {
+                unescaped = unescaped.replace("~1", "/");
+                unescaped = unescaped.replace("~0", "~");
+            }
+            if (unescaped.contains("%")) {
+                try {
+                    unescaped = URLDecoder.decode(unescaped, StandardCharsets.UTF_8.toString());
+                } catch (UnsupportedEncodingException e) {
+                    // Do nothing
+                }
+            }
+            
+            value = node.get(unescaped);
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/networknt/schema/utils/JsonSchemaRefs.java
+++ b/src/main/java/com/networknt/schema/utils/JsonSchemaRefs.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.utils;
+
+import com.networknt.schema.DynamicRefValidator;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaRef;
+import com.networknt.schema.JsonValidator;
+import com.networknt.schema.RecursiveRefValidator;
+import com.networknt.schema.RefValidator;
+
+/**
+ * Utility methods for JsonSchemaRef.
+ */
+public class JsonSchemaRefs {
+
+    /**
+     * Gets the ref.
+     *
+     * @param schema the schema
+     * @return the ref
+     */
+    public static JsonSchemaRef from(JsonSchema schema) {
+        for (JsonValidator validator : schema.getValidators()) {
+            if (validator instanceof RefValidator) {
+                return ((RefValidator) validator).getSchemaRef();
+            } else if (validator instanceof DynamicRefValidator) {
+                return ((DynamicRefValidator) validator).getSchemaRef();
+            } else if (validator instanceof RecursiveRefValidator) {
+                return ((RecursiveRefValidator) validator).getSchemaRef();
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/networknt/schema/walk/AbstractWalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/AbstractWalkListenerRunner.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.JsonNodePath;
 import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonValidator;
 import com.networknt.schema.ValidationMessage;
 
 import java.util.List;
@@ -12,10 +13,10 @@ import java.util.Set;
 public abstract class AbstractWalkListenerRunner implements WalkListenerRunner {
 
     protected WalkEvent constructWalkEvent(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
-            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema) {
+            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema, JsonValidator validator) {
         return WalkEvent.builder().executionContext(executionContext).instanceLocation(instanceLocation)
                 .keyword(keyword).instanceNode(instanceNode)
-                .rootNode(rootNode).schema(schema).build();
+                .rootNode(rootNode).schema(schema).validator(validator).build();
     }
 
     protected boolean runPreWalkListeners(List<JsonSchemaWalkListener> walkListeners, WalkEvent walkEvent) {

--- a/src/main/java/com/networknt/schema/walk/AbstractWalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/AbstractWalkListenerRunner.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.JsonNodePath;
 import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.ValidationContext;
 import com.networknt.schema.ValidationMessage;
@@ -14,14 +13,13 @@ import java.util.Set;
 
 public abstract class AbstractWalkListenerRunner implements WalkListenerRunner {
 
-    protected WalkEvent constructWalkEvent(ExecutionContext executionContext, String keyword, JsonNode node,
+    protected WalkEvent constructWalkEvent(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
             JsonNode rootNode, JsonNodePath instanceLocation, JsonNodePath evaluationPath, SchemaLocation schemaLocation,
-            JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext,
-            JsonSchemaFactory currentJsonSchemaFactory) {
+            JsonNode schemaNode, JsonSchema schema, JsonSchema parentSchema, ValidationContext validationContext) {
         return WalkEvent.builder().executionContext(executionContext).instanceLocation(instanceLocation)
-                .evaluationPath(evaluationPath).keyword(keyword).node(node).parentSchema(parentSchema)
-                .rootNode(rootNode).schemaNode(schemaNode).schemaLocation(schemaLocation)
-                .currentJsonSchemaFactory(currentJsonSchemaFactory).validationContext(validationContext).build();
+                .evaluationPath(evaluationPath).keyword(keyword).instanceNode(instanceNode).parentSchema(parentSchema)
+                .rootNode(rootNode).schemaNode(schemaNode).schema(schema).schemaLocation(schemaLocation)
+                .validationContext(validationContext).build();
     }
 
     protected boolean runPreWalkListeners(List<JsonSchemaWalkListener> walkListeners, WalkEvent walkEvent) {

--- a/src/main/java/com/networknt/schema/walk/AbstractWalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/AbstractWalkListenerRunner.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.JsonNodePath;
 import com.networknt.schema.JsonSchema;
-import com.networknt.schema.SchemaLocation;
-import com.networknt.schema.ValidationContext;
 import com.networknt.schema.ValidationMessage;
 
 import java.util.List;
@@ -14,12 +12,10 @@ import java.util.Set;
 public abstract class AbstractWalkListenerRunner implements WalkListenerRunner {
 
     protected WalkEvent constructWalkEvent(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
-            JsonNode rootNode, JsonNodePath instanceLocation, JsonNodePath evaluationPath, SchemaLocation schemaLocation,
-            JsonNode schemaNode, JsonSchema schema, JsonSchema parentSchema, ValidationContext validationContext) {
+            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema) {
         return WalkEvent.builder().executionContext(executionContext).instanceLocation(instanceLocation)
-                .evaluationPath(evaluationPath).keyword(keyword).instanceNode(instanceNode).parentSchema(parentSchema)
-                .rootNode(rootNode).schemaNode(schemaNode).schema(schema).schemaLocation(schemaLocation)
-                .validationContext(validationContext).build();
+                .keyword(keyword).instanceNode(instanceNode)
+                .rootNode(rootNode).schema(schema).build();
     }
 
     protected boolean runPreWalkListeners(List<JsonSchemaWalkListener> walkListeners, WalkEvent walkEvent) {

--- a/src/main/java/com/networknt/schema/walk/DefaultItemWalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/DefaultItemWalkListenerRunner.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.JsonNodePath;
 import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.ValidationContext;
 import com.networknt.schema.ValidationMessage;
@@ -21,22 +20,21 @@ public class DefaultItemWalkListenerRunner extends AbstractWalkListenerRunner {
     }
 
     @Override
-    public boolean runPreWalkListeners(ExecutionContext executionContext, String keyword, JsonNode node,
+    public boolean runPreWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
             JsonNode rootNode, JsonNodePath instanceLocation, JsonNodePath evaluationPath, SchemaLocation schemaLocation,
-            JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext,
-            JsonSchemaFactory currentJsonSchemaFactory) {
-        WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, node, rootNode, instanceLocation,
-                evaluationPath, schemaLocation, schemaNode, parentSchema, validationContext, currentJsonSchemaFactory);
+            JsonNode schemaNode, JsonSchema schema, JsonSchema parentSchema, ValidationContext validationContext) {
+        WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation,
+                evaluationPath, schemaLocation, schemaNode, schema, parentSchema, validationContext);
         return runPreWalkListeners(itemWalkListeners, walkEvent);
     }
 
     @Override
-    public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode node,
+    public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
             JsonNode rootNode, JsonNodePath instanceLocation, JsonNodePath evaluationPath, SchemaLocation schemaLocation,
-            JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext,
-            JsonSchemaFactory currentJsonSchemaFactory, Set<ValidationMessage> validationMessages) {
-        WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, node, rootNode, instanceLocation,
-                evaluationPath, schemaLocation, schemaNode, parentSchema, validationContext, currentJsonSchemaFactory);
+            JsonNode schemaNode, JsonSchema schema, JsonSchema parentSchema,
+            ValidationContext validationContext, Set<ValidationMessage> validationMessages) {
+        WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation,
+                evaluationPath, schemaLocation, schemaNode, schema, parentSchema, validationContext);
         runPostWalkListeners(itemWalkListeners, walkEvent, validationMessages);
     }
 

--- a/src/main/java/com/networknt/schema/walk/DefaultItemWalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/DefaultItemWalkListenerRunner.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.JsonNodePath;
 import com.networknt.schema.JsonSchema;
-import com.networknt.schema.SchemaLocation;
-import com.networknt.schema.ValidationContext;
 import com.networknt.schema.ValidationMessage;
 
 import java.util.List;
@@ -21,20 +19,17 @@ public class DefaultItemWalkListenerRunner extends AbstractWalkListenerRunner {
 
     @Override
     public boolean runPreWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
-            JsonNode rootNode, JsonNodePath instanceLocation, JsonNodePath evaluationPath, SchemaLocation schemaLocation,
-            JsonNode schemaNode, JsonSchema schema, JsonSchema parentSchema, ValidationContext validationContext) {
+            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema) {
         WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation,
-                evaluationPath, schemaLocation, schemaNode, schema, parentSchema, validationContext);
+                schema);
         return runPreWalkListeners(itemWalkListeners, walkEvent);
     }
 
     @Override
     public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
-            JsonNode rootNode, JsonNodePath instanceLocation, JsonNodePath evaluationPath, SchemaLocation schemaLocation,
-            JsonNode schemaNode, JsonSchema schema, JsonSchema parentSchema,
-            ValidationContext validationContext, Set<ValidationMessage> validationMessages) {
+            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema, Set<ValidationMessage> validationMessages) {
         WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation,
-                evaluationPath, schemaLocation, schemaNode, schema, parentSchema, validationContext);
+                schema);
         runPostWalkListeners(itemWalkListeners, walkEvent, validationMessages);
     }
 

--- a/src/main/java/com/networknt/schema/walk/DefaultItemWalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/DefaultItemWalkListenerRunner.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.JsonNodePath;
 import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonValidator;
 import com.networknt.schema.ValidationMessage;
 
 import java.util.List;
@@ -19,17 +20,17 @@ public class DefaultItemWalkListenerRunner extends AbstractWalkListenerRunner {
 
     @Override
     public boolean runPreWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
-            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema) {
+            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema, JsonValidator validator) {
         WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation,
-                schema);
+                schema, validator);
         return runPreWalkListeners(itemWalkListeners, walkEvent);
     }
 
     @Override
     public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
-            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema, Set<ValidationMessage> validationMessages) {
+            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema, JsonValidator validator, Set<ValidationMessage> validationMessages) {
         WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation,
-                schema);
+                schema, validator);
         runPostWalkListeners(itemWalkListeners, walkEvent, validationMessages);
     }
 

--- a/src/main/java/com/networknt/schema/walk/DefaultKeywordWalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/DefaultKeywordWalkListenerRunner.java
@@ -17,9 +17,9 @@ public class DefaultKeywordWalkListenerRunner extends AbstractWalkListenerRunner
 
     @Override
     public boolean runPreWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode, JsonNode rootNode,
-            JsonNodePath instanceLocation, JsonSchema schema) {
+            JsonNodePath instanceLocation, JsonSchema schema, JsonValidator validator) {
         boolean continueRunningListenersAndWalk = true;
-        WalkEvent keywordWalkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, schema);
+        WalkEvent keywordWalkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, schema, validator);
         // Run Listeners that are setup only for this keyword.
         List<JsonSchemaWalkListener> currentKeywordListeners = keywordWalkListenersMap.get(keyword);
         continueRunningListenersAndWalk = runPreWalkListeners(currentKeywordListeners, keywordWalkEvent);
@@ -34,8 +34,8 @@ public class DefaultKeywordWalkListenerRunner extends AbstractWalkListenerRunner
 
     @Override
     public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode, JsonNode rootNode, JsonNodePath instanceLocation,
-            JsonSchema schema, Set<ValidationMessage> validationMessages) {
-        WalkEvent keywordWalkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, schema);
+            JsonSchema schema, JsonValidator validator, Set<ValidationMessage> validationMessages) {
+        WalkEvent keywordWalkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, schema, validator);
         // Run Listeners that are setup only for this keyword.
         List<JsonSchemaWalkListener> currentKeywordListeners = keywordWalkListenersMap.get(keyword);
         runPostWalkListeners(currentKeywordListeners, keywordWalkEvent, validationMessages);

--- a/src/main/java/com/networknt/schema/walk/DefaultKeywordWalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/DefaultKeywordWalkListenerRunner.java
@@ -16,13 +16,13 @@ public class DefaultKeywordWalkListenerRunner extends AbstractWalkListenerRunner
     }
 
     @Override
-    public boolean runPreWalkListeners(ExecutionContext executionContext, String keyword, JsonNode node, JsonNode rootNode,
+    public boolean runPreWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode, JsonNode rootNode,
             JsonNodePath instanceLocation, JsonNodePath evaluationPath, SchemaLocation schemaLocation,
                                        JsonNode schemaNode,
-                                       JsonSchema parentSchema, ValidationContext validationContext, JsonSchemaFactory currentJsonSchemaFactory) {
+                                       JsonSchema schema, JsonSchema parentSchema, ValidationContext validationContext) {
         boolean continueRunningListenersAndWalk = true;
-        WalkEvent keywordWalkEvent = constructWalkEvent(executionContext, keyword, node, rootNode, instanceLocation, evaluationPath,
-                schemaLocation, schemaNode, parentSchema, validationContext, currentJsonSchemaFactory);
+        WalkEvent keywordWalkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, evaluationPath,
+                schemaLocation, schemaNode, schema, parentSchema, validationContext);
         // Run Listeners that are setup only for this keyword.
         List<JsonSchemaWalkListener> currentKeywordListeners = keywordWalkListenersMap.get(keyword);
         continueRunningListenersAndWalk = runPreWalkListeners(currentKeywordListeners, keywordWalkEvent);
@@ -36,13 +36,13 @@ public class DefaultKeywordWalkListenerRunner extends AbstractWalkListenerRunner
     }
 
     @Override
-    public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation,
+    public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode, JsonNode rootNode, JsonNodePath instanceLocation,
             JsonNodePath evaluationPath, SchemaLocation schemaLocation,
                                      JsonNode schemaNode,
-                                     JsonSchema parentSchema,
-                                     ValidationContext validationContext, JsonSchemaFactory currentJsonSchemaFactory, Set<ValidationMessage> validationMessages) {
-        WalkEvent keywordWalkEvent = constructWalkEvent(executionContext, keyword, node, rootNode, instanceLocation, evaluationPath,
-                schemaLocation, schemaNode, parentSchema, validationContext, currentJsonSchemaFactory);
+                                     JsonSchema schema,
+                                     JsonSchema parentSchema, ValidationContext validationContext, Set<ValidationMessage> validationMessages) {
+        WalkEvent keywordWalkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, evaluationPath,
+                schemaLocation, schemaNode, schema, parentSchema, validationContext);
         // Run Listeners that are setup only for this keyword.
         List<JsonSchemaWalkListener> currentKeywordListeners = keywordWalkListenersMap.get(keyword);
         runPostWalkListeners(currentKeywordListeners, keywordWalkEvent, validationMessages);

--- a/src/main/java/com/networknt/schema/walk/DefaultKeywordWalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/DefaultKeywordWalkListenerRunner.java
@@ -17,12 +17,9 @@ public class DefaultKeywordWalkListenerRunner extends AbstractWalkListenerRunner
 
     @Override
     public boolean runPreWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode, JsonNode rootNode,
-            JsonNodePath instanceLocation, JsonNodePath evaluationPath, SchemaLocation schemaLocation,
-                                       JsonNode schemaNode,
-                                       JsonSchema schema, JsonSchema parentSchema, ValidationContext validationContext) {
+            JsonNodePath instanceLocation, JsonSchema schema) {
         boolean continueRunningListenersAndWalk = true;
-        WalkEvent keywordWalkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, evaluationPath,
-                schemaLocation, schemaNode, schema, parentSchema, validationContext);
+        WalkEvent keywordWalkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, schema);
         // Run Listeners that are setup only for this keyword.
         List<JsonSchemaWalkListener> currentKeywordListeners = keywordWalkListenersMap.get(keyword);
         continueRunningListenersAndWalk = runPreWalkListeners(currentKeywordListeners, keywordWalkEvent);
@@ -37,12 +34,8 @@ public class DefaultKeywordWalkListenerRunner extends AbstractWalkListenerRunner
 
     @Override
     public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode, JsonNode rootNode, JsonNodePath instanceLocation,
-            JsonNodePath evaluationPath, SchemaLocation schemaLocation,
-                                     JsonNode schemaNode,
-                                     JsonSchema schema,
-                                     JsonSchema parentSchema, ValidationContext validationContext, Set<ValidationMessage> validationMessages) {
-        WalkEvent keywordWalkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, evaluationPath,
-                schemaLocation, schemaNode, schema, parentSchema, validationContext);
+            JsonSchema schema, Set<ValidationMessage> validationMessages) {
+        WalkEvent keywordWalkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, schema);
         // Run Listeners that are setup only for this keyword.
         List<JsonSchemaWalkListener> currentKeywordListeners = keywordWalkListenersMap.get(keyword);
         runPostWalkListeners(currentKeywordListeners, keywordWalkEvent, validationMessages);

--- a/src/main/java/com/networknt/schema/walk/DefaultPropertyWalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/DefaultPropertyWalkListenerRunner.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.JsonNodePath;
 import com.networknt.schema.JsonSchema;
-import com.networknt.schema.SchemaLocation;
-import com.networknt.schema.ValidationContext;
 import com.networknt.schema.ValidationMessage;
 
 import java.util.List;
@@ -21,19 +19,15 @@ public class DefaultPropertyWalkListenerRunner extends AbstractWalkListenerRunne
 
     @Override
     public boolean runPreWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode, JsonNode rootNode,
-            JsonNodePath instanceLocation, JsonNodePath evaluationPath, SchemaLocation schemaLocation, JsonNode schemaNode,
-                                       JsonSchema schema, JsonSchema parentSchema, ValidationContext validationContext) {
-        WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, evaluationPath, schemaLocation,
-                schemaNode, schema, parentSchema, validationContext);
+            JsonNodePath instanceLocation, JsonSchema schema) {
+        WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, schema);
         return runPreWalkListeners(propertyWalkListeners, walkEvent);
     }
 
     @Override
     public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode, JsonNode rootNode, JsonNodePath instanceLocation,
-            JsonNodePath evaluationPath, SchemaLocation schemaLocation, JsonNode schemaNode, JsonSchema schema,
-                                     JsonSchema parentSchema, ValidationContext validationContext, Set<ValidationMessage> validationMessages) {
-        WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, evaluationPath, schemaLocation,
-                schemaNode, schema, parentSchema, validationContext);
+            JsonSchema schema, Set<ValidationMessage> validationMessages) {
+        WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, schema);
         runPostWalkListeners(propertyWalkListeners, walkEvent, validationMessages);
 
     }

--- a/src/main/java/com/networknt/schema/walk/DefaultPropertyWalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/DefaultPropertyWalkListenerRunner.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.JsonNodePath;
 import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.ValidationContext;
 import com.networknt.schema.ValidationMessage;
@@ -21,20 +20,20 @@ public class DefaultPropertyWalkListenerRunner extends AbstractWalkListenerRunne
     }
 
     @Override
-    public boolean runPreWalkListeners(ExecutionContext executionContext, String keyword, JsonNode node, JsonNode rootNode,
+    public boolean runPreWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode, JsonNode rootNode,
             JsonNodePath instanceLocation, JsonNodePath evaluationPath, SchemaLocation schemaLocation, JsonNode schemaNode,
-                                       JsonSchema parentSchema, ValidationContext validationContext, JsonSchemaFactory currentJsonSchemaFactory) {
-        WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, node, rootNode, instanceLocation, evaluationPath, schemaLocation,
-                schemaNode, parentSchema, validationContext, currentJsonSchemaFactory);
+                                       JsonSchema schema, JsonSchema parentSchema, ValidationContext validationContext) {
+        WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, evaluationPath, schemaLocation,
+                schemaNode, schema, parentSchema, validationContext);
         return runPreWalkListeners(propertyWalkListeners, walkEvent);
     }
 
     @Override
-    public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation,
-            JsonNodePath evaluationPath, SchemaLocation schemaLocation, JsonNode schemaNode, JsonSchema parentSchema,
-                                     ValidationContext validationContext, JsonSchemaFactory currentJsonSchemaFactory, Set<ValidationMessage> validationMessages) {
-        WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, node, rootNode, instanceLocation, evaluationPath, schemaLocation,
-                schemaNode, parentSchema, validationContext, currentJsonSchemaFactory);
+    public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode, JsonNode rootNode, JsonNodePath instanceLocation,
+            JsonNodePath evaluationPath, SchemaLocation schemaLocation, JsonNode schemaNode, JsonSchema schema,
+                                     JsonSchema parentSchema, ValidationContext validationContext, Set<ValidationMessage> validationMessages) {
+        WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, evaluationPath, schemaLocation,
+                schemaNode, schema, parentSchema, validationContext);
         runPostWalkListeners(propertyWalkListeners, walkEvent, validationMessages);
 
     }

--- a/src/main/java/com/networknt/schema/walk/DefaultPropertyWalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/DefaultPropertyWalkListenerRunner.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.JsonNodePath;
 import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonValidator;
 import com.networknt.schema.ValidationMessage;
 
 import java.util.List;
@@ -19,15 +20,15 @@ public class DefaultPropertyWalkListenerRunner extends AbstractWalkListenerRunne
 
     @Override
     public boolean runPreWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode, JsonNode rootNode,
-            JsonNodePath instanceLocation, JsonSchema schema) {
-        WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, schema);
+            JsonNodePath instanceLocation, JsonSchema schema, JsonValidator validator) {
+        WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, schema, validator);
         return runPreWalkListeners(propertyWalkListeners, walkEvent);
     }
 
     @Override
     public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode, JsonNode rootNode, JsonNodePath instanceLocation,
-            JsonSchema schema, Set<ValidationMessage> validationMessages) {
-        WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, schema);
+            JsonSchema schema, JsonValidator validator, Set<ValidationMessage> validationMessages) {
+        WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, schema, validator);
         runPostWalkListeners(propertyWalkListeners, walkEvent, validationMessages);
 
     }

--- a/src/main/java/com/networknt/schema/walk/WalkEvent.java
+++ b/src/main/java/com/networknt/schema/walk/WalkEvent.java
@@ -15,31 +15,29 @@ import com.networknt.schema.ValidationContext;
 public class WalkEvent {
 
     private ExecutionContext executionContext;
-    private SchemaLocation schemaLocation;
-    private JsonNodePath evaluationPath;
-    private JsonNode schemaNode;
     private JsonSchema schema;
-    private JsonSchema parentSchema;
     private String keyword;
     private JsonNode instanceNode;
     private JsonNode rootNode;
     private JsonNodePath instanceLocation;
-    private ValidationContext validationContext;
 
     public ExecutionContext getExecutionContext() {
         return executionContext;
     }
 
+    @Deprecated
     public SchemaLocation getSchemaLocation() {
-        return schemaLocation;
-    }
-    
-    public JsonNodePath getEvaluationPath() {
-        return evaluationPath;
+        return getSchema().getSchemaLocation();
     }
 
+    @Deprecated
+    public JsonNodePath getEvaluationPath() {
+        return getSchema().getEvaluationPath();
+    }
+
+    @Deprecated
     public JsonNode getSchemaNode() {
-        return schemaNode;
+        return getSchema().getSchemaNode();
     }
 
     /**
@@ -51,8 +49,9 @@ public class WalkEvent {
         return schema;
     }
 
+    @Deprecated
     public JsonSchema getParentSchema() {
-        return parentSchema;
+        return getSchema().getParentSchema();
     }
 
     public String getKeyword() {
@@ -76,32 +75,29 @@ public class WalkEvent {
         return instanceLocation;
     }
 
+    @Deprecated
     public JsonSchema getRefSchema(SchemaLocation schemaLocation) {
-        return this.validationContext.getJsonSchemaFactory().getSchema(schemaLocation, validationContext.getConfig());
+        return getCurrentJsonSchemaFactory().getSchema(schemaLocation, getSchema().getValidationContext().getConfig());
     }
 
+    @Deprecated
     public JsonSchema getRefSchema(SchemaLocation schemaLocation, SchemaValidatorsConfig schemaValidatorsConfig) {
         if (schemaValidatorsConfig != null) {
-            return this.validationContext.getJsonSchemaFactory().getSchema(schemaLocation, schemaValidatorsConfig);
+            return getCurrentJsonSchemaFactory().getSchema(schemaLocation, schemaValidatorsConfig);
         } else {
             return getRefSchema(schemaLocation);
         }
     }
 
-    public JsonSchemaFactory getJsonSchemaFactory() {
-        return this.validationContext.getJsonSchemaFactory();
-    }
-
     @Deprecated
     public JsonSchemaFactory getCurrentJsonSchemaFactory() {
-        return getJsonSchemaFactory();
+        return getSchema().getValidationContext().getJsonSchemaFactory();
     }
-
 
     @Override
     public String toString() {
-        return "WalkEvent [evaluationPath=" + evaluationPath + ", schemaLocation=" + schemaLocation
-                + ", instanceLocation=" + instanceLocation + "]";
+        return "WalkEvent [evaluationPath=" + getSchema().getEvaluationPath() + ", schemaLocation="
+                + getSchema().getSchemaLocation() + ", instanceLocation=" + instanceLocation + "]";
     }
 
     static class WalkEventBuilder {
@@ -117,18 +113,18 @@ public class WalkEvent {
             return this;
         }
 
+        @Deprecated
         public WalkEventBuilder evaluationPath(JsonNodePath evaluationPath) {
-            walkEvent.evaluationPath = evaluationPath;
             return this;
         }
 
+        @Deprecated
         public WalkEventBuilder schemaLocation(SchemaLocation schemaLocation) {
-            walkEvent.schemaLocation = schemaLocation;
             return this;
         }
 
+        @Deprecated
         public WalkEventBuilder schemaNode(JsonNode schemaNode) {
-            walkEvent.schemaNode = schemaNode;
             return this;
         }
 
@@ -137,8 +133,8 @@ public class WalkEvent {
             return this;
         }
 
+        @Deprecated
         public WalkEventBuilder parentSchema(JsonSchema parentSchema) {
-            walkEvent.parentSchema = parentSchema;
             return this;
         }
 
@@ -172,8 +168,8 @@ public class WalkEvent {
             return this;
         }
 
+        @Deprecated
         public WalkEventBuilder validationContext(ValidationContext validationContext) {
-            walkEvent.validationContext = validationContext;
             return this;
         }
 

--- a/src/main/java/com/networknt/schema/walk/WalkEvent.java
+++ b/src/main/java/com/networknt/schema/walk/WalkEvent.java
@@ -21,8 +21,76 @@ public class WalkEvent {
     private JsonNode rootNode;
     private JsonNodePath instanceLocation;
 
+    /**
+     * Gets the execution context.
+     * <p>
+     * As the listeners should be state-less, this allows listeners to store data in
+     * the collector context.
+     * 
+     * @return the execution context
+     */
     public ExecutionContext getExecutionContext() {
         return executionContext;
+    }
+
+    /**
+     * Gets the schema that will be used to evaluate the instance node.
+     * <p>
+     * For the keyword listener, this will allow getting the validator for the given keyword.
+     *
+     * @return the schema
+     */
+    public JsonSchema getSchema() {
+        return schema;
+    }
+
+    /**
+     * Gets the keyword.
+     * 
+     * @return the keyword
+     */
+    public String getKeyword() {
+        return keyword;
+    }
+
+    /**
+     * Gets the instance node.
+     * 
+     * @return the instance node
+     */
+    public JsonNode getInstanceNode() {
+        return instanceNode;
+    }
+
+    /**
+     * Gets the root instance node.
+     * <p>
+     * This makes it possible to get the parent node, for instance by getting the
+     * instance location parent and using the root node.
+     * 
+     * @return the root node
+     */
+    public JsonNode getRootNode() {
+        return rootNode;
+    }
+
+    /**
+     * Gets the instance location of the instance node.
+     * 
+     * @return the instance location of the instance node
+     */
+    public JsonNodePath getInstanceLocation() {
+        return instanceLocation;
+    }
+
+    @Deprecated
+    public JsonNode getNode() {
+        return getInstanceNode();
+    }
+    
+    @Deprecated
+    public JsonSchema getParentSchema() {
+        return getSchema().getParentSchema();
     }
 
     @Deprecated
@@ -38,41 +106,6 @@ public class WalkEvent {
     @Deprecated
     public JsonNode getSchemaNode() {
         return getSchema().getSchemaNode();
-    }
-
-    /**
-     * Gets the JsonSchema indicated by the schema node.
-     *
-     * @return the schema
-     */
-    public JsonSchema getSchema() {
-        return schema;
-    }
-
-    @Deprecated
-    public JsonSchema getParentSchema() {
-        return getSchema().getParentSchema();
-    }
-
-    public String getKeyword() {
-        return keyword;
-    }
-
-    public JsonNode getInstanceNode() {
-        return instanceNode;
-    }
-
-    @Deprecated
-    public JsonNode getNode() {
-        return getInstanceNode();
-    }
-
-    public JsonNode getRootNode() {
-        return rootNode;
-    }
-
-    public JsonNodePath getInstanceLocation() {
-        return instanceLocation;
     }
 
     @Deprecated
@@ -113,6 +146,31 @@ public class WalkEvent {
             return this;
         }
 
+        public WalkEventBuilder schema(JsonSchema schema) {
+            walkEvent.schema = schema;
+            return this;
+        }
+
+        public WalkEventBuilder keyword(String keyword) {
+            walkEvent.keyword = keyword;
+            return this;
+        }
+
+        public WalkEventBuilder instanceNode(JsonNode node) {
+            walkEvent.instanceNode = node;
+            return this;
+        }
+
+        public WalkEventBuilder rootNode(JsonNode rootNode) {
+            walkEvent.rootNode = rootNode;
+            return this;
+        }
+
+        public WalkEventBuilder instanceLocation(JsonNodePath instanceLocation) {
+            walkEvent.instanceLocation = instanceLocation;
+            return this;
+        }
+
         @Deprecated
         public WalkEventBuilder evaluationPath(JsonNodePath evaluationPath) {
             return this;
@@ -128,41 +186,16 @@ public class WalkEvent {
             return this;
         }
 
-        public WalkEventBuilder schema(JsonSchema schema) {
-            walkEvent.schema = schema;
-            return this;
-        }
-
         @Deprecated
         public WalkEventBuilder parentSchema(JsonSchema parentSchema) {
             return this;
         }
-
-        public WalkEventBuilder keyword(String keyword) {
-            walkEvent.keyword = keyword;
-            return this;
-        }
-
-        public WalkEventBuilder instanceNode(JsonNode node) {
-            walkEvent.instanceNode = node;
-            return this;
-        }
-
+        
         @Deprecated
         public WalkEventBuilder node(JsonNode node) {
             return instanceNode(node);
         }
-
-        public WalkEventBuilder rootNode(JsonNode rootNode) {
-            walkEvent.rootNode = rootNode;
-            return this;
-        }
-
-        public WalkEventBuilder instanceLocation(JsonNodePath instanceLocation) {
-            walkEvent.instanceLocation = instanceLocation;
-            return this;
-        }
-
+        
         @Deprecated
         public WalkEventBuilder currentJsonSchemaFactory(JsonSchemaFactory currentJsonSchemaFactory) {
             return this;

--- a/src/main/java/com/networknt/schema/walk/WalkEvent.java
+++ b/src/main/java/com/networknt/schema/walk/WalkEvent.java
@@ -17,8 +17,8 @@ public class WalkEvent {
     private ExecutionContext executionContext;
     private JsonSchema schema;
     private String keyword;
-    private JsonNode instanceNode;
     private JsonNode rootNode;
+    private JsonNode instanceNode;
     private JsonNodePath instanceLocation;
 
     /**
@@ -54,15 +54,6 @@ public class WalkEvent {
     }
 
     /**
-     * Gets the instance node.
-     * 
-     * @return the instance node
-     */
-    public JsonNode getInstanceNode() {
-        return instanceNode;
-    }
-
-    /**
      * Gets the root instance node.
      * <p>
      * This makes it possible to get the parent node, for instance by getting the
@@ -72,6 +63,15 @@ public class WalkEvent {
      */
     public JsonNode getRootNode() {
         return rootNode;
+    }
+
+    /**
+     * Gets the instance node.
+     * 
+     * @return the instance node
+     */
+    public JsonNode getInstanceNode() {
+        return instanceNode;
     }
 
     /**

--- a/src/main/java/com/networknt/schema/walk/WalkEvent.java
+++ b/src/main/java/com/networknt/schema/walk/WalkEvent.java
@@ -18,12 +18,12 @@ public class WalkEvent {
     private SchemaLocation schemaLocation;
     private JsonNodePath evaluationPath;
     private JsonNode schemaNode;
+    private JsonSchema schema;
     private JsonSchema parentSchema;
     private String keyword;
-    private JsonNode node;
+    private JsonNode instanceNode;
     private JsonNode rootNode;
     private JsonNodePath instanceLocation;
-    private JsonSchemaFactory currentJsonSchemaFactory;
     private ValidationContext validationContext;
 
     public ExecutionContext getExecutionContext() {
@@ -42,6 +42,15 @@ public class WalkEvent {
         return schemaNode;
     }
 
+    /**
+     * Gets the JsonSchema indicated by the schema node.
+     *
+     * @return the schema
+     */
+    public JsonSchema getSchema() {
+        return schema;
+    }
+
     public JsonSchema getParentSchema() {
         return parentSchema;
     }
@@ -50,8 +59,13 @@ public class WalkEvent {
         return keyword;
     }
 
+    public JsonNode getInstanceNode() {
+        return instanceNode;
+    }
+
+    @Deprecated
     public JsonNode getNode() {
-        return node;
+        return getInstanceNode();
     }
 
     public JsonNode getRootNode() {
@@ -62,21 +76,27 @@ public class WalkEvent {
         return instanceLocation;
     }
 
-    public JsonSchema getRefSchema(SchemaLocation schemaUri) {
-        return currentJsonSchemaFactory.getSchema(schemaUri, validationContext.getConfig());
+    public JsonSchema getRefSchema(SchemaLocation schemaLocation) {
+        return this.validationContext.getJsonSchemaFactory().getSchema(schemaLocation, validationContext.getConfig());
     }
 
-    public JsonSchema getRefSchema(SchemaLocation schemaUri, SchemaValidatorsConfig schemaValidatorsConfig) {
+    public JsonSchema getRefSchema(SchemaLocation schemaLocation, SchemaValidatorsConfig schemaValidatorsConfig) {
         if (schemaValidatorsConfig != null) {
-            return currentJsonSchemaFactory.getSchema(schemaUri, schemaValidatorsConfig);
+            return this.validationContext.getJsonSchemaFactory().getSchema(schemaLocation, schemaValidatorsConfig);
         } else {
-            return getRefSchema(schemaUri);
+            return getRefSchema(schemaLocation);
         }
     }
 
-    public JsonSchemaFactory getCurrentJsonSchemaFactory() {
-        return currentJsonSchemaFactory;
+    public JsonSchemaFactory getJsonSchemaFactory() {
+        return this.validationContext.getJsonSchemaFactory();
     }
+
+    @Deprecated
+    public JsonSchemaFactory getCurrentJsonSchemaFactory() {
+        return getJsonSchemaFactory();
+    }
+
 
     @Override
     public String toString() {
@@ -112,6 +132,11 @@ public class WalkEvent {
             return this;
         }
 
+        public WalkEventBuilder schema(JsonSchema schema) {
+            walkEvent.schema = schema;
+            return this;
+        }
+
         public WalkEventBuilder parentSchema(JsonSchema parentSchema) {
             walkEvent.parentSchema = parentSchema;
             return this;
@@ -122,9 +147,14 @@ public class WalkEvent {
             return this;
         }
 
-        public WalkEventBuilder node(JsonNode node) {
-            walkEvent.node = node;
+        public WalkEventBuilder instanceNode(JsonNode node) {
+            walkEvent.instanceNode = node;
             return this;
+        }
+
+        @Deprecated
+        public WalkEventBuilder node(JsonNode node) {
+            return instanceNode(node);
         }
 
         public WalkEventBuilder rootNode(JsonNode rootNode) {
@@ -137,8 +167,8 @@ public class WalkEvent {
             return this;
         }
 
+        @Deprecated
         public WalkEventBuilder currentJsonSchemaFactory(JsonSchemaFactory currentJsonSchemaFactory) {
-            walkEvent.currentJsonSchemaFactory = currentJsonSchemaFactory;
             return this;
         }
 

--- a/src/main/java/com/networknt/schema/walk/WalkEvent.java
+++ b/src/main/java/com/networknt/schema/walk/WalkEvent.java
@@ -5,6 +5,7 @@ import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.JsonNodePath;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.JsonValidator;
 import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.SchemaValidatorsConfig;
 import com.networknt.schema.ValidationContext;
@@ -20,6 +21,7 @@ public class WalkEvent {
     private JsonNode rootNode;
     private JsonNode instanceNode;
     private JsonNodePath instanceLocation;
+    private JsonValidator validator;
 
     /**
      * Gets the execution context.
@@ -81,6 +83,16 @@ public class WalkEvent {
      */
     public JsonNodePath getInstanceLocation() {
         return instanceLocation;
+    }
+
+    /**
+     * Gets the validator that corresponds with the keyword.
+     * 
+     * @return the validator
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends JsonValidator> T getValidator() {
+        return (T) this.validator;
     }
 
     @Deprecated
@@ -168,6 +180,11 @@ public class WalkEvent {
 
         public WalkEventBuilder instanceLocation(JsonNodePath instanceLocation) {
             walkEvent.instanceLocation = instanceLocation;
+            return this;
+        }
+
+        public WalkEventBuilder validator(JsonValidator validator) {
+            walkEvent.validator = validator;
             return this;
         }
 

--- a/src/main/java/com/networknt/schema/walk/WalkEvent.java
+++ b/src/main/java/com/networknt/schema/walk/WalkEvent.java
@@ -4,11 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.JsonNodePath;
 import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.JsonValidator;
-import com.networknt.schema.SchemaLocation;
-import com.networknt.schema.SchemaValidatorsConfig;
-import com.networknt.schema.ValidationContext;
 
 /**
  * Encapsulation of Walk data that is passed into the {@link JsonSchemaWalkListener}.
@@ -95,50 +91,6 @@ public class WalkEvent {
         return (T) this.validator;
     }
 
-    @Deprecated
-    public JsonNode getNode() {
-        return getInstanceNode();
-    }
-    
-    @Deprecated
-    public JsonSchema getParentSchema() {
-        return getSchema().getParentSchema();
-    }
-
-    @Deprecated
-    public SchemaLocation getSchemaLocation() {
-        return getSchema().getSchemaLocation();
-    }
-
-    @Deprecated
-    public JsonNodePath getEvaluationPath() {
-        return getSchema().getEvaluationPath();
-    }
-
-    @Deprecated
-    public JsonNode getSchemaNode() {
-        return getSchema().getSchemaNode();
-    }
-
-    @Deprecated
-    public JsonSchema getRefSchema(SchemaLocation schemaLocation) {
-        return getCurrentJsonSchemaFactory().getSchema(schemaLocation, getSchema().getValidationContext().getConfig());
-    }
-
-    @Deprecated
-    public JsonSchema getRefSchema(SchemaLocation schemaLocation, SchemaValidatorsConfig schemaValidatorsConfig) {
-        if (schemaValidatorsConfig != null) {
-            return getCurrentJsonSchemaFactory().getSchema(schemaLocation, schemaValidatorsConfig);
-        } else {
-            return getRefSchema(schemaLocation);
-        }
-    }
-
-    @Deprecated
-    public JsonSchemaFactory getCurrentJsonSchemaFactory() {
-        return getSchema().getValidationContext().getJsonSchemaFactory();
-    }
-
     @Override
     public String toString() {
         return "WalkEvent [evaluationPath=" + getSchema().getEvaluationPath() + ", schemaLocation="
@@ -188,41 +140,6 @@ public class WalkEvent {
             return this;
         }
 
-        @Deprecated
-        public WalkEventBuilder evaluationPath(JsonNodePath evaluationPath) {
-            return this;
-        }
-
-        @Deprecated
-        public WalkEventBuilder schemaLocation(SchemaLocation schemaLocation) {
-            return this;
-        }
-
-        @Deprecated
-        public WalkEventBuilder schemaNode(JsonNode schemaNode) {
-            return this;
-        }
-
-        @Deprecated
-        public WalkEventBuilder parentSchema(JsonSchema parentSchema) {
-            return this;
-        }
-        
-        @Deprecated
-        public WalkEventBuilder node(JsonNode node) {
-            return instanceNode(node);
-        }
-        
-        @Deprecated
-        public WalkEventBuilder currentJsonSchemaFactory(JsonSchemaFactory currentJsonSchemaFactory) {
-            return this;
-        }
-
-        @Deprecated
-        public WalkEventBuilder validationContext(ValidationContext validationContext) {
-            return this;
-        }
-
         public WalkEvent build() {
             return walkEvent;
         }
@@ -232,5 +149,4 @@ public class WalkEvent {
     public static WalkEventBuilder builder() {
         return new WalkEventBuilder();
     }
-
 }

--- a/src/main/java/com/networknt/schema/walk/WalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/WalkListenerRunner.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.JsonNodePath;
 import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonValidator;
 import com.networknt.schema.ValidationMessage;
 
 import java.util.Set;
@@ -11,9 +12,9 @@ import java.util.Set;
 public interface WalkListenerRunner {
 
     public boolean runPreWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
-            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema);
+            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema, JsonValidator validator);
 
     public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
-            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema, Set<ValidationMessage> validationMessages);
+            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema, JsonValidator validator, Set<ValidationMessage> validationMessages);
 
 }

--- a/src/main/java/com/networknt/schema/walk/WalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/WalkListenerRunner.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.JsonNodePath;
 import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.ValidationContext;
 import com.networknt.schema.ValidationMessage;
@@ -13,14 +12,13 @@ import java.util.Set;
 
 public interface WalkListenerRunner {
 
-    public boolean runPreWalkListeners(ExecutionContext executionContext, String keyword, JsonNode node,
+    public boolean runPreWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
             JsonNode rootNode, JsonNodePath instanceLocation, JsonNodePath evaluationPath, SchemaLocation schemaLocation,
-            JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext,
-            JsonSchemaFactory jsonSchemaFactory);
+            JsonNode schemaNode, JsonSchema schema, JsonSchema parentSchema, ValidationContext validationContext);
 
-    public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode node,
+    public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
             JsonNode rootNode, JsonNodePath instanceLocation, JsonNodePath evaluationPath, SchemaLocation schemaLocation,
-            JsonNode schemaNode, JsonSchema parentSchema, ValidationContext validationContext,
-            JsonSchemaFactory jsonSchemaFactory, Set<ValidationMessage> validationMessages);
+            JsonNode schemaNode, JsonSchema schema, JsonSchema parentSchema,
+            ValidationContext validationContext, Set<ValidationMessage> validationMessages);
 
 }

--- a/src/main/java/com/networknt/schema/walk/WalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/WalkListenerRunner.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.JsonNodePath;
 import com.networknt.schema.JsonSchema;
-import com.networknt.schema.SchemaLocation;
-import com.networknt.schema.ValidationContext;
 import com.networknt.schema.ValidationMessage;
 
 import java.util.Set;
@@ -13,12 +11,9 @@ import java.util.Set;
 public interface WalkListenerRunner {
 
     public boolean runPreWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
-            JsonNode rootNode, JsonNodePath instanceLocation, JsonNodePath evaluationPath, SchemaLocation schemaLocation,
-            JsonNode schemaNode, JsonSchema schema, JsonSchema parentSchema, ValidationContext validationContext);
+            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema);
 
     public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
-            JsonNode rootNode, JsonNodePath instanceLocation, JsonNodePath evaluationPath, SchemaLocation schemaLocation,
-            JsonNode schemaNode, JsonSchema schema, JsonSchema parentSchema,
-            ValidationContext validationContext, Set<ValidationMessage> validationMessages);
+            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema, Set<ValidationMessage> validationMessages);
 
 }

--- a/src/test/java/com/networknt/schema/Issue451Test.java
+++ b/src/test/java/com/networknt/schema/Issue451Test.java
@@ -70,7 +70,7 @@ public class Issue451Test {
     private static class CountingWalker implements JsonSchemaWalkListener {
         @Override
         public WalkFlow onWalkStart(WalkEvent walkEvent) {
-            SchemaLocation path = walkEvent.getSchemaLocation();
+            SchemaLocation path = walkEvent.getSchema().getSchemaLocation();
             collector(walkEvent.getExecutionContext()).compute(path.toString(), (k, v) -> v == null ? 1 : v + 1);
             return WalkFlow.CONTINUE;
         }

--- a/src/test/java/com/networknt/schema/Issue467Test.java
+++ b/src/test/java/com/networknt/schema/Issue467Test.java
@@ -48,7 +48,7 @@ public class Issue467Test {
         config.addKeywordWalkListener(ValidatorTypeCode.PROPERTIES.getValue(), new JsonSchemaWalkListener() {
             @Override
             public WalkFlow onWalkStart(WalkEvent walkEvent) {
-                properties.add(walkEvent.getEvaluationPath());
+                properties.add(walkEvent.getSchema().getEvaluationPath().append(walkEvent.getKeyword()));
                 return WalkFlow.CONTINUE;
             }
 
@@ -72,7 +72,7 @@ public class Issue467Test {
         config.addPropertyWalkListener(new JsonSchemaWalkListener() {
             @Override
             public WalkFlow onWalkStart(WalkEvent walkEvent) {
-                properties.add(walkEvent.getEvaluationPath());
+                properties.add(walkEvent.getSchema().getEvaluationPath());
                 return WalkFlow.CONTINUE;
             }
 
@@ -84,7 +84,7 @@ public class Issue467Test {
         JsonNode data = mapper.readTree(Issue467Test.class.getResource("/data/issue467.json"));
         ValidationResult result = schema.walk(data, true);
         assertEquals(
-                new HashSet<>(Arrays.asList("$.properties.tags", "$.properties.tags.items[0].properties.category")),
+                new HashSet<>(Arrays.asList("$.properties.tags", "$.properties.tags.items[0].properties.category", "$.properties.tags.items[0].properties.value")),
                 properties.stream().map(Object::toString).collect(Collectors.toSet()));
         assertEquals(1, result.getValidationMessages().size());
     }

--- a/src/test/java/com/networknt/schema/Issue724Test.java
+++ b/src/test/java/com/networknt/schema/Issue724Test.java
@@ -65,7 +65,7 @@ class Issue724Test {
         @Override
         public WalkFlow onWalkStart(WalkEvent walkEvent) {
             boolean isString =
-                Optional.of(walkEvent.getSchemaNode())
+                Optional.of(walkEvent.getSchema().getSchemaNode())
                     .map(jsonNode -> jsonNode.get("type"))
                     .map(JsonNode::asText)
                     .map(type -> type.equals("string"))

--- a/src/test/java/com/networknt/schema/Issue724Test.java
+++ b/src/test/java/com/networknt/schema/Issue724Test.java
@@ -72,7 +72,7 @@ class Issue724Test {
                     .orElse(false);
 
             if (isString) {
-                this.strings.add(walkEvent.getNode().asText());
+                this.strings.add(walkEvent.getInstanceNode().asText());
             }
 
             return WalkFlow.CONTINUE;

--- a/src/test/java/com/networknt/schema/JsonWalkTest.java
+++ b/src/test/java/com/networknt/schema/JsonWalkTest.java
@@ -170,7 +170,7 @@ public class JsonWalkTest {
             if (keyWordName.equals(CUSTOM_KEYWORD) && schemaNode.get(CUSTOM_KEYWORD).isArray()) {
                 ObjectNode objectNode = (ObjectNode) collectorContext.get(SAMPLE_WALK_COLLECTOR_TYPE);
                 objectNode.put(keywordWalkEvent.getSchemaNode().get("title").textValue().toUpperCase(),
-                        keywordWalkEvent.getNode().textValue());
+                        keywordWalkEvent.getInstanceNode().textValue());
             }
             return WalkFlow.CONTINUE;
         }
@@ -192,7 +192,7 @@ public class JsonWalkTest {
             }
             ObjectNode objectNode = (ObjectNode) collectorContext.get(SAMPLE_WALK_COLLECTOR_TYPE);
             objectNode.set(keywordWalkEvent.getSchemaNode().get("title").textValue().toLowerCase(),
-                    keywordWalkEvent.getNode());
+                    keywordWalkEvent.getInstanceNode());
             return WalkFlow.SKIP;
         }
 

--- a/src/test/java/com/networknt/schema/JsonWalkTest.java
+++ b/src/test/java/com/networknt/schema/JsonWalkTest.java
@@ -162,14 +162,14 @@ public class JsonWalkTest {
         public WalkFlow onWalkStart(WalkEvent keywordWalkEvent) {
             ObjectMapper mapper = new ObjectMapper();
             String keyWordName = keywordWalkEvent.getKeyword();
-            JsonNode schemaNode = keywordWalkEvent.getSchemaNode();
+            JsonNode schemaNode = keywordWalkEvent.getSchema().getSchemaNode();
             CollectorContext collectorContext = keywordWalkEvent.getExecutionContext().getCollectorContext();
             if (collectorContext.get(SAMPLE_WALK_COLLECTOR_TYPE) == null) {
                 collectorContext.add(SAMPLE_WALK_COLLECTOR_TYPE, mapper.createObjectNode());
             }
             if (keyWordName.equals(CUSTOM_KEYWORD) && schemaNode.get(CUSTOM_KEYWORD).isArray()) {
                 ObjectNode objectNode = (ObjectNode) collectorContext.get(SAMPLE_WALK_COLLECTOR_TYPE);
-                objectNode.put(keywordWalkEvent.getSchemaNode().get("title").textValue().toUpperCase(),
+                objectNode.put(keywordWalkEvent.getSchema().getSchemaNode().get("title").textValue().toUpperCase(),
                         keywordWalkEvent.getInstanceNode().textValue());
             }
             return WalkFlow.CONTINUE;
@@ -191,7 +191,7 @@ public class JsonWalkTest {
                 collectorContext.add(SAMPLE_WALK_COLLECTOR_TYPE, mapper.createObjectNode());
             }
             ObjectNode objectNode = (ObjectNode) collectorContext.get(SAMPLE_WALK_COLLECTOR_TYPE);
-            objectNode.set(keywordWalkEvent.getSchemaNode().get("title").textValue().toLowerCase(),
+            objectNode.set(keywordWalkEvent.getSchema().getSchemaNode().get("title").textValue().toLowerCase(),
                     keywordWalkEvent.getInstanceNode());
             return WalkFlow.SKIP;
         }
@@ -206,7 +206,7 @@ public class JsonWalkTest {
 
         @Override
         public WalkFlow onWalkStart(WalkEvent keywordWalkEvent) {
-            JsonNode schemaNode = keywordWalkEvent.getSchemaNode();
+            JsonNode schemaNode = keywordWalkEvent.getSchema().getSchemaNode();
             if (schemaNode.get("title").textValue().equals("Property3")) {
                 return WalkFlow.SKIP;
             }

--- a/src/test/java/com/networknt/schema/walk/JsonSchemaWalkListenerTest.java
+++ b/src/test/java/com/networknt/schema/walk/JsonSchemaWalkListenerTest.java
@@ -20,16 +20,19 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.networknt.schema.ApplyDefaultsStrategy;
 import com.networknt.schema.InputFormat;
@@ -96,7 +99,7 @@ class JsonSchemaWalkListenerTest {
                 propertyKeywords.add(walkEvent);
                 return WalkFlow.CONTINUE;
             }
-            
+
             @Override
             public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
             }
@@ -166,7 +169,7 @@ class JsonSchemaWalkListenerTest {
         SchemaValidatorsConfig config = new SchemaValidatorsConfig();
         config.setPathType(PathType.JSON_POINTER);
         config.addPropertyWalkListener(new JsonSchemaWalkListener() {
-            
+
             @Override
             public WalkFlow onWalkStart(WalkEvent walkEvent) {
                 @SuppressWarnings("unchecked")
@@ -200,7 +203,7 @@ class JsonSchemaWalkListenerTest {
         List<WalkEvent> properties = (List<WalkEvent>) result.getExecutionContext().getCollectorContext().get("properties");
         assertEquals(5, properties.size());
         assertEquals("properties", properties.get(0).getValidator().getKeyword());
-        
+
         assertEquals("/tags", properties.get(0).getInstanceLocation().toString());
         assertEquals("/properties/tags", properties.get(0).getSchema().getEvaluationPath().toString());
 
@@ -248,11 +251,11 @@ class JsonSchemaWalkListenerTest {
                 + "    }\r\n"
                 + "  }\r\n"
                 + "}";
-        
+
         SchemaValidatorsConfig config = new SchemaValidatorsConfig();
         config.setPathType(PathType.JSON_POINTER);
         config.addItemWalkListener(new JsonSchemaWalkListener() {
-            
+
             @Override
             public WalkFlow onWalkStart(WalkEvent walkEvent) {
                 @SuppressWarnings("unchecked")
@@ -287,10 +290,10 @@ class JsonSchemaWalkListenerTest {
         assertEquals(2, items.size());
         assertEquals("items", items.get(0).getValidator().getKeyword());
         assertTrue(items.get(0).getValidator() instanceof ItemsValidator);
-        
+
         assertEquals("/tags/0", items.get(0).getInstanceLocation().toString());
         assertEquals("/properties/tags/items", items.get(0).getSchema().getEvaluationPath().toString());
-        
+
         assertEquals("/tags/1", items.get(1).getInstanceLocation().toString());
         assertEquals("/properties/tags/items", items.get(1).getSchema().getEvaluationPath().toString());
     }
@@ -322,11 +325,11 @@ class JsonSchemaWalkListenerTest {
                 + "    }\r\n"
                 + "  }\r\n"
                 + "}";
-        
+
         SchemaValidatorsConfig config = new SchemaValidatorsConfig();
         config.setPathType(PathType.JSON_POINTER);
         config.addItemWalkListener(new JsonSchemaWalkListener() {
-            
+
             @Override
             public WalkFlow onWalkStart(WalkEvent walkEvent) {
                 @SuppressWarnings("unchecked")
@@ -361,10 +364,10 @@ class JsonSchemaWalkListenerTest {
         assertEquals(2, items.size());
         assertEquals("items", items.get(0).getValidator().getKeyword());
         assertTrue(items.get(0).getValidator() instanceof ItemsValidator202012);
-        
+
         assertEquals("/tags/0", items.get(0).getInstanceLocation().toString());
         assertEquals("/properties/tags/items", items.get(0).getSchema().getEvaluationPath().toString());
-        
+
         assertEquals("/tags/1", items.get(1).getInstanceLocation().toString());
         assertEquals("/properties/tags/items", items.get(1).getSchema().getEvaluationPath().toString());
     }
@@ -548,7 +551,7 @@ class JsonSchemaWalkListenerTest {
                 + "    }\r\n"
                 + "  }\r\n"
                 + "}";
-        
+
         SchemaValidatorsConfig config = new SchemaValidatorsConfig();
         config.setApplyDefaultsStrategy(new ApplyDefaultsStrategy(true, true, true));
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
@@ -580,10 +583,10 @@ class JsonSchemaWalkListenerTest {
                 + "    }\r\n"
                 + "  }\r\n"
                 + "}";
-        
+
         SchemaValidatorsConfig config = new SchemaValidatorsConfig();
         config.addPropertyWalkListener(new JsonSchemaWalkListener() {
-            
+
             @Override
             public WalkFlow onWalkStart(WalkEvent walkEvent) {
                 if (walkEvent.getInstanceNode() == null || walkEvent.getInstanceNode().isMissingNode()
@@ -637,10 +640,10 @@ class JsonSchemaWalkListenerTest {
                 + "    }\r\n"
                 + "  }\r\n"
                 + "}";
-        
+
         SchemaValidatorsConfig config = new SchemaValidatorsConfig();
         config.addPropertyWalkListener(new JsonSchemaWalkListener() {
-            
+
             @Override
             public WalkFlow onWalkStart(WalkEvent walkEvent) {
                 if (walkEvent.getInstanceNode() == null || walkEvent.getInstanceNode().isMissingNode()
@@ -700,7 +703,7 @@ class JsonSchemaWalkListenerTest {
         Map<String, JsonNode> missingSchemaNode = new LinkedHashMap<>();
         SchemaValidatorsConfig config = new SchemaValidatorsConfig();
         config.addKeywordWalkListener(ValidatorTypeCode.PROPERTIES.getValue(), new JsonSchemaWalkListener() {
-            
+
             @Override
             public WalkFlow onWalkStart(WalkEvent walkEvent) {
                 JsonNode requiredNode = walkEvent.getSchema().getSchemaNode().get("required");
@@ -727,7 +730,7 @@ class JsonSchemaWalkListenerTest {
                 }
                 return WalkFlow.CONTINUE;
             }
-            
+
             @Override
             public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
             }
@@ -739,5 +742,73 @@ class JsonSchemaWalkListenerTest {
         assertFalse(result.getValidationMessages().isEmpty());
         assertEquals("{\"type\":\"integer\"}", missingSchemaNode.get("s").toString());
         assertEquals("{\"type\":\"string\"}", missingSchemaNode.get("ref").toString());
+    }
+
+    @Test
+    void generateDataWithWalker() throws JsonMappingException, JsonProcessingException {
+        Map<String, Supplier<String>> generators = new HashMap<>();
+        generators.put("name.findName", () -> "John Doe");
+        generators.put("internet.email", () -> "john.doe@gmail.com");
+
+        String schemaData = "{\r\n"
+                + "  \"type\": \"object\",\r\n"
+                + "  \"properties\": {\r\n"
+                + "    \"name\": {\r\n"
+                + "      \"$ref\": \"#/$defs/Name\"\r\n"
+                + "    },\r\n"
+                + "    \"email\": {\r\n"
+                + "      \"type\": \"string\",\r\n"
+                + "      \"faker\": \"internet.email\"\r\n"
+                + "    }\r\n"
+                + "  },\r\n"
+                + "  \"required\": [\r\n"
+                + "    \"name\",\r\n"
+                + "    \"email\"\r\n"
+                + "  ],\r\n"
+                + "  \"$defs\": {\r\n"
+                + "    \"Name\": {\r\n"
+                + "      \"type\": \"string\",\r\n"
+                + "      \"faker\": \"name.findName\"\r\n"
+                + "    }\r\n"
+                + "  }\r\n"
+                + "}";
+
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.addPropertyWalkListener(new JsonSchemaWalkListener() {
+            @Override
+            public WalkFlow onWalkStart(WalkEvent walkEvent) {
+                if (walkEvent.getInstanceNode() == null || walkEvent.getInstanceNode().isMissingNode()
+                        || walkEvent.getInstanceNode().isNull()) {
+                    JsonSchema schema = walkEvent.getSchema();
+                    JsonSchemaRef schemaRef = null;
+                    do {
+                        schemaRef = JsonSchemaRefs.from(schema);
+                        if (schemaRef != null) {
+                            schema = schemaRef.getSchema();
+                        }
+                    } while (schemaRef != null);
+                    JsonNode fakerNode = schema.getSchemaNode().get("faker");
+                    if (fakerNode != null) {
+                        String faker = fakerNode.asText();
+                        String fakeData = generators.get(faker).get();
+                        JsonNode fakeDataNode = JsonNodeFactory.instance.textNode(fakeData);
+                        ObjectNode parentNode = (ObjectNode) JsonNodes.get(walkEvent.getRootNode(),
+                                walkEvent.getInstanceLocation().getParent());
+                        parentNode.set(walkEvent.getInstanceLocation().getName(-1), fakeDataNode);
+                    }
+                }
+                return WalkFlow.CONTINUE;
+            }
+
+            @Override
+            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+            }
+        });
+
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        JsonNode inputNode = JsonMapperFactory.getInstance().readTree("{}");
+        ValidationResult result = schema.walk(inputNode, true);
+        assertEquals("{\"name\":\"John Doe\",\"email\":\"john.doe@gmail.com\"}", inputNode.toString());
+        assertTrue(result.getValidationMessages().isEmpty());
     }
 }

--- a/src/test/java/com/networknt/schema/walk/JsonSchemaWalkListenerTest.java
+++ b/src/test/java/com/networknt/schema/walk/JsonSchemaWalkListenerTest.java
@@ -16,10 +16,13 @@
 package com.networknt.schema.walk;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -31,12 +34,15 @@ import com.networknt.schema.ApplyDefaultsStrategy;
 import com.networknt.schema.InputFormat;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.JsonSchemaRef;
 import com.networknt.schema.PathType;
+import com.networknt.schema.PropertiesValidator;
 import com.networknt.schema.SchemaId;
 import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.SchemaValidatorsConfig;
 import com.networknt.schema.SpecVersion.VersionFlag;
 import com.networknt.schema.serialization.JsonMapperFactory;
+import com.networknt.schema.utils.JsonSchemaRefs;
 import com.networknt.schema.ValidationMessage;
 import com.networknt.schema.ValidationResult;
 import com.networknt.schema.ValidatorTypeCode;
@@ -106,12 +112,15 @@ class JsonSchemaWalkListenerTest {
         assertTrue(result.getValidationMessages().isEmpty());
         assertEquals(3, propertyKeywords.size());
         assertEquals("", propertyKeywords.get(0).getInstanceLocation().toString());
-        assertEquals("/properties", propertyKeywords.get(0).getEvaluationPath().toString());
+        assertEquals("/properties", propertyKeywords.get(0).getSchema().getEvaluationPath()
+                .append(propertyKeywords.get(0).getKeyword()).toString());
         assertEquals("/tags/0", propertyKeywords.get(1).getInstanceLocation().toString());
         assertEquals("image", propertyKeywords.get(1).getInstanceNode().get("name").asText());
-        assertEquals("/properties/tags/items/$ref/properties", propertyKeywords.get(1).getEvaluationPath().toString());
+        assertEquals("/properties/tags/items/$ref/properties", propertyKeywords.get(1).getSchema().getEvaluationPath()
+                .append(propertyKeywords.get(1).getKeyword()).toString());
         assertEquals("/tags/1", propertyKeywords.get(2).getInstanceLocation().toString());
-        assertEquals("/properties/tags/items/$ref/properties", propertyKeywords.get(2).getEvaluationPath().toString());
+        assertEquals("/properties/tags/items/$ref/properties", propertyKeywords.get(2).getSchema().getEvaluationPath()
+                .append(propertyKeywords.get(2).getKeyword()).toString());
         assertEquals("link", propertyKeywords.get(2).getInstanceNode().get("name").asText());
     }
     
@@ -175,23 +184,23 @@ class JsonSchemaWalkListenerTest {
         assertTrue(result.getValidationMessages().isEmpty());
         assertEquals(5, properties.size());
         assertEquals("/tags", properties.get(0).getInstanceLocation().toString());
-        assertEquals("/properties/tags", properties.get(0).getEvaluationPath().toString());
+        assertEquals("/properties/tags", properties.get(0).getSchema().getEvaluationPath().toString());
 
         assertEquals("/tags/0/name", properties.get(1).getInstanceLocation().toString());
         assertEquals("image", properties.get(1).getInstanceNode().asText());
-        assertEquals("/properties/tags/items/$ref/properties/name", properties.get(1).getEvaluationPath().toString());
+        assertEquals("/properties/tags/items/$ref/properties/name", properties.get(1).getSchema().getEvaluationPath().toString());
 
         assertEquals("/tags/0/description", properties.get(2).getInstanceLocation().toString());
         assertEquals("An image", properties.get(2).getInstanceNode().asText());
-        assertEquals("/properties/tags/items/$ref/properties/description", properties.get(2).getEvaluationPath().toString());
+        assertEquals("/properties/tags/items/$ref/properties/description", properties.get(2).getSchema().getEvaluationPath().toString());
 
         assertEquals("/tags/1/name", properties.get(3).getInstanceLocation().toString());
         assertEquals("link", properties.get(3).getInstanceNode().asText());
-        assertEquals("/properties/tags/items/$ref/properties/name", properties.get(3).getEvaluationPath().toString());
+        assertEquals("/properties/tags/items/$ref/properties/name", properties.get(3).getSchema().getEvaluationPath().toString());
 
         assertEquals("/tags/1/description", properties.get(4).getInstanceLocation().toString());
         assertEquals("A link", properties.get(4).getInstanceNode().asText());
-        assertEquals("/properties/tags/items/$ref/properties/description", properties.get(4).getEvaluationPath().toString());
+        assertEquals("/properties/tags/items/$ref/properties/description", properties.get(4).getSchema().getEvaluationPath().toString());
     }
 
     @Test
@@ -234,116 +243,116 @@ class JsonSchemaWalkListenerTest {
         assertEquals(28, propertyKeywords.size());
         
         assertEquals("", propertyKeywords.get(0).getInstanceLocation().toString());
-        assertEquals("/properties", propertyKeywords.get(0).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/schema#/properties", propertyKeywords.get(0).getSchemaLocation().toString());
+        assertEquals("/properties", propertyKeywords.get(0).getSchema().getEvaluationPath().append(propertyKeywords.get(0).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/schema#/properties", propertyKeywords.get(0).getSchema().getSchemaLocation().append(propertyKeywords.get(0).getKeyword()).toString());
 
         assertEquals("", propertyKeywords.get(1).getInstanceLocation().toString());
-        assertEquals("/allOf/0/$ref/properties", propertyKeywords.get(1).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/core#/properties", propertyKeywords.get(1).getSchemaLocation().toString());
+        assertEquals("/allOf/0/$ref/properties", propertyKeywords.get(1).getSchema().getEvaluationPath().append(propertyKeywords.get(1).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/core#/properties", propertyKeywords.get(1).getSchema().getSchemaLocation().append(propertyKeywords.get(1).getKeyword()).toString());
 
         assertEquals("", propertyKeywords.get(2).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties", propertyKeywords.get(2).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/applicator#/properties", propertyKeywords.get(2).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties", propertyKeywords.get(2).getSchema().getEvaluationPath().append(propertyKeywords.get(2).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/applicator#/properties", propertyKeywords.get(2).getSchema().getSchemaLocation().append(propertyKeywords.get(2).getKeyword()).toString());
 
         assertEquals("/properties/kebab-case", propertyKeywords.get(3).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/properties", propertyKeywords.get(3).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/schema#/properties", propertyKeywords.get(3).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/properties", propertyKeywords.get(3).getSchema().getEvaluationPath().append(propertyKeywords.get(3).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/schema#/properties", propertyKeywords.get(3).getSchema().getSchemaLocation().append(propertyKeywords.get(3).getKeyword()).toString());
 
         assertEquals("/properties/kebab-case", propertyKeywords.get(4).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/0/$ref/properties", propertyKeywords.get(4).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/core#/properties", propertyKeywords.get(4).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/0/$ref/properties", propertyKeywords.get(4).getSchema().getEvaluationPath().append(propertyKeywords.get(4).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/core#/properties", propertyKeywords.get(4).getSchema().getSchemaLocation().append(propertyKeywords.get(4).getKeyword()).toString());
 
         assertEquals("/properties/kebab-case", propertyKeywords.get(5).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/1/$ref/properties", propertyKeywords.get(5).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/applicator#/properties", propertyKeywords.get(5).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/1/$ref/properties", propertyKeywords.get(5).getSchema().getEvaluationPath().append(propertyKeywords.get(5).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/applicator#/properties", propertyKeywords.get(5).getSchema().getSchemaLocation().append(propertyKeywords.get(5).getKeyword()).toString());
 
         assertEquals("/properties/kebab-case", propertyKeywords.get(6).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/2/$ref/properties", propertyKeywords.get(6).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/validation#/properties", propertyKeywords.get(6).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/2/$ref/properties", propertyKeywords.get(6).getSchema().getEvaluationPath().append(propertyKeywords.get(6).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/validation#/properties", propertyKeywords.get(6).getSchema().getSchemaLocation().append(propertyKeywords.get(6).getKeyword()).toString());
 
         assertEquals("/properties/kebab-case", propertyKeywords.get(7).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/3/$ref/properties", propertyKeywords.get(7).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/meta-data#/properties", propertyKeywords.get(7).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/3/$ref/properties", propertyKeywords.get(7).getSchema().getEvaluationPath().append(propertyKeywords.get(7).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/meta-data#/properties", propertyKeywords.get(7).getSchema().getSchemaLocation().append(propertyKeywords.get(7).getKeyword()).toString());
 
         assertEquals("/properties/kebab-case", propertyKeywords.get(8).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/4/$ref/properties", propertyKeywords.get(8).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/format#/properties", propertyKeywords.get(8).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/4/$ref/properties", propertyKeywords.get(8).getSchema().getEvaluationPath().append(propertyKeywords.get(8).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/format#/properties", propertyKeywords.get(8).getSchema().getSchemaLocation().append(propertyKeywords.get(8).getKeyword()).toString());
 
         assertEquals("/properties/kebab-case", propertyKeywords.get(9).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/5/$ref/properties", propertyKeywords.get(9).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/content#/properties", propertyKeywords.get(9).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/5/$ref/properties", propertyKeywords.get(9).getSchema().getEvaluationPath().append(propertyKeywords.get(9).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/content#/properties", propertyKeywords.get(9).getSchema().getSchemaLocation().append(propertyKeywords.get(9).getKeyword()).toString());
 
         assertEquals("/properties/snake_case", propertyKeywords.get(10).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/properties", propertyKeywords.get(10).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/schema#/properties", propertyKeywords.get(10).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/properties", propertyKeywords.get(10).getSchema().getEvaluationPath().append(propertyKeywords.get(10).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/schema#/properties", propertyKeywords.get(10).getSchema().getSchemaLocation().append(propertyKeywords.get(10).getKeyword()).toString());
 
         assertEquals("/properties/snake_case", propertyKeywords.get(11).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/0/$ref/properties", propertyKeywords.get(11).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/core#/properties", propertyKeywords.get(11).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/0/$ref/properties", propertyKeywords.get(11).getSchema().getEvaluationPath().append(propertyKeywords.get(11).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/core#/properties", propertyKeywords.get(11).getSchema().getSchemaLocation().append(propertyKeywords.get(11).getKeyword()).toString());
 
         assertEquals("/properties/snake_case", propertyKeywords.get(12).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/1/$ref/properties", propertyKeywords.get(12).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/applicator#/properties", propertyKeywords.get(12).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/1/$ref/properties", propertyKeywords.get(12).getSchema().getEvaluationPath().append(propertyKeywords.get(12).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/applicator#/properties", propertyKeywords.get(12).getSchema().getSchemaLocation().append(propertyKeywords.get(12).getKeyword()).toString());
 
         assertEquals("/properties/snake_case", propertyKeywords.get(13).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/2/$ref/properties", propertyKeywords.get(13).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/validation#/properties", propertyKeywords.get(13).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/2/$ref/properties", propertyKeywords.get(13).getSchema().getEvaluationPath().append(propertyKeywords.get(13).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/validation#/properties", propertyKeywords.get(13).getSchema().getSchemaLocation().append(propertyKeywords.get(13).getKeyword()).toString());
 
         assertEquals("/properties/snake_case", propertyKeywords.get(14).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/3/$ref/properties", propertyKeywords.get(14).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/meta-data#/properties", propertyKeywords.get(14).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/3/$ref/properties", propertyKeywords.get(14).getSchema().getEvaluationPath().append(propertyKeywords.get(14).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/meta-data#/properties", propertyKeywords.get(14).getSchema().getSchemaLocation().append(propertyKeywords.get(14).getKeyword()).toString());
 
         assertEquals("/properties/snake_case", propertyKeywords.get(15).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/4/$ref/properties", propertyKeywords.get(15).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/format#/properties", propertyKeywords.get(15).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/4/$ref/properties", propertyKeywords.get(15).getSchema().getEvaluationPath().append(propertyKeywords.get(15).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/format#/properties", propertyKeywords.get(15).getSchema().getSchemaLocation().append(propertyKeywords.get(15).getKeyword()).toString());
 
         assertEquals("/properties/snake_case", propertyKeywords.get(16).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/5/$ref/properties", propertyKeywords.get(16).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/content#/properties", propertyKeywords.get(16).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/5/$ref/properties", propertyKeywords.get(16).getSchema().getEvaluationPath().append(propertyKeywords.get(16).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/content#/properties", propertyKeywords.get(16).getSchema().getSchemaLocation().append(propertyKeywords.get(16).getKeyword()).toString());
 
         assertEquals("/properties/a", propertyKeywords.get(17).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/properties", propertyKeywords.get(17).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/schema#/properties", propertyKeywords.get(17).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/properties", propertyKeywords.get(17).getSchema().getEvaluationPath().append(propertyKeywords.get(17).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/schema#/properties", propertyKeywords.get(17).getSchema().getSchemaLocation().append(propertyKeywords.get(17).getKeyword()).toString());
 
         assertEquals("/properties/a", propertyKeywords.get(18).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/0/$ref/properties", propertyKeywords.get(18).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/core#/properties", propertyKeywords.get(18).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/0/$ref/properties", propertyKeywords.get(18).getSchema().getEvaluationPath().append(propertyKeywords.get(18).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/core#/properties", propertyKeywords.get(18).getSchema().getSchemaLocation().append(propertyKeywords.get(18).getKeyword()).toString());
 
         assertEquals("/properties/a", propertyKeywords.get(19).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/1/$ref/properties", propertyKeywords.get(19).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/applicator#/properties", propertyKeywords.get(19).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/1/$ref/properties", propertyKeywords.get(19).getSchema().getEvaluationPath().append(propertyKeywords.get(19).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/applicator#/properties", propertyKeywords.get(19).getSchema().getSchemaLocation().append(propertyKeywords.get(19).getKeyword()).toString());
 
         assertEquals("/properties/a", propertyKeywords.get(20).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/2/$ref/properties", propertyKeywords.get(20).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/validation#/properties", propertyKeywords.get(20).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/2/$ref/properties", propertyKeywords.get(20).getSchema().getEvaluationPath().append(propertyKeywords.get(20).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/validation#/properties", propertyKeywords.get(20).getSchema().getSchemaLocation().append(propertyKeywords.get(20).getKeyword()).toString());
 
         assertEquals("/properties/a", propertyKeywords.get(21).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/3/$ref/properties", propertyKeywords.get(21).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/meta-data#/properties", propertyKeywords.get(21).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/3/$ref/properties", propertyKeywords.get(21).getSchema().getEvaluationPath().append(propertyKeywords.get(21).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/meta-data#/properties", propertyKeywords.get(21).getSchema().getSchemaLocation().append(propertyKeywords.get(21).getKeyword()).toString());
 
         assertEquals("/properties/a", propertyKeywords.get(22).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/4/$ref/properties", propertyKeywords.get(22).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/format#/properties", propertyKeywords.get(22).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/4/$ref/properties", propertyKeywords.get(22).getSchema().getEvaluationPath().append(propertyKeywords.get(22).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/format#/properties", propertyKeywords.get(22).getSchema().getSchemaLocation().append(propertyKeywords.get(22).getKeyword()).toString());
 
         assertEquals("/properties/a", propertyKeywords.get(23).getInstanceLocation().toString());
-        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/5/$ref/properties", propertyKeywords.get(23).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/content#/properties", propertyKeywords.get(23).getSchemaLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/5/$ref/properties", propertyKeywords.get(23).getSchema().getEvaluationPath().append(propertyKeywords.get(23).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/content#/properties", propertyKeywords.get(23).getSchema().getSchemaLocation().append(propertyKeywords.get(23).getKeyword()).toString());
 
         assertEquals("", propertyKeywords.get(24).getInstanceLocation().toString());
-        assertEquals("/allOf/2/$ref/properties", propertyKeywords.get(24).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/validation#/properties", propertyKeywords.get(24).getSchemaLocation().toString());
+        assertEquals("/allOf/2/$ref/properties", propertyKeywords.get(24).getSchema().getEvaluationPath().append(propertyKeywords.get(24).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/validation#/properties", propertyKeywords.get(24).getSchema().getSchemaLocation().append(propertyKeywords.get(24).getKeyword()).toString());
 
         assertEquals("", propertyKeywords.get(25).getInstanceLocation().toString());
-        assertEquals("/allOf/3/$ref/properties", propertyKeywords.get(25).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/meta-data#/properties", propertyKeywords.get(25).getSchemaLocation().toString());
+        assertEquals("/allOf/3/$ref/properties", propertyKeywords.get(25).getSchema().getEvaluationPath().append(propertyKeywords.get(25).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/meta-data#/properties", propertyKeywords.get(25).getSchema().getSchemaLocation().append(propertyKeywords.get(25).getKeyword()).toString());
 
         assertEquals("", propertyKeywords.get(26).getInstanceLocation().toString());
-        assertEquals("/allOf/4/$ref/properties", propertyKeywords.get(26).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/format#/properties", propertyKeywords.get(26).getSchemaLocation().toString());
+        assertEquals("/allOf/4/$ref/properties", propertyKeywords.get(26).getSchema().getEvaluationPath().append(propertyKeywords.get(26).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/format#/properties", propertyKeywords.get(26).getSchema().getSchemaLocation().append(propertyKeywords.get(26).getKeyword()).toString());
 
         assertEquals("", propertyKeywords.get(27).getInstanceLocation().toString());
-        assertEquals("/allOf/5/$ref/properties", propertyKeywords.get(27).getEvaluationPath().toString());
-        assertEquals("https://json-schema.org/draft/2019-09/meta/content#/properties", propertyKeywords.get(27).getSchemaLocation().toString());
+        assertEquals("/allOf/5/$ref/properties", propertyKeywords.get(27).getSchema().getEvaluationPath().append(propertyKeywords.get(27).getKeyword()).toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/content#/properties", propertyKeywords.get(27).getSchema().getSchemaLocation().append(propertyKeywords.get(27).getKeyword()).toString());
     }
     
     @Test
@@ -386,7 +395,7 @@ class JsonSchemaWalkListenerTest {
                 + "  \"type\": \"object\",\r\n"
                 + "  \"properties\": {\r\n"
                 + "    \"s\": {\r\n"
-                + "      \"type\": \"string\"\r\n"
+                + "      \"type\": \"integer\"\r\n"
                 + "    },\r\n"
                 + "    \"ref\": { \"$ref\": \"#/$defs/r\" }\r\n"
                 + "  },\r\n"
@@ -398,13 +407,13 @@ class JsonSchemaWalkListenerTest {
                 + "    }\r\n"
                 + "  }\r\n"
                 + "}";
-        
+        Map<String, JsonNode> missingSchemaNode = new LinkedHashMap<>();
         SchemaValidatorsConfig config = new SchemaValidatorsConfig();
         config.addKeywordWalkListener(ValidatorTypeCode.PROPERTIES.getValue(), new JsonSchemaWalkListener() {
             
             @Override
             public WalkFlow onWalkStart(WalkEvent walkEvent) {
-                JsonNode requiredNode = walkEvent.getSchemaNode().get("required");
+                JsonNode requiredNode = walkEvent.getSchema().getSchemaNode().get("required");
                 List<String> requiredProperties = new ArrayList<>();
                 if (requiredNode != null) {
                     if (requiredNode.isArray()) {
@@ -417,7 +426,14 @@ class JsonSchemaWalkListenerTest {
                     JsonNode propertyNode = walkEvent.getInstanceNode().get(requiredProperty);
                     if (propertyNode == null) {
                         // Get the schema
-                        JsonSchema schema = walkEvent.getSchema();
+                        PropertiesValidator propertiesValidator = (PropertiesValidator) walkEvent.getSchema().getValidators().stream()
+                                .filter(v -> walkEvent.getKeyword().equals(v.getKeyword())).findFirst().get();
+                        JsonSchema propertySchema = propertiesValidator.getSchemas().get(requiredProperty);
+                        JsonSchemaRef schemaRef = JsonSchemaRefs.from(propertySchema);
+                        if (schemaRef != null) {
+                            propertySchema = schemaRef.getSchema();
+                        }
+                        missingSchemaNode.put(requiredProperty, propertySchema.getSchemaNode());
                     }
                 }
                 return WalkFlow.CONTINUE;
@@ -431,7 +447,8 @@ class JsonSchemaWalkListenerTest {
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
         JsonNode inputNode = JsonMapperFactory.getInstance().readTree("{}");
         ValidationResult result = schema.walk(inputNode, true);
-        assertEquals("{\"s\":\"S\",\"ref\":\"REF\"}", inputNode.toString());
-        assertTrue(result.getValidationMessages().isEmpty());
+        assertFalse(result.getValidationMessages().isEmpty());
+        assertEquals("{\"type\":\"integer\"}", missingSchemaNode.get("s").toString());
+        assertEquals("{\"type\":\"string\"}", missingSchemaNode.get("ref").toString());
     }
 }

--- a/src/test/java/com/networknt/schema/walk/JsonSchemaWalkListenerTest.java
+++ b/src/test/java/com/networknt/schema/walk/JsonSchemaWalkListenerTest.java
@@ -716,8 +716,7 @@ class JsonSchemaWalkListenerTest {
                     JsonNode propertyNode = walkEvent.getInstanceNode().get(requiredProperty);
                     if (propertyNode == null) {
                         // Get the schema
-                        PropertiesValidator propertiesValidator = (PropertiesValidator) walkEvent.getSchema().getValidators().stream()
-                                .filter(v -> walkEvent.getKeyword().equals(v.getKeyword())).findFirst().get();
+                        PropertiesValidator propertiesValidator = walkEvent.getValidator();
                         JsonSchema propertySchema = propertiesValidator.getSchemas().get(requiredProperty);
                         JsonSchemaRef schemaRef = JsonSchemaRefs.from(propertySchema);
                         if (schemaRef != null) {

--- a/src/test/java/com/networknt/schema/walk/JsonSchemaWalkListenerTest.java
+++ b/src/test/java/com/networknt/schema/walk/JsonSchemaWalkListenerTest.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.walk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.networknt.schema.ApplyDefaultsStrategy;
+import com.networknt.schema.InputFormat;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.PathType;
+import com.networknt.schema.SchemaId;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SchemaValidatorsConfig;
+import com.networknt.schema.SpecVersion.VersionFlag;
+import com.networknt.schema.serialization.JsonMapperFactory;
+import com.networknt.schema.ValidationMessage;
+import com.networknt.schema.ValidationResult;
+import com.networknt.schema.ValidatorTypeCode;
+
+/**
+ * JsonSchemaWalkListenerTest.
+ */
+class JsonSchemaWalkListenerTest {
+
+    @Test
+    void keywordListener() {
+        String schemaData = "{\r\n"
+                + "  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\r\n"
+                + "  \"type\": \"object\",\r\n"
+                + "  \"description\": \"Default Description\",\r\n"
+                + "  \"properties\": {\r\n"
+                + "    \"tags\": {\r\n"
+                + "      \"type\": \"array\",\r\n"
+                + "      \"items\": {\r\n"
+                + "        \"$ref\": \"#/definitions/tag\"\r\n"
+                + "      }\r\n"
+                + "    }\r\n"
+                + "  },\r\n"
+                + "  \"definitions\": {\r\n"
+                + "    \"tag\": {\r\n"
+                + "      \"properties\": {\r\n"
+                + "        \"name\": {\r\n"
+                + "          \"type\": \"string\"\r\n"
+                + "        },\r\n"
+                + "        \"description\": {\r\n"
+                + "          \"type\": \"string\"\r\n"
+                + "        }\r\n"
+                + "      }\r\n"
+                + "    }\r\n"
+                + "  }\r\n"
+                + "}";
+        
+        List<WalkEvent> propertyKeywords = new ArrayList<>();
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.setPathType(PathType.JSON_POINTER);
+        config.addKeywordWalkListener(ValidatorTypeCode.PROPERTIES.getValue(), new JsonSchemaWalkListener() {
+            
+            @Override
+            public WalkFlow onWalkStart(WalkEvent walkEvent) {
+                propertyKeywords.add(walkEvent);
+                return WalkFlow.CONTINUE;
+            }
+            
+            @Override
+            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+            }
+        });
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V7).getSchema(schemaData, config);
+        String inputData = "{\r\n"
+                + "  \"tags\": [\r\n"
+                + "    {\r\n"
+                + "      \"name\": \"image\",\r\n"
+                + "      \"description\": \"An image\"\r\n"
+                + "    },\r\n"
+                + "    {\r\n"
+                + "      \"name\": \"link\",\r\n"
+                + "      \"description\": \"A link\"\r\n"
+                + "    }\r\n"
+                + "  ]\r\n"
+                + "}";
+        ValidationResult result = schema.walk(inputData, InputFormat.JSON, true);
+        assertTrue(result.getValidationMessages().isEmpty());
+        assertEquals(3, propertyKeywords.size());
+        assertEquals("", propertyKeywords.get(0).getInstanceLocation().toString());
+        assertEquals("/properties", propertyKeywords.get(0).getEvaluationPath().toString());
+        assertEquals("/tags/0", propertyKeywords.get(1).getInstanceLocation().toString());
+        assertEquals("image", propertyKeywords.get(1).getInstanceNode().get("name").asText());
+        assertEquals("/properties/tags/items/$ref/properties", propertyKeywords.get(1).getEvaluationPath().toString());
+        assertEquals("/tags/1", propertyKeywords.get(2).getInstanceLocation().toString());
+        assertEquals("/properties/tags/items/$ref/properties", propertyKeywords.get(2).getEvaluationPath().toString());
+        assertEquals("link", propertyKeywords.get(2).getInstanceNode().get("name").asText());
+    }
+    
+    @Test
+    void propertyListener() {
+        String schemaData = "{\r\n"
+                + "  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\r\n"
+                + "  \"type\": \"object\",\r\n"
+                + "  \"description\": \"Default Description\",\r\n"
+                + "  \"properties\": {\r\n"
+                + "    \"tags\": {\r\n"
+                + "      \"type\": \"array\",\r\n"
+                + "      \"items\": {\r\n"
+                + "        \"$ref\": \"#/definitions/tag\"\r\n"
+                + "      }\r\n"
+                + "    }\r\n"
+                + "  },\r\n"
+                + "  \"definitions\": {\r\n"
+                + "    \"tag\": {\r\n"
+                + "      \"properties\": {\r\n"
+                + "        \"name\": {\r\n"
+                + "          \"type\": \"string\"\r\n"
+                + "        },\r\n"
+                + "        \"description\": {\r\n"
+                + "          \"type\": \"string\"\r\n"
+                + "        }\r\n"
+                + "      }\r\n"
+                + "    }\r\n"
+                + "  }\r\n"
+                + "}";
+        
+        List<WalkEvent> properties = new ArrayList<>();
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.setPathType(PathType.JSON_POINTER);
+        config.addPropertyWalkListener(new JsonSchemaWalkListener() {
+            
+            @Override
+            public WalkFlow onWalkStart(WalkEvent walkEvent) {
+                properties.add(walkEvent);
+                return WalkFlow.CONTINUE;
+            }
+
+            @Override
+            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+            }
+        });
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V7).getSchema(schemaData, config);
+        String inputData = "{\r\n"
+                + "  \"tags\": [\r\n"
+                + "    {\r\n"
+                + "      \"name\": \"image\",\r\n"
+                + "      \"description\": \"An image\"\r\n"
+                + "    },\r\n"
+                + "    {\r\n"
+                + "      \"name\": \"link\",\r\n"
+                + "      \"description\": \"A link\"\r\n"
+                + "    }\r\n"
+                + "  ]\r\n"
+                + "}";
+        ValidationResult result = schema.walk(inputData, InputFormat.JSON, true);
+        assertTrue(result.getValidationMessages().isEmpty());
+        assertEquals(5, properties.size());
+        assertEquals("/tags", properties.get(0).getInstanceLocation().toString());
+        assertEquals("/properties/tags", properties.get(0).getEvaluationPath().toString());
+
+        assertEquals("/tags/0/name", properties.get(1).getInstanceLocation().toString());
+        assertEquals("image", properties.get(1).getInstanceNode().asText());
+        assertEquals("/properties/tags/items/$ref/properties/name", properties.get(1).getEvaluationPath().toString());
+
+        assertEquals("/tags/0/description", properties.get(2).getInstanceLocation().toString());
+        assertEquals("An image", properties.get(2).getInstanceNode().asText());
+        assertEquals("/properties/tags/items/$ref/properties/description", properties.get(2).getEvaluationPath().toString());
+
+        assertEquals("/tags/1/name", properties.get(3).getInstanceLocation().toString());
+        assertEquals("link", properties.get(3).getInstanceNode().asText());
+        assertEquals("/properties/tags/items/$ref/properties/name", properties.get(3).getEvaluationPath().toString());
+
+        assertEquals("/tags/1/description", properties.get(4).getInstanceLocation().toString());
+        assertEquals("A link", properties.get(4).getInstanceNode().asText());
+        assertEquals("/properties/tags/items/$ref/properties/description", properties.get(4).getEvaluationPath().toString());
+    }
+
+    @Test
+    void draft201909() {
+        List<WalkEvent> propertyKeywords = new ArrayList<>();
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.setPathType(PathType.JSON_POINTER);
+        config.addKeywordWalkListener(ValidatorTypeCode.PROPERTIES.getValue(), new JsonSchemaWalkListener() {
+            
+            @Override
+            public WalkFlow onWalkStart(WalkEvent walkEvent) {
+                propertyKeywords.add(walkEvent);
+                return WalkFlow.CONTINUE;
+            }
+            
+            @Override
+            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+            }
+        });
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V201909)
+                .getSchema(SchemaLocation.of(SchemaId.V201909), config);
+        String inputData = "{\r\n"
+                + "  \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\r\n"
+                + "  \"type\": \"object\",\r\n"
+                + "  \"properties\": {\r\n"
+                + "    \"kebab-case\": {\r\n"
+                + "      \"type\": \"string\"\r\n"
+                + "    },\r\n"
+                + "    \"snake_case\": {\r\n"
+                + "      \"type\": \"string\"\r\n"
+                + "    },\r\n"
+                + "    \"a\": {\r\n"
+                + "      \"type\": \"string\"\r\n"
+                + "    }\r\n"
+                + "  }\r\n"
+                + "}";
+        ValidationResult result = schema.walk(inputData, InputFormat.JSON, true);
+        assertTrue(result.getValidationMessages().isEmpty());
+        
+        assertEquals(28, propertyKeywords.size());
+        
+        assertEquals("", propertyKeywords.get(0).getInstanceLocation().toString());
+        assertEquals("/properties", propertyKeywords.get(0).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/schema#/properties", propertyKeywords.get(0).getSchemaLocation().toString());
+
+        assertEquals("", propertyKeywords.get(1).getInstanceLocation().toString());
+        assertEquals("/allOf/0/$ref/properties", propertyKeywords.get(1).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/core#/properties", propertyKeywords.get(1).getSchemaLocation().toString());
+
+        assertEquals("", propertyKeywords.get(2).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties", propertyKeywords.get(2).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/applicator#/properties", propertyKeywords.get(2).getSchemaLocation().toString());
+
+        assertEquals("/properties/kebab-case", propertyKeywords.get(3).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/properties", propertyKeywords.get(3).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/schema#/properties", propertyKeywords.get(3).getSchemaLocation().toString());
+
+        assertEquals("/properties/kebab-case", propertyKeywords.get(4).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/0/$ref/properties", propertyKeywords.get(4).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/core#/properties", propertyKeywords.get(4).getSchemaLocation().toString());
+
+        assertEquals("/properties/kebab-case", propertyKeywords.get(5).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/1/$ref/properties", propertyKeywords.get(5).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/applicator#/properties", propertyKeywords.get(5).getSchemaLocation().toString());
+
+        assertEquals("/properties/kebab-case", propertyKeywords.get(6).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/2/$ref/properties", propertyKeywords.get(6).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/validation#/properties", propertyKeywords.get(6).getSchemaLocation().toString());
+
+        assertEquals("/properties/kebab-case", propertyKeywords.get(7).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/3/$ref/properties", propertyKeywords.get(7).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/meta-data#/properties", propertyKeywords.get(7).getSchemaLocation().toString());
+
+        assertEquals("/properties/kebab-case", propertyKeywords.get(8).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/4/$ref/properties", propertyKeywords.get(8).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/format#/properties", propertyKeywords.get(8).getSchemaLocation().toString());
+
+        assertEquals("/properties/kebab-case", propertyKeywords.get(9).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/5/$ref/properties", propertyKeywords.get(9).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/content#/properties", propertyKeywords.get(9).getSchemaLocation().toString());
+
+        assertEquals("/properties/snake_case", propertyKeywords.get(10).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/properties", propertyKeywords.get(10).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/schema#/properties", propertyKeywords.get(10).getSchemaLocation().toString());
+
+        assertEquals("/properties/snake_case", propertyKeywords.get(11).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/0/$ref/properties", propertyKeywords.get(11).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/core#/properties", propertyKeywords.get(11).getSchemaLocation().toString());
+
+        assertEquals("/properties/snake_case", propertyKeywords.get(12).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/1/$ref/properties", propertyKeywords.get(12).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/applicator#/properties", propertyKeywords.get(12).getSchemaLocation().toString());
+
+        assertEquals("/properties/snake_case", propertyKeywords.get(13).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/2/$ref/properties", propertyKeywords.get(13).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/validation#/properties", propertyKeywords.get(13).getSchemaLocation().toString());
+
+        assertEquals("/properties/snake_case", propertyKeywords.get(14).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/3/$ref/properties", propertyKeywords.get(14).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/meta-data#/properties", propertyKeywords.get(14).getSchemaLocation().toString());
+
+        assertEquals("/properties/snake_case", propertyKeywords.get(15).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/4/$ref/properties", propertyKeywords.get(15).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/format#/properties", propertyKeywords.get(15).getSchemaLocation().toString());
+
+        assertEquals("/properties/snake_case", propertyKeywords.get(16).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/5/$ref/properties", propertyKeywords.get(16).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/content#/properties", propertyKeywords.get(16).getSchemaLocation().toString());
+
+        assertEquals("/properties/a", propertyKeywords.get(17).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/properties", propertyKeywords.get(17).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/schema#/properties", propertyKeywords.get(17).getSchemaLocation().toString());
+
+        assertEquals("/properties/a", propertyKeywords.get(18).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/0/$ref/properties", propertyKeywords.get(18).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/core#/properties", propertyKeywords.get(18).getSchemaLocation().toString());
+
+        assertEquals("/properties/a", propertyKeywords.get(19).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/1/$ref/properties", propertyKeywords.get(19).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/applicator#/properties", propertyKeywords.get(19).getSchemaLocation().toString());
+
+        assertEquals("/properties/a", propertyKeywords.get(20).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/2/$ref/properties", propertyKeywords.get(20).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/validation#/properties", propertyKeywords.get(20).getSchemaLocation().toString());
+
+        assertEquals("/properties/a", propertyKeywords.get(21).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/3/$ref/properties", propertyKeywords.get(21).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/meta-data#/properties", propertyKeywords.get(21).getSchemaLocation().toString());
+
+        assertEquals("/properties/a", propertyKeywords.get(22).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/4/$ref/properties", propertyKeywords.get(22).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/format#/properties", propertyKeywords.get(22).getSchemaLocation().toString());
+
+        assertEquals("/properties/a", propertyKeywords.get(23).getInstanceLocation().toString());
+        assertEquals("/allOf/1/$ref/properties/properties/additionalProperties/$recursiveRef/allOf/5/$ref/properties", propertyKeywords.get(23).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/content#/properties", propertyKeywords.get(23).getSchemaLocation().toString());
+
+        assertEquals("", propertyKeywords.get(24).getInstanceLocation().toString());
+        assertEquals("/allOf/2/$ref/properties", propertyKeywords.get(24).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/validation#/properties", propertyKeywords.get(24).getSchemaLocation().toString());
+
+        assertEquals("", propertyKeywords.get(25).getInstanceLocation().toString());
+        assertEquals("/allOf/3/$ref/properties", propertyKeywords.get(25).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/meta-data#/properties", propertyKeywords.get(25).getSchemaLocation().toString());
+
+        assertEquals("", propertyKeywords.get(26).getInstanceLocation().toString());
+        assertEquals("/allOf/4/$ref/properties", propertyKeywords.get(26).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/format#/properties", propertyKeywords.get(26).getSchemaLocation().toString());
+
+        assertEquals("", propertyKeywords.get(27).getInstanceLocation().toString());
+        assertEquals("/allOf/5/$ref/properties", propertyKeywords.get(27).getEvaluationPath().toString());
+        assertEquals("https://json-schema.org/draft/2019-09/meta/content#/properties", propertyKeywords.get(27).getSchemaLocation().toString());
+    }
+    
+    @Test
+    void applyDefaults() throws JsonMappingException, JsonProcessingException {
+        String schemaData = "{\r\n"
+                + "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\r\n"
+                + "  \"title\": \"\",\r\n"
+                + "  \"type\": \"object\",\r\n"
+                + "  \"properties\": {\r\n"
+                + "    \"s\": {\r\n"
+                + "      \"type\": \"string\",\r\n"
+                + "      \"default\": \"S\"\r\n"
+                + "    },\r\n"
+                + "    \"ref\": { \"$ref\": \"#/$defs/r\" }\r\n"
+                + "  },\r\n"
+                + "  \"required\": [ \"s\", \"ref\" ],\r\n"
+                + "\r\n"
+                + "  \"$defs\": {\r\n"
+                + "    \"r\": {\r\n"
+                + "      \"type\": \"string\",\r\n"
+                + "      \"default\": \"REF\"\r\n"
+                + "    }\r\n"
+                + "  }\r\n"
+                + "}";
+        
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.setApplyDefaultsStrategy(new ApplyDefaultsStrategy(true, true, true));
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        JsonNode inputNode = JsonMapperFactory.getInstance().readTree("{}");
+        ValidationResult result = schema.walk(inputNode, true);
+        assertEquals("{\"s\":\"S\",\"ref\":\"REF\"}", inputNode.toString());
+        assertTrue(result.getValidationMessages().isEmpty());
+    }
+
+    @Test
+    void missingRequired() throws JsonMappingException, JsonProcessingException {
+        String schemaData = "{\r\n"
+                + "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\r\n"
+                + "  \"title\": \"\",\r\n"
+                + "  \"type\": \"object\",\r\n"
+                + "  \"properties\": {\r\n"
+                + "    \"s\": {\r\n"
+                + "      \"type\": \"string\"\r\n"
+                + "    },\r\n"
+                + "    \"ref\": { \"$ref\": \"#/$defs/r\" }\r\n"
+                + "  },\r\n"
+                + "  \"required\": [ \"s\", \"ref\" ],\r\n"
+                + "\r\n"
+                + "  \"$defs\": {\r\n"
+                + "    \"r\": {\r\n"
+                + "      \"type\": \"string\"\r\n"
+                + "    }\r\n"
+                + "  }\r\n"
+                + "}";
+        
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.addKeywordWalkListener(ValidatorTypeCode.PROPERTIES.getValue(), new JsonSchemaWalkListener() {
+            
+            @Override
+            public WalkFlow onWalkStart(WalkEvent walkEvent) {
+                JsonNode requiredNode = walkEvent.getSchemaNode().get("required");
+                List<String> requiredProperties = new ArrayList<>();
+                if (requiredNode != null) {
+                    if (requiredNode.isArray()) {
+                        for (JsonNode fieldName : requiredNode) {
+                            requiredProperties.add(fieldName.asText());
+                        }
+                    }
+                }
+                for (String requiredProperty : requiredProperties) {
+                    JsonNode propertyNode = walkEvent.getInstanceNode().get(requiredProperty);
+                    if (propertyNode == null) {
+                        // Get the schema
+                        JsonSchema schema = walkEvent.getSchema();
+                    }
+                }
+                return WalkFlow.CONTINUE;
+            }
+            
+            @Override
+            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+            }
+        });
+
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        JsonNode inputNode = JsonMapperFactory.getInstance().readTree("{}");
+        ValidationResult result = schema.walk(inputNode, true);
+        assertEquals("{\"s\":\"S\",\"ref\":\"REF\"}", inputNode.toString());
+        assertTrue(result.getValidationMessages().isEmpty());
+    }
+}

--- a/src/test/java/com/networknt/schema/walk/JsonSchemaWalkListenerTest.java
+++ b/src/test/java/com/networknt/schema/walk/JsonSchemaWalkListenerTest.java
@@ -125,6 +125,8 @@ class JsonSchemaWalkListenerTest {
                 .append(propertyKeywords.get(0).getKeyword()).toString());
         assertEquals("/tags/0", propertyKeywords.get(1).getInstanceLocation().toString());
         assertEquals("image", propertyKeywords.get(1).getInstanceNode().get("name").asText());
+        assertEquals("/properties/tags/items/$ref/properties",
+                propertyKeywords.get(1).getValidator().getEvaluationPath().toString());
         assertEquals("/properties/tags/items/$ref/properties", propertyKeywords.get(1).getSchema().getEvaluationPath()
                 .append(propertyKeywords.get(1).getKeyword()).toString());
         assertEquals("/tags/1", propertyKeywords.get(2).getInstanceLocation().toString());


### PR DESCRIPTION
Closes #441, closes #467, closes #841, closes #868, closes #882

This contains breaking changes to those using the walk functionality

When using the walker with defaults the `default` across a `$ref` are properly resolved and used.

The behavior for the property listener is now more consistent whether or not validation is enabled. Previously if validation is enabled but the property is `null` the property listener is not called while if validation is not enabled it will be called. Now the property listener will be called in both scenarios.

The following are the breaking changes to those using the walk functionality. Previously there wasn't a way to get the `JsonSchema` of the schema that was referenced by the `schemaNode` and it was unclear what the `schemaLocation` or `evaluationPath` was referring to.

`WalkEvent`
| Field                    | Change       | Notes
|--------------------------|--------------|----------
| `schemaLocation`         | Removed      | For keywords: `getValidator().getSchemaLocation()`. For items and properties: `getSchema().getSchemaLocation()`
| `evaluationPath`         | Removed      | For keywords: `getValidator().getEvaluationPath()`. For items and properties: `getSchema().getEvaluationPath()`
| `schemaNode`             | Removed      | `getSchema().getSchemaNode()`
| `parentSchema`           | Removed      | `getSchema().getParentSchema()`
| `schema`                 | New          | For keywords this is the parent schema of the validator. For items and properties this is the item or property schema being evaluated.
| `node`                   | Renamed      | `instanceNode`
| `currentJsonSchemaFactory`| Removed     | `getSchema().getValidationContext().getJsonSchemaFactory()`
| `validator`              | New          | The validator indicated by the keyword.