### PR TITLE
Allow customization of assertion for outputunit

### DIFF
--- a/src/main/java/com/networknt/schema/OutputFormat.java
+++ b/src/main/java/com/networknt/schema/OutputFormat.java
@@ -16,11 +16,13 @@
 package com.networknt.schema;
 
 import java.util.Set;
+import java.util.function.Function;
 
 import com.networknt.schema.output.HierarchicalOutputUnitFormatter;
 import com.networknt.schema.output.ListOutputUnitFormatter;
 import com.networknt.schema.output.OutputFlag;
 import com.networknt.schema.output.OutputUnit;
+import com.networknt.schema.output.OutputUnitData;
 
 /**
  * Formats the validation results.
@@ -132,6 +134,21 @@ public interface OutputFormat<T> {
      * The List output format.
      */
     public static class List implements OutputFormat<OutputUnit> {
+        private final Function<ValidationMessage, Object> assertionMapper;
+
+        public List() {
+            this(OutputUnitData::formatAssertion);
+        }
+
+        /**
+         * Constructor.
+         * 
+         * @param assertionMapper to map the assertion
+         */
+        public List(Function<ValidationMessage, Object> assertionMapper) {
+            this.assertionMapper = assertionMapper;
+        }
+
         @Override
         public void customize(ExecutionContext executionContext, ValidationContext validationContext) {
         }
@@ -139,7 +156,8 @@ public interface OutputFormat<T> {
         @Override
         public OutputUnit format(JsonSchema jsonSchema, Set<ValidationMessage> validationMessages,
                 ExecutionContext executionContext, ValidationContext validationContext) {
-            return ListOutputUnitFormatter.format(validationMessages, executionContext, validationContext);
+            return ListOutputUnitFormatter.format(validationMessages, executionContext, validationContext,
+                    this.assertionMapper);
         }
     }
 
@@ -147,6 +165,21 @@ public interface OutputFormat<T> {
      * The Hierarchical output format.
      */
     public static class Hierarchical implements OutputFormat<OutputUnit> {
+        private final Function<ValidationMessage, Object> assertionMapper;
+
+        public Hierarchical() {
+            this(OutputUnitData::formatAssertion);
+        }
+
+        /**
+         * Constructor.
+         * 
+         * @param assertionMapper to map the assertion
+         */
+        public Hierarchical(Function<ValidationMessage, Object> assertionMapper) {
+            this.assertionMapper = assertionMapper;
+        }
+
         @Override
         public void customize(ExecutionContext executionContext, ValidationContext validationContext) {
         }
@@ -154,7 +187,8 @@ public interface OutputFormat<T> {
         @Override
         public OutputUnit format(JsonSchema jsonSchema, Set<ValidationMessage> validationMessages,
                 ExecutionContext executionContext, ValidationContext validationContext) {
-            return HierarchicalOutputUnitFormatter.format(jsonSchema, validationMessages, executionContext, validationContext);
+            return HierarchicalOutputUnitFormatter.format(jsonSchema, validationMessages, executionContext,
+                    validationContext, this.assertionMapper);
         }
     }
 }

--- a/src/main/java/com/networknt/schema/output/ListOutputUnitFormatter.java
+++ b/src/main/java/com/networknt/schema/output/ListOutputUnitFormatter.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Function;
 import java.util.Set;
 
 import com.networknt.schema.ExecutionContext;
@@ -30,13 +31,7 @@ import com.networknt.schema.ValidationMessage;
  * ListOutputUnitFormatter.
  */
 public class ListOutputUnitFormatter {
-    public static OutputUnit format(Set<ValidationMessage> validationMessages, ExecutionContext executionContext,
-            ValidationContext validationContext) {
-        OutputUnit root = new OutputUnit();
-        root.setValid(validationMessages.isEmpty());
-
-        OutputUnitData data = OutputUnitData.from(validationMessages, executionContext);
-
+    public static OutputUnit format(OutputUnit root, OutputUnitData data) {
         Map<OutputUnitKey, Boolean> valid = data.getValid();
         Map<OutputUnitKey, Map<String, Object>> errors = data.getErrors();
         Map<OutputUnitKey, Map<String, Object>> annotations = data.getAnnotations();
@@ -94,5 +89,12 @@ public class ListOutputUnitFormatter {
         }
 
         return root;
+    }
+
+    public static OutputUnit format(Set<ValidationMessage> validationMessages, ExecutionContext executionContext,
+            ValidationContext validationContext, Function<ValidationMessage, Object> assertionMapper) {
+        OutputUnit root = new OutputUnit();
+        root.setValid(validationMessages.isEmpty());
+        return format(root, OutputUnitData.from(validationMessages, executionContext, assertionMapper));
     }
 }

--- a/src/test/java/com/networknt/schema/OutputUnitTest.java
+++ b/src/test/java/com/networknt/schema/OutputUnitTest.java
@@ -17,6 +17,7 @@ package com.networknt.schema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -339,4 +340,34 @@ public class OutputUnitTest {
         assertEquals(expected, output);
     }
 
+    @Test
+    void listAssertionMapper() {
+        String formatSchema = "{\r\n"
+                + "  \"type\": \"string\"\r\n"
+                + "}";
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.setPathType(PathType.JSON_POINTER);
+        JsonSchema schema = factory.getSchema(formatSchema, config);
+        OutputUnit outputUnit = schema.validate("1234", InputFormat.JSON, new OutputFormat.List(a -> a));
+        assertFalse(outputUnit.isValid());
+        OutputUnit details = outputUnit.getDetails().get(0);
+        Object assertion = details.getErrors().get("type");
+        assertInstanceOf(ValidationMessage.class, assertion);
+    }
+
+    @Test
+    void hierarchicalAssertionMapper() {
+        String formatSchema = "{\r\n"
+                + "  \"type\": \"string\"\r\n"
+                + "}";
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.setPathType(PathType.JSON_POINTER);
+        JsonSchema schema = factory.getSchema(formatSchema, config);
+        OutputUnit outputUnit = schema.validate("1234", InputFormat.JSON, new OutputFormat.Hierarchical(a -> a));
+        assertFalse(outputUnit.isValid());
+        Object assertion = outputUnit.getErrors().get("type");
+        assertInstanceOf(ValidationMessage.class, assertion);
+    }
 }


### PR DESCRIPTION
Closes #1030

This adds a constructor argument for `OutputFormat.Hierarchical` and `OutputFormat.List` to add a function to allow mapping of the `ValidationMessage` to an `Object`. This allows the message to be customized or allows the `ValidationMessage` to be passed through as is if the identity function is used.