### PR TITLE
refactored copySchemaResources with polymorphism

### DIFF
--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -118,19 +118,15 @@ public class RefValidator extends BaseJsonValidator {
     }
 
     private static void copySchemaResources(ValidationContext validationContext, JsonSchema schemaResource) {
-        if (!schemaResource.getValidationContext().getSchemaResources().isEmpty()) {
-            validationContext.getSchemaResources()
-                    .putAll(schemaResource.getValidationContext().getSchemaResources());
-        }
-        if (!schemaResource.getValidationContext().getSchemaReferences().isEmpty()) {
-            validationContext.getSchemaReferences()
-                    .putAll(schemaResource.getValidationContext().getSchemaReferences());
-        }
-        if (!schemaResource.getValidationContext().getDynamicAnchors().isEmpty()) {
-            validationContext.getDynamicAnchors()
-                    .putAll(schemaResource.getValidationContext().getDynamicAnchors());
-        }
+        copy(new SchemaResourcesCopier(), schemaResource.getValidationContext(), validationContext);
+        copy(new SchemaReferencesCopier(), schemaResource.getValidationContext(), validationContext);
+        copy(new DynamicAnchorsCopier(), schemaResource.getValidationContext(), validationContext);
     }
+    
+    private static void copy(ResourceCopier copier, ValidationContext source, ValidationContext destination) {
+        copier.copyResources(source, destination);
+    }
+    
     
     private static String resolve(JsonSchema parentSchema, String refValue) {
         // $ref prevents a sibling $id from changing the base uri

--- a/src/main/java/com/networknt/schema/ResourceCopier.java
+++ b/src/main/java/com/networknt/schema/ResourceCopier.java
@@ -1,0 +1,28 @@
+package com.networknt.schema;
+
+
+
+abstract class ResourceCopier {
+    public abstract void copyResources(ValidationContext source, ValidationContext destination);
+}
+
+class SchemaResourcesCopier extends ResourceCopier {
+    @Override
+    public void copyResources(ValidationContext source, ValidationContext destination) {
+        destination.getSchemaResources().putAll(source.getSchemaResources());
+    }
+}
+
+class SchemaReferencesCopier extends ResourceCopier {
+    @Override
+    public void copyResources(ValidationContext source, ValidationContext destination) {
+        destination.getSchemaReferences().putAll(source.getSchemaReferences());
+    }
+}
+
+class DynamicAnchorsCopier extends ResourceCopier {
+    @Override
+    public void copyResources(ValidationContext source, ValidationContext destination) {
+        destination.getDynamicAnchors().putAll(source.getDynamicAnchors());
+    }
+}


### PR DESCRIPTION
The conditional logic in `copySchemaResources` method has been replaced with polymorphic behavior. Each type of resource copying is now handled by a separate subclass of ResourceCopier, promoting cleaner code and easier maintenance.