### PR TITLE
Walk items schema instead of walking instance data

### DIFF
--- a/src/main/java/com/networknt/schema/AdditionalPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/AdditionalPropertiesValidator.java
@@ -165,7 +165,7 @@ public class AdditionalPropertiesValidator extends BaseJsonValidator {
 
     @Override
     public Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
-        if (shouldValidateSchema) {
+        if (shouldValidateSchema && node != null) {
             return validate(executionContext, node, rootNode, instanceLocation);
         }
 

--- a/src/main/java/com/networknt/schema/DynamicRefValidator.java
+++ b/src/main/java/com/networknt/schema/DynamicRefValidator.java
@@ -113,6 +113,22 @@ public class DynamicRefValidator extends BaseJsonValidator {
                     .arguments(schemaNode.asText()).build();
             throw new InvalidSchemaRefException(validationMessage);
         }
+        if (node == null) {
+            // Check for circular dependency
+            SchemaLocation schemaLocation = refSchema.getSchemaLocation();
+            JsonSchema check = refSchema;
+            boolean circularDependency = false;
+            while (check.getEvaluationParentSchema() != null) {
+                check = check.getEvaluationParentSchema();
+                if (check.getSchemaLocation().equals(schemaLocation)) {
+                    circularDependency = true;
+                    break;
+                }
+            }
+            if (circularDependency) {
+                return Collections.emptySet();
+            }
+        }
         return refSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
     }
 

--- a/src/main/java/com/networknt/schema/ItemsValidator.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator.java
@@ -203,25 +203,125 @@ public class ItemsValidator extends BaseJsonValidator {
 
     @Override
     public Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
-        HashSet<ValidationMessage> validationMessages = new LinkedHashSet<>();
-        if (node instanceof ArrayNode) {
-            ArrayNode arrayNode = (ArrayNode) node;
-            JsonNode defaultNode = null;
-            if (this.validationContext.getConfig().getApplyDefaultsStrategy().shouldApplyArrayDefaults()
-                    && this.schema != null) {
-                defaultNode = getDefaultNode(this.schema);
-            }
-            int i = 0;
-            for (JsonNode n : arrayNode) {
-                if (n.isNull() && defaultNode != null) {
-                    arrayNode.set(i, defaultNode);
-                    n = defaultNode;
+        Set<ValidationMessage> validationMessages = new LinkedHashSet<>();
+        boolean collectAnnotations = collectAnnotations();
+
+        // Add items annotation
+        if (collectAnnotations || collectAnnotations(executionContext)) {
+            if (this.schema != null) {
+                // Applies to all
+                executionContext.getAnnotations()
+                        .put(JsonNodeAnnotation.builder().instanceLocation(instanceLocation)
+                                .evaluationPath(this.evaluationPath).schemaLocation(this.schemaLocation)
+                                .keyword(getKeyword()).value(true).build());
+            } else if (this.tupleSchema != null) {
+                // Tuples
+                int items = node.isArray() ? node.size() : 1;
+                int schemas = this.tupleSchema.size();
+                if (items > schemas) {
+                    // More items than schemas so the keyword only applied to the number of schemas
+                    executionContext.getAnnotations()
+                            .put(JsonNodeAnnotation.builder().instanceLocation(instanceLocation)
+                                    .evaluationPath(this.evaluationPath).schemaLocation(this.schemaLocation)
+                                    .keyword(getKeyword()).value(schemas).build());
+                } else {
+                    // Applies to all
+                    executionContext.getAnnotations()
+                            .put(JsonNodeAnnotation.builder().instanceLocation(instanceLocation)
+                                    .evaluationPath(this.evaluationPath).schemaLocation(this.schemaLocation)
+                                    .keyword(getKeyword()).value(true).build());
                 }
-                doWalk(executionContext, validationMessages, i, n, rootNode, instanceLocation, shouldValidateSchema);
-                i++;
             }
-        } else {
-            doWalk(executionContext, validationMessages, 0, node, rootNode, instanceLocation, shouldValidateSchema);
+        }
+
+        if (this.schema != null) {
+            // Walk the schema.
+            if (node instanceof ArrayNode) {
+                int count = Math.max(1, node.size());
+                ArrayNode arrayNode = (ArrayNode) node;
+                JsonNode defaultNode = null;
+                if (this.validationContext.getConfig().getApplyDefaultsStrategy().shouldApplyArrayDefaults()) {
+                    defaultNode = getDefaultNode(this.schema);
+                }
+                for (int i = 0; i < count; i++) {
+                    JsonNode n = arrayNode.get(i);
+                    if (n != null) {
+                        if (n.isNull() && defaultNode != null) {
+                            arrayNode.set(i, defaultNode);
+                            n = defaultNode;
+                        }
+                    }
+                    walkSchema(executionContext, this.schema, n, rootNode, instanceLocation.append(i), shouldValidateSchema, validationMessages, ValidatorTypeCode.ITEMS.getValue());
+                }
+            } else {
+                walkSchema(executionContext, this.schema, null, rootNode, instanceLocation.append(0), shouldValidateSchema, validationMessages, ValidatorTypeCode.ITEMS.getValue());
+            }
+        }
+        else if (this.tupleSchema != null) {
+            int prefixItems = this.tupleSchema.size();
+            for (int i = 0; i < prefixItems; i++) {
+                // walk tuple schema
+                if (node instanceof ArrayNode) {
+                    ArrayNode arrayNode = (ArrayNode) node;
+                    JsonNode defaultNode = null;
+                    JsonNode n = arrayNode.get(i);
+                    if (this.validationContext.getConfig().getApplyDefaultsStrategy().shouldApplyArrayDefaults()) {
+                        defaultNode = getDefaultNode(this.tupleSchema.get(i));
+                    }
+                    if (n != null) {
+                        if (n.isNull() && defaultNode != null) {
+                            arrayNode.set(i, defaultNode);
+                            n = defaultNode;
+                        }
+                    }
+                    walkSchema(executionContext, this.tupleSchema.get(i), n, rootNode, instanceLocation.append(i),
+                            shouldValidateSchema, validationMessages, ValidatorTypeCode.ITEMS.getValue());
+                } else {
+                    walkSchema(executionContext, this.tupleSchema.get(i), null, rootNode, instanceLocation.append(i),
+                            shouldValidateSchema, validationMessages, ValidatorTypeCode.ITEMS.getValue());
+                }
+            }
+            if (this.additionalSchema != null) {
+                boolean hasAdditionalItem = false;
+
+                int additionalItems = Math.max(1, (node != null ? node.size() : 0) - prefixItems);
+                for (int x = 0; x < additionalItems; x++) {
+                    int i = x + prefixItems;
+                    // walk additional item schema
+                    if (node instanceof ArrayNode) {
+                        ArrayNode arrayNode = (ArrayNode) node;
+                        JsonNode defaultNode = null;
+                        JsonNode n = arrayNode.get(i);
+                        if (this.validationContext.getConfig().getApplyDefaultsStrategy().shouldApplyArrayDefaults()) {
+                            defaultNode = getDefaultNode(this.additionalSchema);
+                        }
+                        if (n != null) {
+                            if (n.isNull() && defaultNode != null) {
+                                arrayNode.set(i, defaultNode);
+                                n = defaultNode;
+                            }
+                        }
+                        walkSchema(executionContext, this.additionalSchema, n, rootNode, instanceLocation.append(i),
+                                shouldValidateSchema, validationMessages, PROPERTY_ADDITIONAL_ITEMS);
+                        if (n != null) {
+                            hasAdditionalItem = true;
+                        }
+                    } else {
+                        walkSchema(executionContext, this.additionalSchema, null, rootNode, instanceLocation.append(i),
+                                shouldValidateSchema, validationMessages, PROPERTY_ADDITIONAL_ITEMS);
+                    }
+                }
+
+                if (hasAdditionalItem) {
+                    if (collectAnnotations || collectAnnotations(executionContext, "additionalItems")) {
+                        executionContext.getAnnotations()
+                                .put(JsonNodeAnnotation.builder().instanceLocation(instanceLocation)
+                                        .evaluationPath(this.additionalItemsEvaluationPath)
+                                        .schemaLocation(this.additionalItemsSchemaLocation)
+                                        .keyword("additionalItems").value(true).build());
+                    }
+                }
+            }
         }
         return validationMessages;
     }
@@ -237,36 +337,14 @@ public class ItemsValidator extends BaseJsonValidator {
         return result;
     }
 
-    private void doWalk(ExecutionContext executionContext, HashSet<ValidationMessage> validationMessages, int i, JsonNode node,
-            JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
-        if (this.schema != null) {
-            // Walk the schema.
-            walkSchema(executionContext, this.schema, node, rootNode, instanceLocation.append(i), shouldValidateSchema, validationMessages);
-        }
-
-        if (this.tupleSchema != null) {
-            if (i < this.tupleSchema.size()) {
-                // walk tuple schema
-                walkSchema(executionContext, this.tupleSchema.get(i), node, rootNode, instanceLocation.append(i),
-                        shouldValidateSchema, validationMessages);
-            } else {
-                if (this.additionalSchema != null) {
-                    // walk additional item schema
-                    walkSchema(executionContext, this.additionalSchema, node, rootNode, instanceLocation.append(i),
-                            shouldValidateSchema, validationMessages);
-                }
-            }
-        }
-    }
-
     private void walkSchema(ExecutionContext executionContext, JsonSchema walkSchema, JsonNode node, JsonNode rootNode,
-            JsonNodePath instanceLocation, boolean shouldValidateSchema, Set<ValidationMessage> validationMessages) {
-        boolean executeWalk = this.validationContext.getConfig().getItemWalkListenerRunner().runPreWalkListeners(executionContext, ValidatorTypeCode.ITEMS.getValue(),
+            JsonNodePath instanceLocation, boolean shouldValidateSchema, Set<ValidationMessage> validationMessages, String keyword) {
+        boolean executeWalk = this.validationContext.getConfig().getItemWalkListenerRunner().runPreWalkListeners(executionContext, keyword,
                 node, rootNode, instanceLocation, walkSchema, this);
         if (executeWalk) {
             validationMessages.addAll(walkSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema));
         }
-        this.validationContext.getConfig().getItemWalkListenerRunner().runPostWalkListeners(executionContext, ValidatorTypeCode.ITEMS.getValue(), node, rootNode,
+        this.validationContext.getConfig().getItemWalkListenerRunner().runPostWalkListeners(executionContext, keyword, node, rootNode,
                 instanceLocation, walkSchema, this, validationMessages);
 
     }

--- a/src/main/java/com/networknt/schema/JsonValidator.java
+++ b/src/main/java/com/networknt/schema/JsonValidator.java
@@ -59,6 +59,10 @@ public interface JsonValidator extends JsonSchemaWalker {
     @Override
     default Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation, boolean shouldValidateSchema) {
+        if (node == null) {
+            // Note that null is not the same as NullNode
+            return Collections.emptySet();
+        }
         return shouldValidateSchema ? validate(executionContext, node, rootNode, instanceLocation)
                 : Collections.emptySet();
     }

--- a/src/main/java/com/networknt/schema/RecursiveRefValidator.java
+++ b/src/main/java/com/networknt/schema/RecursiveRefValidator.java
@@ -110,6 +110,22 @@ public class RecursiveRefValidator extends BaseJsonValidator {
                     .arguments(schemaNode.asText()).build();
             throw new InvalidSchemaRefException(validationMessage);
         }
+        if (node == null) {
+            // Check for circular dependency
+            SchemaLocation schemaLocation = refSchema.getSchemaLocation();
+            JsonSchema check = refSchema;
+            boolean circularDependency = false;
+            while (check.getEvaluationParentSchema() != null) {
+                check = check.getEvaluationParentSchema();
+                if (check.getSchemaLocation().equals(schemaLocation)) {
+                    circularDependency = true;
+                    break;
+                }
+            }
+            if (circularDependency) {
+                return Collections.emptySet();
+            }
+        }
         return refSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
     }
 

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -195,6 +195,22 @@ public class RefValidator extends BaseJsonValidator {
                     .arguments(schemaNode.asText()).build();
             throw new InvalidSchemaRefException(validationMessage);
         }
+        if (node == null) {
+            // Check for circular dependency
+            SchemaLocation schemaLocation = refSchema.getSchemaLocation();
+            JsonSchema check = refSchema;
+            boolean circularDependency = false;
+            while (check.getEvaluationParentSchema() != null) {
+                check = check.getEvaluationParentSchema();
+                if (check.getSchemaLocation().equals(schemaLocation)) {
+                    circularDependency = true;
+                    break;
+                }
+            }
+            if (circularDependency) {
+                return Collections.emptySet();
+            }
+        }
         return refSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
     }
 

--- a/src/test/java/com/networknt/schema/TypeValidatorTest.java
+++ b/src/test/java/com/networknt/schema/TypeValidatorTest.java
@@ -16,6 +16,7 @@
 package com.networknt.schema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
 
@@ -138,5 +139,15 @@ public class TypeValidatorTest {
         assertEquals(1, messages.size());
         messages = schema.validate("2.000001", InputFormat.JSON);
         assertEquals(1, messages.size());
+    }
+
+    @Test
+    void walkNull() {
+        String schemaData = "{\r\n"
+                + "  \"type\": \"integer\"\r\n"
+                + "}";
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V4).getSchema(schemaData);
+        ValidationResult result = schema.walk(null, true);
+        assertTrue(result.getValidationMessages().isEmpty());
     }
 }

--- a/src/test/java/com/networknt/schema/walk/JsonSchemaWalkListenerTest.java
+++ b/src/test/java/com/networknt/schema/walk/JsonSchemaWalkListenerTest.java
@@ -38,6 +38,7 @@ import com.networknt.schema.ApplyDefaultsStrategy;
 import com.networknt.schema.InputFormat;
 import com.networknt.schema.ItemsValidator;
 import com.networknt.schema.ItemsValidator202012;
+import com.networknt.schema.JsonNodePath;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.JsonSchemaRef;
@@ -811,4 +812,129 @@ class JsonSchemaWalkListenerTest {
         assertEquals("{\"name\":\"John Doe\",\"email\":\"john.doe@gmail.com\"}", inputNode.toString());
         assertTrue(result.getValidationMessages().isEmpty());
     }
+
+    /**
+     * Issue 989
+     */
+    @Test
+    void itemListenerDraft201909() {
+        String schemaData = "        {\r\n"
+                + "          \"type\": \"object\",\r\n"
+                + "          \"properties\": {\r\n"
+                + "            \"name\": {\r\n"
+                + "              \"type\": \"string\"\r\n"
+                + "            },\r\n"
+                + "            \"children\": {\r\n"
+                + "              \"type\": \"array\",\r\n"
+                + "              \"items\": {\r\n"
+                + "                \"type\": \"object\",\r\n"
+                + "                \"properties\": {\r\n"
+                + "                  \"name\": {\r\n"
+                + "                    \"type\": \"string\"\r\n"
+                + "                  }\r\n"
+                + "                }\r\n"
+                + "              }\r\n"
+                + "            }\r\n"
+                + "          }\r\n"
+                + "        }";
+        JsonSchemaWalkListener listener = new JsonSchemaWalkListener() {
+            @Override
+            public WalkFlow onWalkStart(WalkEvent walkEvent) {
+                return WalkFlow.CONTINUE;
+            }
+
+            @Override
+            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+                @SuppressWarnings("unchecked")
+                List<WalkEvent> items = (List<WalkEvent>) walkEvent.getExecutionContext()
+                        .getCollectorContext()
+                        .getCollectorMap()
+                        .computeIfAbsent("items", key -> new ArrayList<JsonNodePath>());
+                items.add(walkEvent);
+            }
+        }; 
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.addItemWalkListener(listener);
+        config.addPropertyWalkListener(listener);
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V201909).getSchema(schemaData, config);
+        ValidationResult result = schema.walk(null, true);
+        @SuppressWarnings("unchecked")
+        List<WalkEvent> items = (List<WalkEvent>) result.getExecutionContext().getCollectorContext().get("items");
+        assertEquals(4, items.size());
+        assertEquals("$.name", items.get(0).getInstanceLocation().toString());
+        assertEquals("properties", items.get(0).getKeyword());
+        assertEquals("#/properties/name", items.get(0).getSchema().getSchemaLocation().toString());
+        assertEquals("$.children[0].name", items.get(1).getInstanceLocation().toString());
+        assertEquals("properties", items.get(1).getKeyword());
+        assertEquals("#/properties/children/items/properties/name", items.get(1).getSchema().getSchemaLocation().toString());
+        assertEquals("$.children[0]", items.get(2).getInstanceLocation().toString());
+        assertEquals("items", items.get(2).getKeyword());
+        assertEquals("#/properties/children/items", items.get(2).getSchema().getSchemaLocation().toString());
+        assertEquals("$.children", items.get(3).getInstanceLocation().toString());
+        assertEquals("properties", items.get(3).getKeyword());
+        assertEquals("#/properties/children", items.get(3).getSchema().getSchemaLocation().toString());
+    }
+
+    /**
+     * Issue 989
+     */
+    @Test
+    void itemListenerDraft202012() {
+        String schemaData = "        {\r\n"
+                + "          \"type\": \"object\",\r\n"
+                + "          \"properties\": {\r\n"
+                + "            \"name\": {\r\n"
+                + "              \"type\": \"string\"\r\n"
+                + "            },\r\n"
+                + "            \"children\": {\r\n"
+                + "              \"type\": \"array\",\r\n"
+                + "              \"items\": {\r\n"
+                + "                \"type\": \"object\",\r\n"
+                + "                \"properties\": {\r\n"
+                + "                  \"name\": {\r\n"
+                + "                    \"type\": \"string\"\r\n"
+                + "                  }\r\n"
+                + "                }\r\n"
+                + "              }\r\n"
+                + "            }\r\n"
+                + "          }\r\n"
+                + "        }";
+        JsonSchemaWalkListener listener = new JsonSchemaWalkListener() {
+            @Override
+            public WalkFlow onWalkStart(WalkEvent walkEvent) {
+                return WalkFlow.CONTINUE;
+            }
+
+            @Override
+            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+                @SuppressWarnings("unchecked")
+                List<WalkEvent> items = (List<WalkEvent>) walkEvent.getExecutionContext()
+                        .getCollectorContext()
+                        .getCollectorMap()
+                        .computeIfAbsent("items", key -> new ArrayList<JsonNodePath>());
+                items.add(walkEvent);
+            }
+        }; 
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.addItemWalkListener(listener);
+        config.addPropertyWalkListener(listener);
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        ValidationResult result = schema.walk(null, true);
+        @SuppressWarnings("unchecked")
+        List<WalkEvent> items = (List<WalkEvent>) result.getExecutionContext().getCollectorContext().get("items");
+        assertEquals(4, items.size());
+        assertEquals("$.name", items.get(0).getInstanceLocation().toString());
+        assertEquals("properties", items.get(0).getKeyword());
+        assertEquals("#/properties/name", items.get(0).getSchema().getSchemaLocation().toString());
+        assertEquals("$.children[0].name", items.get(1).getInstanceLocation().toString());
+        assertEquals("properties", items.get(1).getKeyword());
+        assertEquals("#/properties/children/items/properties/name", items.get(1).getSchema().getSchemaLocation().toString());
+        assertEquals("$.children[0]", items.get(2).getInstanceLocation().toString());
+        assertEquals("items", items.get(2).getKeyword());
+        assertEquals("#/properties/children/items", items.get(2).getSchema().getSchemaLocation().toString());
+        assertEquals("$.children", items.get(3).getInstanceLocation().toString());
+        assertEquals("properties", items.get(3).getKeyword());
+        assertEquals("#/properties/children", items.get(3).getSchema().getSchemaLocation().toString());
+    }
+
 }


### PR DESCRIPTION
Closes #989

This changes the behavior of the walk for the item walk listener to walk the schema instead of walking the instance data. All the relevant item schemas will be called at least once with `null` as the instance node (This is not the same as `NullNode` which is a node with a value of null while `null` is the absence of the node) when there is no applicable instance data.

This also fixes the incorrect `schemaLocation` and `evaluationPath` used for the tuple schemas for `prefixItems`.