### PR TITLE
Check type validator is of correct class

### DIFF
--- a/src/main/java/com/networknt/schema/JsonSchema.java
+++ b/src/main/java/com/networknt/schema/JsonSchema.java
@@ -474,7 +474,9 @@ public class JsonSchema extends BaseJsonValidator {
                     } else if ("required".equals(pname)) {
                         this.requiredValidator = validator;
                     } else if ("type".equals(pname)) {
-                        this.typeValidator = (TypeValidator) validator;
+                        if (validator instanceof TypeValidator) {
+                            this.typeValidator = (TypeValidator) validator;
+                        }
                     }
                 }
 

--- a/src/test/java/com/networknt/schema/Issue994Test.java
+++ b/src/test/java/com/networknt/schema/Issue994Test.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.networknt.schema;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.networknt.schema.SpecVersion.VersionFlag;
+import com.networknt.schema.serialization.JsonMapperFactory;
+
+public class Issue994Test {
+    @Test
+    void test() throws JsonMappingException, JsonProcessingException {
+        String schemaData = "{\r\n"
+                + "    \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\r\n"
+                + "    \"type\": \"object\",\r\n"
+                + "    \"properties\": {\r\n"
+                + "        \"textValue\": {\r\n"
+                + "            \"type\": [\r\n"
+                + "                \"string\",\r\n"
+                + "                \"null\"\r\n"
+                + "            ],\r\n"
+                + "            \"isMandatory\": true\r\n"
+                + "        }\r\n"
+                + "    }\r\n"
+                + "}";
+        JsonMetaSchema metaSchema = JsonMetaSchema.builder(JsonMetaSchema.getV202012()).vocabularies(vocabularies -> {
+            vocabularies.remove(Vocabulary.V202012_VALIDATION.getIri());
+        }).build();
+        JsonNode schemaNode = JsonMapperFactory.getInstance().readTree(schemaData);
+        JsonSchema schema = JsonSchemaFactory
+                .getInstance(VersionFlag.V202012, builder -> builder.metaSchema(metaSchema)).getSchema(schemaNode);
+        String inputData = "{\r\n"
+                + "  \"textValue\": \"hello\"\r\n"
+                + "}";
+        assertTrue(schema.validate(inputData, InputFormat.JSON, OutputFormat.BOOLEAN));
+    }
+}


### PR DESCRIPTION
Explicitly check that the type validator is of type `TypeValidator` before using to prevent a `java.lang.ClassCastException` in the event a meta-schema uses a different validator for instance if the standard validation vocab isn't used.