### PR TITLE
Fix root classpath resolve

### DIFF
--- a/src/main/java/com/networknt/schema/AbsoluteIri.java
+++ b/src/main/java/com/networknt/schema/AbsoluteIri.java
@@ -101,7 +101,10 @@ public class AbsoluteIri {
                 String base = parent;
                 int scheme = parent.indexOf("://");
                 if (scheme == -1) {
-                    scheme = 0;
+                    scheme = parent.indexOf(':');
+                    if (scheme == -1) {
+                        scheme = 0;
+                    }
                 } else {
                     scheme = scheme + 3;
                 }
@@ -114,7 +117,15 @@ public class AbsoluteIri {
                     } else if (".".equals(iriParts[x])) {
                         // skip
                     } else {
-                        base = base + "/" + iriParts[x];
+                        if (base.endsWith(":")) {
+                            if (parent.length() > base.length() && parent.charAt(base.length()) == '/') {
+                                base = base + "/" + iriParts[x];
+                            } else {
+                                base = base + iriParts[x];
+                            }
+                        } else {
+                            base = base + "/" + iriParts[x];
+                        }
                     }
                 }
                 if (iri.endsWith("/")) {
@@ -127,6 +138,12 @@ public class AbsoluteIri {
     
     protected static String parent(String iri, int scheme) {
         int slash = iri.lastIndexOf('/');
+        if (slash == -1) {
+            slash = iri.lastIndexOf(':');
+            if (slash != -1) {
+                slash = slash + 1;
+            }
+        }
         if (slash != -1 && slash > scheme) {
             return iri.substring(0, slash);
         }

--- a/src/main/java/com/networknt/schema/OutputFormat.java
+++ b/src/main/java/com/networknt/schema/OutputFormat.java
@@ -60,7 +60,7 @@ public interface OutputFormat<T> {
     /**
      * The Boolean output format.
      */
-    public static final Flag BOOLEAN = new Flag();
+    public static final Boolean BOOLEAN = new Boolean();
 
     /**
      * The Flag output format.

--- a/src/test/java/com/networknt/schema/AbsoluteIriTest.java
+++ b/src/test/java/com/networknt/schema/AbsoluteIriTest.java
@@ -60,6 +60,30 @@ class AbsoluteIriTest {
     @Test
     void relativeAtRootWithSchemeSpecificPart() {
         AbsoluteIri iri = new AbsoluteIri("classpath:resource");
+        assertEquals("classpath:test.json", iri.resolve("test.json").toString());
+    }
+
+    @Test
+    void relativeAtRootWithSchemeSpecificPartNoPath() {
+        AbsoluteIri iri = new AbsoluteIri("classpath:");
+        assertEquals("classpath:test.json", iri.resolve("test.json").toString());
+    }
+
+    @Test
+    void relativeAtRootWithSchemeSpecificPartSlash() {
+        AbsoluteIri iri = new AbsoluteIri("classpath:/resource");
+        assertEquals("classpath:/test.json", iri.resolve("test.json").toString());
+    }
+
+    @Test
+    void relativeAtRootWithSchemeSpecificPartNoPathTrailingSlash() {
+        AbsoluteIri iri = new AbsoluteIri("classpath:/");
+        assertEquals("classpath:/test.json", iri.resolve("test.json").toString());
+    }
+
+    @Test
+    void relativeAtRootWithSchemeSpecificPartTrailingSlash() {
+        AbsoluteIri iri = new AbsoluteIri("classpath:resource/");
         assertEquals("classpath:resource/test.json", iri.resolve("test.json").toString());
     }
 

--- a/src/test/java/com/networknt/schema/RefValidatorTest.java
+++ b/src/test/java/com/networknt/schema/RefValidatorTest.java
@@ -16,6 +16,7 @@
 package com.networknt.schema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.Collections;
 import java.util.Set;
@@ -102,5 +103,37 @@ public class RefValidatorTest {
         JsonSchema jsonSchema = factory.getSchema(mainSchema);
         Set<ValidationMessage> messages = jsonSchema.validate("\"string\"", InputFormat.JSON);
         assertEquals(1, messages.size());
+    }
+
+    @Test
+    void classPathSlash() {
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V201909);
+        JsonSchema schema = factory.getSchema(SchemaLocation.of("classpath:/schema/main/main.json"));
+        String inputData = "{\r\n"
+                + "  \"fields\": {\r\n"
+                + "    \"ids\": {\r\n"
+                + "      \"value\": {\r\n"
+                + "        \"value\": 1\r\n"
+                + "      }\r\n"
+                + "    }\r\n"
+                + "  }\r\n"
+                + "}";
+        assertFalse(schema.validate(inputData, InputFormat.JSON, OutputFormat.BOOLEAN));
+    }
+
+    @Test
+    void classPathNoSlash() {
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V201909);
+        JsonSchema schema = factory.getSchema(SchemaLocation.of("classpath:schema/main/main.json"));
+        String inputData = "{\r\n"
+                + "  \"fields\": {\r\n"
+                + "    \"ids\": {\r\n"
+                + "      \"value\": {\r\n"
+                + "        \"value\": 1\r\n"
+                + "      }\r\n"
+                + "    }\r\n"
+                + "  }\r\n"
+                + "}";
+        assertFalse(schema.validate(inputData, InputFormat.JSON, OutputFormat.BOOLEAN));
     }
 }

--- a/src/test/resources/schema/common/child.json
+++ b/src/test/resources/schema/common/child.json
@@ -1,0 +1,9 @@
+{
+    "title": "child schema",
+    "type": "object",
+    "properties": {
+        "value": {
+            "$ref": "./child2.json"
+        }
+    }
+}

--- a/src/test/resources/schema/common/child2.json
+++ b/src/test/resources/schema/common/child2.json
@@ -1,0 +1,10 @@
+{
+    "title": "child2 schema",
+    "type": "object",
+    "properties": {
+        "value": {
+            "type": "string",
+            "$comment": "child value."
+        }
+    }
+}

--- a/src/test/resources/schema/main/main.json
+++ b/src/test/resources/schema/main/main.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "main schema",
+  "type": "object",
+  "properties": {
+    "fields": {
+      "type": "object",
+      "properties": {
+        "ids": {
+          "$ref": "../common/child.json"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes the IRI resolve at the root when there is no starting slash.

For instance given `classpath:resource.json` and resolving `test.json` will now return `classpath:test.json`.