### PR TITLE
Refactored code: Pull-up var/method, Extract class, Polymorphism

### DIFF
--- a/src/main/java/com/networknt/schema/AnnotationKeyword.java
+++ b/src/main/java/com/networknt/schema/AnnotationKeyword.java
@@ -46,11 +46,11 @@ public class AnnotationKeyword extends AbstractKeyword {
 
         protected Object getAnnotationValue(JsonNode schemaNode) {
             if (schemaNode.isTextual()) {
-                return schemaNode.textValue(); 
+                return new TextualValueHandler().getAnnotationValue(schemaNode);
             } else if (schemaNode.isNumber()) {
-                return schemaNode.numberValue();
+                return new NumericValueHandler().getAnnotationValue(schemaNode);
             } else if (schemaNode.isObject()) {
-                return schemaNode;
+                return new ObjectValueHandler().getAnnotationValue(schemaNode);
             }
             return null;
         }

--- a/src/main/java/com/networknt/schema/AnnotationsHandler.java
+++ b/src/main/java/com/networknt/schema/AnnotationsHandler.java
@@ -1,0 +1,28 @@
+package com.networknt.schema;
+import com.fasterxml.jackson.databind.JsonNode;
+
+abstract class AnnotationValueHandler {
+    public abstract Object getAnnotationValue(JsonNode schemaNode);
+}
+
+class TextualValueHandler extends AnnotationValueHandler {
+    @Override
+    public Object getAnnotationValue(JsonNode schemaNode) {
+        return schemaNode.textValue();
+    }
+}
+
+class NumericValueHandler extends AnnotationValueHandler {
+    @Override
+    public Object getAnnotationValue(JsonNode schemaNode) {
+        return schemaNode.numberValue();
+    }
+}
+
+class ObjectValueHandler extends AnnotationValueHandler {
+    @Override
+    public Object getAnnotationValue(JsonNode schemaNode) {
+        return schemaNode;
+    }
+} 
+

--- a/src/main/java/com/networknt/schema/DiscriminatorHandler.java
+++ b/src/main/java/com/networknt/schema/DiscriminatorHandler.java
@@ -1,0 +1,124 @@
+package com.networknt.schema;
+
+import java.util.Map;
+import java.util.Iterator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class DiscriminatorHandler {
+ 
+    protected static void checkDiscriminatorMatch(final DiscriminatorContext currentDiscriminatorContext,
+            final ObjectNode discriminator,
+            final String discriminatorPropertyValue,
+            final JsonSchema jsonSchema) {
+        if (discriminatorPropertyValue == null) {
+            currentDiscriminatorContext.markIgnore();
+            return;
+        }
+
+        final JsonNode discriminatorMapping = discriminator.get("mapping");
+        if (null == discriminatorMapping) {
+            checkForImplicitDiscriminatorMappingMatch(currentDiscriminatorContext,
+                    discriminatorPropertyValue,
+                    jsonSchema);
+        } else {
+            checkForExplicitDiscriminatorMappingMatch(currentDiscriminatorContext,
+                    discriminatorPropertyValue,
+                    discriminatorMapping,
+                    jsonSchema);
+            if (!currentDiscriminatorContext.isDiscriminatorMatchFound()
+                    && noExplicitDiscriminatorKeyOverride(discriminatorMapping, jsonSchema)) {
+                checkForImplicitDiscriminatorMappingMatch(currentDiscriminatorContext,
+                        discriminatorPropertyValue,
+                        jsonSchema);
+            }
+        }
+    }
+
+ 
+    protected static void registerAndMergeDiscriminator(final DiscriminatorContext currentDiscriminatorContext,
+            final ObjectNode discriminator,
+            final JsonSchema schema,
+            final JsonNodePath instanceLocation) {
+        final JsonNode discriminatorOnSchema = schema.schemaNode.get("discriminator");
+        if (null != discriminatorOnSchema && null != currentDiscriminatorContext
+                .getDiscriminatorForPath(schema.schemaLocation)) {
+            // This is where A -> B -> C inheritance exists, A has the root discriminator
+            // and B adds to the mapping
+            final JsonNode propertyName = discriminatorOnSchema.get("propertyName");
+            if (null != propertyName) {
+                throw new JsonSchemaException(
+                        instanceLocation + " schema " + schema + " attempts redefining the discriminator property");
+            }
+            final ObjectNode mappingOnContextDiscriminator = (ObjectNode) discriminator.get("mapping");
+            final ObjectNode mappingOnCurrentSchemaDiscriminator = (ObjectNode) discriminatorOnSchema.get("mapping");
+            if (null == mappingOnContextDiscriminator && null != mappingOnCurrentSchemaDiscriminator) {
+                // Here we have a mapping on a nested discriminator and none on the root
+                // discriminator, so we can simply make it the root's
+                discriminator.set("mapping", discriminatorOnSchema);
+            } else if (null != mappingOnContextDiscriminator && null != mappingOnCurrentSchemaDiscriminator) {
+                // Here we have to merge. The spec doesn't specify anything on this, but here we
+                // don't accept redefinition of mappings that already exist
+                final Iterator<Map.Entry<String, JsonNode>> fieldsToAdd = mappingOnCurrentSchemaDiscriminator.fields();
+                while (fieldsToAdd.hasNext()) {
+                    final Map.Entry<String, JsonNode> fieldToAdd = fieldsToAdd.next();
+                    final String mappingKeyToAdd = fieldToAdd.getKey();
+                    final JsonNode mappingValueToAdd = fieldToAdd.getValue();
+        
+                    final JsonNode currentMappingValue = mappingOnContextDiscriminator.get(mappingKeyToAdd);
+                    if (null != currentMappingValue && currentMappingValue != mappingValueToAdd) {
+                        throw new JsonSchemaException(
+                                instanceLocation + "discriminator mapping redefinition from " + mappingKeyToAdd
+                                        + "/" + currentMappingValue + " to " + mappingValueToAdd);
+                    } else if (null == currentMappingValue) {
+                        mappingOnContextDiscriminator.set(mappingKeyToAdd, mappingValueToAdd);
+                    }
+                }
+            }
+        }
+        currentDiscriminatorContext.registerDiscriminator(schema.schemaLocation, discriminator);
+    }
+
+
+    protected static void checkForImplicitDiscriminatorMappingMatch(
+            final DiscriminatorContext currentDiscriminatorContext,
+            final String discriminatorPropertyValue,
+            final JsonSchema schema) {
+        if (schema.schemaLocation.getFragment().getName(-1).equals(discriminatorPropertyValue)) {
+            currentDiscriminatorContext.markMatch();
+        }
+    }
+
+
+
+    protected static void checkForExplicitDiscriminatorMappingMatch(
+            final DiscriminatorContext currentDiscriminatorContext,
+            final String discriminatorPropertyValue,
+            final JsonNode discriminatorMapping,
+            final JsonSchema schema) {
+        final Iterator<Map.Entry<String, JsonNode>> explicitMappings = discriminatorMapping.fields();
+        while (explicitMappings.hasNext()) {
+            final Map.Entry<String, JsonNode> candidateExplicitMapping = explicitMappings.next();
+            if (candidateExplicitMapping.getKey().equals(discriminatorPropertyValue)
+                    && ("#" + schema.schemaLocation.getFragment().toString())
+                            .equals(candidateExplicitMapping.getValue().asText())) {
+                currentDiscriminatorContext.markMatch();
+                break;
+            }
+        }
+    }
+
+
+    protected static boolean noExplicitDiscriminatorKeyOverride(final JsonNode discriminatorMapping,
+            final JsonSchema parentSchema) {
+        final Iterator<Map.Entry<String, JsonNode>> explicitMappings = discriminatorMapping.fields();
+        while (explicitMappings.hasNext()) {
+            final Map.Entry<String, JsonNode> candidateExplicitMapping = explicitMappings.next();
+            if (candidateExplicitMapping.getValue().asText()
+                    .equals(parentSchema.schemaLocation.getFragment().toString())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/networknt/schema/ItemsValidator.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator.java
@@ -19,7 +19,6 @@ package com.networknt.schema;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.networknt.schema.annotation.JsonNodeAnnotation;
-import com.networknt.schema.utils.JsonSchemaRefs;
 import com.networknt.schema.utils.SetView;
 
 import org.slf4j.Logger;
@@ -326,16 +325,6 @@ public class ItemsValidator extends BaseJsonValidator {
         return validationMessages;
     }
 
-    private static JsonNode getDefaultNode(JsonSchema schema) {
-        JsonNode result = schema.getSchemaNode().get("default");
-        if (result == null) {
-            JsonSchemaRef schemaRef = JsonSchemaRefs.from(schema);
-            if (schemaRef != null) {
-                result = getDefaultNode(schemaRef.getSchema());
-            }
-        }
-        return result;
-    }
 
     private void walkSchema(ExecutionContext executionContext, JsonSchema walkSchema, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation, boolean shouldValidateSchema, Set<ValidationMessage> validationMessages, String keyword) {

--- a/src/main/java/com/networknt/schema/ItemsValidator202012.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator202012.java
@@ -19,7 +19,6 @@ package com.networknt.schema;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.networknt.schema.annotation.JsonNodeAnnotation;
-import com.networknt.schema.utils.JsonSchemaRefs;
 import com.networknt.schema.utils.SetView;
 
 import org.slf4j.Logger;
@@ -155,16 +154,6 @@ public class ItemsValidator202012 extends BaseJsonValidator {
         return validationMessages;
     }
 
-    private static JsonNode getDefaultNode(JsonSchema schema) {
-        JsonNode result = schema.getSchemaNode().get("default");
-        if (result == null) {
-            JsonSchemaRef schemaRef = JsonSchemaRefs.from(schema);
-            if (schemaRef != null) {
-                result = getDefaultNode(schemaRef.getSchema());
-            }
-        }
-        return result;
-    }
 
     private void walkSchema(ExecutionContext executionContext, JsonSchema walkSchema, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation, boolean shouldValidateSchema, Set<ValidationMessage> validationMessages) {

--- a/src/main/java/com/networknt/schema/PrefixItemsValidator.java
+++ b/src/main/java/com/networknt/schema/PrefixItemsValidator.java
@@ -19,7 +19,6 @@ package com.networknt.schema;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.networknt.schema.annotation.JsonNodeAnnotation;
-import com.networknt.schema.utils.JsonSchemaRefs;
 import com.networknt.schema.utils.SetView;
 
 import org.slf4j.Logger;
@@ -150,16 +149,6 @@ public class PrefixItemsValidator extends BaseJsonValidator {
         return validationMessages;
     }
 
-    private static JsonNode getDefaultNode(JsonSchema schema) {
-        JsonNode result = schema.getSchemaNode().get("default");
-        if (result == null) {
-            JsonSchemaRef schemaRef = JsonSchemaRefs.from(schema);
-            if (schemaRef != null) {
-                result = getDefaultNode(schemaRef.getSchema());
-            }
-        }
-        return result;
-    }
 
     private void doWalk(ExecutionContext executionContext, Set<ValidationMessage> validationMessages, int i,
             JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {

--- a/src/main/java/com/networknt/schema/PropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/PropertiesValidator.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.networknt.schema.annotation.JsonNodeAnnotation;
-import com.networknt.schema.utils.JsonSchemaRefs;
 import com.networknt.schema.utils.SetView;
 import com.networknt.schema.walk.WalkListenerRunner;
 import org.slf4j.Logger;
@@ -202,17 +201,6 @@ public class PropertiesValidator extends BaseJsonValidator {
                 node.set(entry.getKey(), defaultNode);
             }
         }
-    }
-
-    private static JsonNode getDefaultNode(JsonSchema schema) {
-        JsonNode result = schema.getSchemaNode().get("default");
-        if (result == null) {
-            JsonSchemaRef schemaRef = JsonSchemaRefs.from(schema);
-            if (schemaRef != null) {
-                result = getDefaultNode(schemaRef.getSchema());
-            }
-        }
-        return result;
     }
 
     private void walkSchema(ExecutionContext executionContext, Map.Entry<String, JsonSchema> entry, JsonNode node,


### PR DESCRIPTION
1. PropertiesValidator, PrefixItemsValidator, ItemsValidator202012, and ItemsValidator class have duplicate code i.e. “getDefaultNode” method and all these classes extend the same class i.e. BaseJsonValidator. Hence, I have pulled up the “getDefaultNode” method in its BaseJsonValidator class. This promotes code reusability and eliminates duplication within those subclasses. This refactoring can simplify maintenance and reduce the risk of inconsistencies if the same logic is duplicated across multiple classes.

2. The BaseJsonValidator class contains many useful methods. Creating the new class called DiscriminatorHandler encapsulates all the methods and functionality related to discriminator handling. The BaseJsonValidator class now delegates the calls to discriminator-related methods to the DiscriminatorHandler class. By extracting the discriminator-related functionality into a separate class, the code organization, maintainability, and reusability are improved. The BaseJsonValidator class is now more focused on its core responsibilities, making it easier to understand and maintain.

3. In AnnotationKeyword class, getAnnotationValue method’s conditional logic has been replaced with polymorphic behavior. Each type of JSON node is now handled by a separate subclass of AnnotationsHandler which promotes cleaner code and easier maintenance and also be used for future functionality enhancement concerned with annotation value.

