### PR TITLE
Update dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,15 +71,27 @@
     <java.testversion>1.8</java.testversion>
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.hamcrest>2.2</version.hamcrest>
-    <version.itu>1.8.0</version.itu>
-    <version.jackson>2.15.3</version.jackson>
-    <version.joni>2.1.41</version.joni>
-    <version.junit>5.9.2</version.junit>
+
+    <version.itu>1.10.2</version.itu>
+    <version.jackson>2.17.0</version.jackson>
+    <version.joni>2.2.1</version.joni>
     <version.logback>1.3.14</version.logback>
-    <version.slf4j>2.0.9</version.slf4j>
-    <version.surefire>3.0.0</version.surefire>
+    <version.slf4j>2.0.13</version.slf4j>
+
+    <version.hamcrest>2.2</version.hamcrest>
+    <version.junit>5.10.2</version.junit>
     <version.undertow>2.2.31.Final</version.undertow>
+
+    <version.jacoco-maven-plugin>0.8.12</version.jacoco-maven-plugin>
+    <version.maven-compiler-plugin>3.13.0</version.maven-compiler-plugin>
+    <version.maven-bundle-plugin>5.1.9</version.maven-bundle-plugin>
+    <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
+    <version.maven-javadoc-plugin>3.6.3</version.maven-javadoc-plugin>
+    <version.maven-source-plugin>3.3.1</version.maven-source-plugin>
+    <version.maven-surefire-junit5-tree-reporter>1.2.1</version.maven-surefire-junit5-tree-reporter>
+    <version.maven-surefire-plugin>3.2.5</version.maven-surefire-plugin>
+    <version.moditect-maven-plugin>1.2.1.Final</version.moditect-maven-plugin>
+    <version.nexus-staging-maven-plugin>1.6.13</version.nexus-staging-maven-plugin>
   </properties>
 
   <dependencies>
@@ -184,7 +196,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>5.1.8</version>
+        <version>${version.maven-bundle-plugin}</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>
@@ -202,7 +214,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <version>${version.nexus-staging-maven-plugin}</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>
@@ -214,7 +226,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>${version.maven-source-plugin}</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -228,7 +240,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>${version.maven-javadoc-plugin}</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -245,7 +257,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>${version.maven-compiler-plugin}</version>
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
@@ -270,7 +282,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${version.surefire}</version>
+        <version>${version.maven-surefire-plugin}</version>
         <configuration>
           <argLine>@{argLine} -Duser.language=en -Duser.region=GB</argLine>
           <reportFormat>plain</reportFormat>
@@ -291,7 +303,7 @@
           <dependency>
             <groupId>me.fabriciorby</groupId>
             <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
-            <version>1.1.0</version>
+            <version>${version.maven-surefire-junit5-tree-reporter}</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -299,7 +311,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.10</version>
+        <version>${version.jacoco-maven-plugin}</version>
 
         <configuration>
           <excludes>
@@ -346,7 +358,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>${version.surefire}</version>
+        <version>${version.maven-surefire-plugin}</version>
       </plugin>
     </plugins>
   </reporting>
@@ -366,7 +378,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>${version.maven-gpg-plugin}</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -391,7 +403,7 @@
           <plugin>
             <groupId>org.moditect</groupId>
             <artifactId>moditect-maven-plugin</artifactId>
-            <version>1.0.0.Final</version>
+            <version>${version.moditect-maven-plugin}</version>
             <executions>
               <execution>
                 <id>add-module-infos</id>

--- a/src/test/java/com/networknt/schema/MaximumValidatorTest.java
+++ b/src/test/java/com/networknt/schema/MaximumValidatorTest.java
@@ -208,7 +208,8 @@ public class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
             v = factory.getSchema(bigDecimalMapper.readTree(schema), config);
             Set<ValidationMessage> messages3 = v.validate(doc);
             //when the schema and value are both using BigDecimal, the value should be parsed in same mechanism.
-            if (maximum.toLowerCase().equals(value.toLowerCase()) || Double.valueOf(maximum).equals(Double.POSITIVE_INFINITY)) {
+            String theValue = value.toLowerCase().replace("\"", "");
+            if (maximum.toLowerCase().equals(theValue)) {
                 assertTrue(messages3.isEmpty(), format("Maximum %s and value %s are equal, thus no schema violation should be reported", maximum, value));
             } else {
                 assertFalse(messages3.isEmpty(), format("Maximum %s is smaller than value %s ,  should be validation error reported", maximum, value));
@@ -278,7 +279,9 @@ public class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
          */
         v = factory.getSchema(bigDecimalMapper.readTree(schema));
         messages = v.validate(doc);
-        assertTrue(messages.isEmpty(), "Validation should success because the bug of bigDecimalMapper, it will treat 1.7976931348623159e+308 as INFINITY");
+        // Before 2.16.0 messages will be empty due to bug https://github.com/FasterXML/jackson-databind/issues/1770
+        // assertTrue(messages.isEmpty(), "Validation should success because the bug of bigDecimalMapper, it will treat 1.7976931348623159e+308 as INFINITY");
+        assertFalse(messages.isEmpty(), "Validation should fail as Incorrect deserialization for BigDecimal numbers is fixed in 2.16.0");
     }
 
     private static final String POSITIVE_TEST_CASE_TEMPLATE = "Expecting no validation errors, maximum %s is greater than value %s";

--- a/src/test/java/com/networknt/schema/MinimumValidatorTest.java
+++ b/src/test/java/com/networknt/schema/MinimumValidatorTest.java
@@ -199,7 +199,8 @@ public class MinimumValidatorTest {
             v = factory.getSchema(bigDecimalMapper.readTree(schema), config);
             Set<ValidationMessage> messages3 = v.validate(doc);
             //when the schema and value are both using BigDecimal, the value should be parsed in same mechanism.
-            if (minimum.toLowerCase().equals(value.toLowerCase()) || Double.valueOf(minimum).equals(Double.NEGATIVE_INFINITY)) {
+            String theValue = value.toLowerCase().replace("\"", "");
+            if (minimum.toLowerCase().equals(theValue)) {
                 assertTrue(messages3.isEmpty(), format("Minimum %s and value %s are equal, thus no schema violation should be reported", minimum, value));
             } else {
                 assertFalse(messages3.isEmpty(), format("Minimum %s is larger than value %s ,  should be validation error reported", minimum, value));
@@ -258,7 +259,9 @@ public class MinimumValidatorTest {
 
         v = factory.getSchema(bigDecimalMapper.readTree(schema));
         messages = v.validate(doc);
-        assertTrue(messages.isEmpty(), "Validation should succeed due to the bug of BigDecimal option of mapper");
+        // Before 2.16.0 messages will be empty due to bug https://github.com/FasterXML/jackson-databind/issues/1770
+        //assertTrue(messages.isEmpty(), "Validation should succeed due to the bug of BigDecimal option of mapper");
+        assertFalse(messages.isEmpty(), "Validation should fail as Incorrect deserialization for BigDecimal numbers is fixed in 2.16.0");
     }
 
     private void expectSomeMessages(String[][] values, String number, ObjectMapper mapper, ObjectMapper mapper2) throws IOException {


### PR DESCRIPTION
This updates the versions used by the dependencies to a recent version.

As Jackson has fixed the `Incorrect deserialization for BigDecimal numbers` issue since 2.16.0 the `MaximumValidatorTest` and `MinimumValidatorTest` needed to be updated with the new expectation that the bug no longer applies 