### PR TITLE
segregated getDefaultNode in utils

### DIFF
--- a/src/main/java/com/networknt/schema/ItemsValidator.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator.java
@@ -19,9 +19,8 @@ package com.networknt.schema;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.networknt.schema.annotation.JsonNodeAnnotation;
-import com.networknt.schema.utils.JsonSchemaRefs;
 import com.networknt.schema.utils.SetView;
-
+import com.networknt.schema.utils.DefaultNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -241,7 +240,7 @@ public class ItemsValidator extends BaseJsonValidator {
                 ArrayNode arrayNode = (ArrayNode) node;
                 JsonNode defaultNode = null;
                 if (this.validationContext.getConfig().getApplyDefaultsStrategy().shouldApplyArrayDefaults()) {
-                    defaultNode = getDefaultNode(this.schema);
+                    defaultNode = DefaultNode.getDefaultNode(this.schema);
                 }
                 for (int i = 0; i < count; i++) {
                     JsonNode n = arrayNode.get(i);
@@ -266,7 +265,7 @@ public class ItemsValidator extends BaseJsonValidator {
                     JsonNode defaultNode = null;
                     JsonNode n = arrayNode.get(i);
                     if (this.validationContext.getConfig().getApplyDefaultsStrategy().shouldApplyArrayDefaults()) {
-                        defaultNode = getDefaultNode(this.tupleSchema.get(i));
+                        defaultNode = DefaultNode.getDefaultNode(this.tupleSchema.get(i));
                     }
                     if (n != null) {
                         if (n.isNull() && defaultNode != null) {
@@ -293,7 +292,7 @@ public class ItemsValidator extends BaseJsonValidator {
                         JsonNode defaultNode = null;
                         JsonNode n = arrayNode.get(i);
                         if (this.validationContext.getConfig().getApplyDefaultsStrategy().shouldApplyArrayDefaults()) {
-                            defaultNode = getDefaultNode(this.additionalSchema);
+                            defaultNode = DefaultNode.getDefaultNode(this.additionalSchema);
                         }
                         if (n != null) {
                             if (n.isNull() && defaultNode != null) {
@@ -324,17 +323,6 @@ public class ItemsValidator extends BaseJsonValidator {
             }
         }
         return validationMessages;
-    }
-
-    private static JsonNode getDefaultNode(JsonSchema schema) {
-        JsonNode result = schema.getSchemaNode().get("default");
-        if (result == null) {
-            JsonSchemaRef schemaRef = JsonSchemaRefs.from(schema);
-            if (schemaRef != null) {
-                result = getDefaultNode(schemaRef.getSchema());
-            }
-        }
-        return result;
     }
 
     private void walkSchema(ExecutionContext executionContext, JsonSchema walkSchema, JsonNode node, JsonNode rootNode,

--- a/src/main/java/com/networknt/schema/ItemsValidator202012.java
+++ b/src/main/java/com/networknt/schema/ItemsValidator202012.java
@@ -19,7 +19,7 @@ package com.networknt.schema;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.networknt.schema.annotation.JsonNodeAnnotation;
-import com.networknt.schema.utils.JsonSchemaRefs;
+import com.networknt.schema.utils.DefaultNode;
 import com.networknt.schema.utils.SetView;
 
 import org.slf4j.Logger;
@@ -120,7 +120,7 @@ public class ItemsValidator202012 extends BaseJsonValidator {
             JsonNode defaultNode = null;
             if (this.validationContext.getConfig().getApplyDefaultsStrategy().shouldApplyArrayDefaults()
                     && this.schema != null) {
-                defaultNode = getDefaultNode(this.schema);
+                defaultNode = DefaultNode.getDefaultNode(this.schema);
             }
             boolean evaluated = false;
             for (int i = this.prefixCount; i < node.size(); ++i) {
@@ -155,17 +155,7 @@ public class ItemsValidator202012 extends BaseJsonValidator {
         return validationMessages;
     }
 
-    private static JsonNode getDefaultNode(JsonSchema schema) {
-        JsonNode result = schema.getSchemaNode().get("default");
-        if (result == null) {
-            JsonSchemaRef schemaRef = JsonSchemaRefs.from(schema);
-            if (schemaRef != null) {
-                result = getDefaultNode(schemaRef.getSchema());
-            }
-        }
-        return result;
-    }
-
+   
     private void walkSchema(ExecutionContext executionContext, JsonSchema walkSchema, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation, boolean shouldValidateSchema, Set<ValidationMessage> validationMessages) {
         //@formatter:off

--- a/src/main/java/com/networknt/schema/PrefixItemsValidator.java
+++ b/src/main/java/com/networknt/schema/PrefixItemsValidator.java
@@ -19,7 +19,7 @@ package com.networknt.schema;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.networknt.schema.annotation.JsonNodeAnnotation;
-import com.networknt.schema.utils.JsonSchemaRefs;
+import com.networknt.schema.utils.DefaultNode;
 import com.networknt.schema.utils.SetView;
 
 import org.slf4j.Logger;
@@ -110,7 +110,7 @@ public class PrefixItemsValidator extends BaseJsonValidator {
             for (int i = 0; i < count; ++i) {
                 JsonNode n = node.get(i);
                 if (this.validationContext.getConfig().getApplyDefaultsStrategy().shouldApplyArrayDefaults()) {
-                    JsonNode defaultNode = getDefaultNode(this.tupleSchema.get(i));
+                    JsonNode defaultNode = DefaultNode.getDefaultNode(this.tupleSchema.get(i));
                     if (n != null) {
                         // Defaults only set if array index is explicitly null
                         if (n.isNull() && defaultNode != null) {
@@ -150,16 +150,6 @@ public class PrefixItemsValidator extends BaseJsonValidator {
         return validationMessages;
     }
 
-    private static JsonNode getDefaultNode(JsonSchema schema) {
-        JsonNode result = schema.getSchemaNode().get("default");
-        if (result == null) {
-            JsonSchemaRef schemaRef = JsonSchemaRefs.from(schema);
-            if (schemaRef != null) {
-                result = getDefaultNode(schemaRef.getSchema());
-            }
-        }
-        return result;
-    }
 
     private void doWalk(ExecutionContext executionContext, Set<ValidationMessage> validationMessages, int i,
             JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {

--- a/src/main/java/com/networknt/schema/PropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/PropertiesValidator.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.networknt.schema.annotation.JsonNodeAnnotation;
-import com.networknt.schema.utils.JsonSchemaRefs;
+import com.networknt.schema.utils.DefaultNode;
 import com.networknt.schema.utils.SetView;
 import com.networknt.schema.walk.WalkListenerRunner;
 import org.slf4j.Logger;
@@ -192,7 +192,7 @@ public class PropertiesValidator extends BaseJsonValidator {
         for (Map.Entry<String, JsonSchema> entry : this.schemas.entrySet()) {
             JsonNode propertyNode = node.get(entry.getKey());
 
-            JsonNode defaultNode = getDefaultNode(entry.getValue());
+            JsonNode defaultNode = DefaultNode.getDefaultNode(entry.getValue());
             if (defaultNode == null) {
                 continue;
             }
@@ -202,17 +202,6 @@ public class PropertiesValidator extends BaseJsonValidator {
                 node.set(entry.getKey(), defaultNode);
             }
         }
-    }
-
-    private static JsonNode getDefaultNode(JsonSchema schema) {
-        JsonNode result = schema.getSchemaNode().get("default");
-        if (result == null) {
-            JsonSchemaRef schemaRef = JsonSchemaRefs.from(schema);
-            if (schemaRef != null) {
-                result = getDefaultNode(schemaRef.getSchema());
-            }
-        }
-        return result;
     }
 
     private void walkSchema(ExecutionContext executionContext, Map.Entry<String, JsonSchema> entry, JsonNode node,

--- a/src/main/java/com/networknt/schema/utils/DefaultNode.java
+++ b/src/main/java/com/networknt/schema/utils/DefaultNode.java
@@ -1,0 +1,19 @@
+package com.networknt.schema.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaRef;
+
+public class DefaultNode {
+    
+      public static JsonNode getDefaultNode(JsonSchema schema) {
+        JsonNode result = schema.getSchemaNode().get("default");
+        if (result == null) {
+            JsonSchemaRef schemaRef = JsonSchemaRefs.from(schema);
+            if (schemaRef != null) {
+                result = getDefaultNode(schemaRef.getSchema());
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Segregated `getDefaultNode`  method to the utlis package to avoid duplicate code in the class.