### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,23 +13,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 17, 20 ]
+        java: [ 8, 11, 17, 21 ]
     name: Java ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn clean verify
+        run: mvn --batch-mode --update-snapshots verify -Dstyle.color=always
 
       - name: Upload coverage to Codecov
         if: matrix.java == '8'
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v4
         with:
-          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false


### PR DESCRIPTION
It looks like `codecov` now requires a [token](https://docs.codecov.com/docs/adding-the-codecov-token) to be configured to work.

This changes the `Upload coverage to Codecov` to not fail on error as a workaround while the token isn't configured.