### PR TITLE
Allow tracking of json node location information

### DIFF
--- a/src/main/java/com/networknt/schema/JsonMetaSchema.java
+++ b/src/main/java/com/networknt/schema/JsonMetaSchema.java
@@ -369,7 +369,7 @@ public class JsonMetaSchema {
      * Use {@link #getV4()} for the Draft 4 Metaschema, or if you need a builder based on Draft4, use
      *
      * <code>
-     * JsonMetaSchema.builder("http://your-metaschema-iri", JsonMetaSchema.getDraftV4()).build();
+     * JsonMetaSchema.builder("http://your-metaschema-iri", JsonMetaSchema.getV4()).build();
      * </code>
      *
      * @param iri the IRI of the metaschema that will be defined via this builder.

--- a/src/main/java/com/networknt/schema/JsonNodeLocation.java
+++ b/src/main/java/com/networknt/schema/JsonNodeLocation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema;
+
+/**
+ * JsonNode location information.
+ */
+public class JsonNodeLocation {
+    private final int line;
+    private final int column;
+
+    public JsonNodeLocation(int line, int column) {
+        super();
+        this.line = line;
+        this.column = column;
+    }
+
+    public int getLine() {
+        return line;
+    }
+
+    public int getColumn() {
+        return column;
+    }
+
+    @Override
+    public String toString() {
+        return "JsonNodeLocation [line=" + line + ", column=" + column + "]";
+    }
+}

--- a/src/main/java/com/networknt/schema/serialization/node/JsonLocationAware.java
+++ b/src/main/java/com/networknt/schema/serialization/node/JsonLocationAware.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import com.fasterxml.jackson.core.JsonLocation;
+
+/**
+ * JsonNodes that are aware of the token location will implement this interface.
+ */
+public interface JsonLocationAware {
+    /**
+     * Gets the token location.
+     *
+     * @return the token location
+     */
+    JsonLocation tokenLocation();
+}

--- a/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareArrayNode.java
+++ b/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareArrayNode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * {@link ArrayNode} that is {@link JsonLocationAware}.
+ */
+public class JsonLocationAwareArrayNode extends ArrayNode implements JsonLocationAware {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    private final JsonLocation tokenLocation;
+
+    public JsonLocationAwareArrayNode(JsonNodeFactory nf, int capacity, JsonLocation tokenLocation) {
+        super(nf, capacity);
+        this.tokenLocation = tokenLocation;
+    }
+
+    public JsonLocationAwareArrayNode(JsonNodeFactory nf, List<JsonNode> children, JsonLocation tokenLocation) {
+        super(nf, children);
+        this.tokenLocation = tokenLocation;
+    }
+
+    public JsonLocationAwareArrayNode(JsonNodeFactory nf, JsonLocation tokenLocation) {
+        super(nf);
+        this.tokenLocation = tokenLocation;
+    }
+
+    @Override
+    public JsonLocation tokenLocation() {
+        return this.tokenLocation;
+    }
+}

--- a/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareBigIntegerNode.java
+++ b/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareBigIntegerNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import java.math.BigInteger;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.databind.node.BigIntegerNode;
+
+/**
+ * {@link BigIntegerNode} that is {@link JsonLocationAware}.
+ */
+public class JsonLocationAwareBigIntegerNode extends BigIntegerNode implements JsonLocationAware {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    private final JsonLocation tokenLocation;
+
+    public JsonLocationAwareBigIntegerNode(BigInteger v, JsonLocation tokenLocation) {
+        super(v);
+        this.tokenLocation = tokenLocation;
+    }
+
+    @Override
+    public JsonLocation tokenLocation() {
+        return this.tokenLocation;
+    }
+}

--- a/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareBinaryNode.java
+++ b/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareBinaryNode.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.databind.node.BinaryNode;
+
+/**
+ * {@link BinaryNode} that is {@link JsonLocationAware}.
+ */
+public class JsonLocationAwareBinaryNode extends BinaryNode implements JsonLocationAware {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    private final JsonLocation tokenLocation;
+
+    public JsonLocationAwareBinaryNode(byte[] data, JsonLocation tokenLocation) {
+        super(data);
+        this.tokenLocation = tokenLocation;
+    }
+    
+    public JsonLocationAwareBinaryNode(byte[] data, int offset, int length, JsonLocation tokenLocation) {
+        super(data, offset, length);
+        this.tokenLocation = tokenLocation;
+    }
+
+
+    @Override
+    public JsonLocation tokenLocation() {
+        return this.tokenLocation;
+    }
+}

--- a/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareBooleanNode.java
+++ b/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareBooleanNode.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+
+/**
+ * {@link BooleanNode} that is {@link JsonLocationAware}.
+ */
+public class JsonLocationAwareBooleanNode extends BooleanNode implements JsonLocationAware {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    private final JsonLocation tokenLocation;
+
+    public JsonLocationAwareBooleanNode(boolean v, JsonLocation tokenLocation) {
+        super(v);
+        this.tokenLocation = tokenLocation;
+    }
+
+    @Override
+    public JsonLocation tokenLocation() {
+        return this.tokenLocation;
+    }
+}

--- a/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareDecimalNode.java
+++ b/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareDecimalNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.databind.node.DecimalNode;
+
+/**
+ * {@link DecimalNode} that is {@link JsonLocationAware}.
+ */
+public class JsonLocationAwareDecimalNode extends DecimalNode implements JsonLocationAware {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    private final JsonLocation tokenLocation;
+
+    public JsonLocationAwareDecimalNode(BigDecimal v, JsonLocation tokenLocation) {
+        super(v);
+        this.tokenLocation = tokenLocation;
+    }
+
+    @Override
+    public JsonLocation tokenLocation() {
+        return this.tokenLocation;
+    }
+}

--- a/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareDoubleNode.java
+++ b/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareDoubleNode.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+
+/**
+ * {@link DoubleNode} that is {@link JsonLocationAware}.
+ */
+public class JsonLocationAwareDoubleNode extends DoubleNode implements JsonLocationAware {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    private final JsonLocation tokenLocation;
+
+    public JsonLocationAwareDoubleNode(double v, JsonLocation tokenLocation) {
+        super(v);
+        this.tokenLocation = tokenLocation;
+    }
+
+    @Override
+    public JsonLocation tokenLocation() {
+        return this.tokenLocation;
+    }
+}

--- a/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareFloatNode.java
+++ b/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareFloatNode.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.databind.node.FloatNode;
+
+/**
+ * {@link FloatNode} that is {@link JsonLocationAware}.
+ */
+public class JsonLocationAwareFloatNode extends FloatNode implements JsonLocationAware {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    private final JsonLocation tokenLocation;
+
+    public JsonLocationAwareFloatNode(float v, JsonLocation tokenLocation) {
+        super(v);
+        this.tokenLocation = tokenLocation;
+    }
+
+    @Override
+    public JsonLocation tokenLocation() {
+        return this.tokenLocation;
+    }
+}

--- a/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareIntNode.java
+++ b/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareIntNode.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.databind.node.IntNode;
+
+/**
+ * {@link IntNode} that is {@link JsonLocationAware}.
+ */
+public class JsonLocationAwareIntNode extends IntNode implements JsonLocationAware {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    private final JsonLocation tokenLocation;
+
+    public JsonLocationAwareIntNode(int v, JsonLocation tokenLocation) {
+        super(v);
+        this.tokenLocation = tokenLocation;
+    }
+
+    @Override
+    public JsonLocation tokenLocation() {
+        return this.tokenLocation;
+    }
+}

--- a/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareLongNode.java
+++ b/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareLongNode.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.databind.node.LongNode;
+
+/**
+ * {@link LongNode} that is {@link JsonLocationAware}.
+ */
+public class JsonLocationAwareLongNode extends LongNode implements JsonLocationAware {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    private final JsonLocation tokenLocation;
+
+    public JsonLocationAwareLongNode(long v, JsonLocation tokenLocation) {
+        super(v);
+        this.tokenLocation = tokenLocation;
+    }
+
+    @Override
+    public JsonLocation tokenLocation() {
+        return this.tokenLocation;
+    }
+}

--- a/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareNullNode.java
+++ b/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareNullNode.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.databind.node.NullNode;
+
+/**
+ * {@link NullNode} that is {@link JsonLocationAware}.
+ */
+public class JsonLocationAwareNullNode extends NullNode implements JsonLocationAware {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    private final JsonLocation tokenLocation;
+
+    public JsonLocationAwareNullNode(JsonLocation tokenLocation) {
+        super();
+        this.tokenLocation = tokenLocation;
+    }
+
+    @Override
+    public JsonLocation tokenLocation() {
+        return this.tokenLocation;
+    }
+}

--- a/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareObjectNode.java
+++ b/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareObjectNode.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * {@link ObjectNode} that is {@link JsonLocationAware}.
+ */
+public class JsonLocationAwareObjectNode extends ObjectNode implements JsonLocationAware {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    private final JsonLocation tokenLocation;
+
+    public JsonLocationAwareObjectNode(JsonNodeFactory nc, Map<String, JsonNode> children, JsonLocation tokenLocation) {
+        super(nc, children);
+        this.tokenLocation = tokenLocation;
+    }
+
+    public JsonLocationAwareObjectNode(JsonNodeFactory nc, JsonLocation tokenLocation) {
+        super(nc);
+        this.tokenLocation = tokenLocation;
+    }
+
+    @Override
+    public JsonLocation tokenLocation() {
+        return this.tokenLocation;
+    }
+}

--- a/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwarePOJONode.java
+++ b/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwarePOJONode.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.databind.node.POJONode;
+
+/**
+ * {@link POJONode} that is {@link JsonLocationAware}.
+ */
+public class JsonLocationAwarePOJONode extends POJONode implements JsonLocationAware {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    private final JsonLocation tokenLocation;
+
+    public JsonLocationAwarePOJONode(Object v, JsonLocation tokenLocation) {
+        super(v);
+        this.tokenLocation = tokenLocation;
+    }
+
+    @Override
+    public JsonLocation tokenLocation() {
+        return this.tokenLocation;
+    }
+}

--- a/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareShortNode.java
+++ b/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareShortNode.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.databind.node.ShortNode;
+
+/**
+ * {@link ShortNode} that is {@link JsonLocationAware}.
+ */
+public class JsonLocationAwareShortNode extends ShortNode implements JsonLocationAware {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    private final JsonLocation tokenLocation;
+
+    public JsonLocationAwareShortNode(short v, JsonLocation tokenLocation) {
+        super(v);
+        this.tokenLocation = tokenLocation;
+    }
+
+    @Override
+    public JsonLocation tokenLocation() {
+        return this.tokenLocation;
+    }
+}

--- a/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareTextNode.java
+++ b/src/main/java/com/networknt/schema/serialization/node/JsonLocationAwareTextNode.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+/**
+ * {@link TextNode} that is {@link JsonLocationAware}.
+ */
+public class JsonLocationAwareTextNode extends TextNode implements JsonLocationAware {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    private final JsonLocation tokenLocation;
+
+    public JsonLocationAwareTextNode(String v, JsonLocation tokenLocation) {
+        super(v);
+        this.tokenLocation = tokenLocation;
+    }
+
+    @Override
+    public JsonLocation tokenLocation() {
+        return this.tokenLocation;
+    }
+}

--- a/src/main/java/com/networknt/schema/serialization/node/JsonNodeFactoryFactory.java
+++ b/src/main/java/com/networknt/schema/serialization/node/JsonNodeFactoryFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Factory that produces a {@link JsonNodeFactory}.
+ */
+public interface JsonNodeFactoryFactory {
+    /**
+     * Gets the JsonNodeFactory.
+     *
+     * @param jsonParser the json parser
+     * @return the json node factory
+     */
+    JsonNodeFactory getJsonNodeFactory(JsonParser jsonParser);
+}

--- a/src/main/java/com/networknt/schema/serialization/node/LocationJsonNodeFactory.java
+++ b/src/main/java/com/networknt/schema/serialization/node/LocationJsonNodeFactory.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BinaryNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.NumericNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.fasterxml.jackson.databind.node.ValueNode;
+import com.fasterxml.jackson.databind.util.RawValue;
+
+/**
+ * {@link JsonNodeFactory} that creates {@link JsonLocationAware} nodes.
+ * <p>
+ * Note that this will adversely affect performance as nodes with the same value
+ * can no longer be cached and reused.
+ */
+public class LocationJsonNodeFactory extends JsonNodeFactory {
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+
+    private final JsonParser jsonParser;
+
+    /**
+     * Constructor.
+     *
+     * @param jsonParser the json parser
+     */
+    public LocationJsonNodeFactory(JsonParser jsonParser) {
+        this.jsonParser = jsonParser;
+    }
+
+    @Override
+    public BooleanNode booleanNode(boolean v) {
+        return new JsonLocationAwareBooleanNode(v, this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public NullNode nullNode() {
+        return new JsonLocationAwareNullNode(this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public JsonNode missingNode() {
+        return super.missingNode();
+    }
+
+    @Override
+    public NumericNode numberNode(byte v) {
+        return new JsonLocationAwareIntNode(v, this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public ValueNode numberNode(Byte v) {
+        return (v == null) ? nullNode() : numberNode(v.intValue());
+    }
+
+    @Override
+    public NumericNode numberNode(short v) {
+        return new JsonLocationAwareShortNode(v, this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public ValueNode numberNode(Short value) {
+        return (value == null) ? nullNode() : numberNode(value.shortValue());
+    }
+
+    @Override
+    public NumericNode numberNode(int v) {
+        return new JsonLocationAwareIntNode(v, this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public ValueNode numberNode(Integer v) {
+        return (v == null) ? nullNode() : numberNode(v.intValue());
+    }
+
+    @Override
+    public NumericNode numberNode(long v) {
+        return new JsonLocationAwareLongNode(v, this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public ValueNode numberNode(Long v) {
+        return (v == null) ? nullNode() : numberNode(v.longValue());
+    }
+
+    @Override
+    public ValueNode numberNode(BigInteger v) {
+        return (v == null) ? nullNode() : new JsonLocationAwareBigIntegerNode(v, this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public NumericNode numberNode(float v) {
+        return new JsonLocationAwareFloatNode(v, this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public ValueNode numberNode(Float v) {
+        return (v == null) ? nullNode() : numberNode(v.floatValue());
+    }
+
+    @Override
+    public NumericNode numberNode(double v) {
+        return new JsonLocationAwareDoubleNode(v, this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public ValueNode numberNode(Double v) {
+        return (v == null) ? nullNode() : numberNode(v.doubleValue());
+    }
+
+    @Override
+    public ValueNode numberNode(BigDecimal v) {
+        return (v == null) ? nullNode() : new JsonLocationAwareDecimalNode(v, this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public TextNode textNode(String text) {
+        return new JsonLocationAwareTextNode(text, this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public BinaryNode binaryNode(byte[] data) {
+        return new JsonLocationAwareBinaryNode(data, this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public BinaryNode binaryNode(byte[] data, int offset, int length) {
+        return new JsonLocationAwareBinaryNode(data, offset, length, this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public ArrayNode arrayNode() {
+        return new JsonLocationAwareArrayNode(this, this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public ArrayNode arrayNode(int capacity) {
+        return new JsonLocationAwareArrayNode(this, capacity, this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public ObjectNode objectNode() {
+        return new JsonLocationAwareObjectNode(this, this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public ValueNode pojoNode(Object pojo) {
+        return new JsonLocationAwarePOJONode(pojo, this.jsonParser.currentTokenLocation());
+    }
+
+    @Override
+    public ValueNode rawValueNode(RawValue value) {
+        return new JsonLocationAwarePOJONode(value, this.jsonParser.currentTokenLocation());
+    }
+
+}

--- a/src/main/java/com/networknt/schema/serialization/node/LocationJsonNodeFactoryFactory.java
+++ b/src/main/java/com/networknt/schema/serialization/node/LocationJsonNodeFactoryFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.serialization.node;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * {@link JsonNodeFactoryFactory} that produces {@link LocationJsonNodeFactory}.
+ * <p>
+ * Note that this will adversely affect performance as nodes with the same value
+ * can no longer be cached and reused.
+ */
+public class LocationJsonNodeFactoryFactory implements JsonNodeFactoryFactory {
+    
+    private static final LocationJsonNodeFactoryFactory INSTANCE = new LocationJsonNodeFactoryFactory();
+    
+    public static LocationJsonNodeFactoryFactory getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public JsonNodeFactory getJsonNodeFactory(JsonParser jsonParser) {
+        return new LocationJsonNodeFactory(jsonParser);
+    }
+}

--- a/src/test/java/com/networknt/schema/JsonSchemaFactoryTest.java
+++ b/src/test/java/com/networknt/schema/JsonSchemaFactoryTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import com.networknt.schema.SpecVersion.VersionFlag;
+
+/**
+ * Tests for JsonSchemaFactory.
+ */
+class JsonSchemaFactoryTest {
+    @Test
+    void concurrency() {
+        String metaSchemaData = "{\r\n"
+                + "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\r\n"
+                + "  \"$id\": \"https://www.example.com/no-validation-no-format/schema\",\r\n"
+                + "  \"$vocabulary\": {\r\n"
+                + "    \"https://www.example.com/vocab/validation\": false,\r\n"
+                + "    \"https://json-schema.org/draft/2020-12/vocab/applicator\": true,\r\n"
+                + "    \"https://json-schema.org/draft/2020-12/vocab/core\": true\r\n"
+                + "  },\r\n"
+                + "  \"allOf\": [\r\n"
+                + "    { \"$ref\": \"https://json-schema.org/draft/2020-12/meta/applicator\" },\r\n"
+                + "    { \"$ref\": \"https://json-schema.org/draft/2020-12/meta/core\" }\r\n"
+                + "  ]\r\n"
+                + "}";
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012, builder -> builder.schemaLoaders(schemaLoaders -> schemaLoaders.schemas(Collections
+                .singletonMap("https://www.example.com/no-validation-no-format/schema",
+                        metaSchemaData))));
+        AtomicBoolean failed = new AtomicBoolean(false);
+        JsonMetaSchema[] instance = new JsonMetaSchema[1];;
+        CountDownLatch latch = new CountDownLatch(1);
+        List<Thread> threads = new ArrayList<>();
+        for (int i = 0; i < 50; ++i) {
+            Runnable runner = new Runnable() {
+                public void run() {
+                    SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+                    try {
+                        latch.await();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    JsonMetaSchema metaSchema = factory.getMetaSchema("https://www.example.com/no-validation-no-format/schema", config);
+                    synchronized(instance) {
+                        if (instance[0] == null) {
+                            instance[0] = metaSchema;
+                        }
+                        // Ensure references are the same despite concurrency
+                        if (!(instance[0] == metaSchema)) {
+                            failed.set(true);
+                        }
+                    }
+                }
+            };
+            Thread thread = new Thread(runner, "Thread" + i);
+            thread.start();
+            threads.add(thread);
+        }
+        latch.countDown(); // Release the latch for threads to run concurrently
+        threads.forEach(t -> {
+            try {
+                t.join();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        assertFalse(failed.get());
+    }
+}

--- a/src/test/java/com/networknt/schema/JsonSchemaTest.java
+++ b/src/test/java/com/networknt/schema/JsonSchemaTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import com.networknt.schema.SpecVersion.VersionFlag;
+
+/**
+ * Tests for JsonSchemaFactory.
+ */
+class JsonSchemaTest {
+    @Test
+    void concurrency() throws Exception {
+        String schemaData = "{\r\n"
+                + "  \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\r\n"
+                + "  \"$id\": \"http://example.org/schema.json\",\r\n"
+                + "  \"type\": \"object\",\r\n"
+                + "  \"$ref\": \"ref.json\"\r\n"
+                + "}";
+        String refSchemaData = "{\r\n"
+                + "  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\r\n"
+                + "  \"$id\": \"http://example.org/ref.json\",\r\n"
+                + "  \"properties\": {\r\n"
+                + "    \"name\": {\r\n"
+                + "      \"type\": \"string\",\r\n"
+                + "      \"description\": \"The name\"\r\n"
+                + "    },\r\n"
+                + "    \"required\": [\r\n"
+                + "      \"name\"\r\n"
+                + "    ]\r\n"
+                + "  }\r\n"
+                + "}";        
+        String inputData = "{\r\n"
+                + "  \"name\": 1\r\n"
+                + "}";
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012,
+                builder -> builder.schemaLoaders(schemaLoaders -> schemaLoaders
+                        .schemas(Collections.singletonMap("http://example.org/ref.json", refSchemaData))));
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.setPreloadJsonSchema(false);
+        JsonSchema schema = factory.getSchema(schemaData, config);
+        Exception[] instance = new Exception[1];
+        CountDownLatch latch = new CountDownLatch(1);
+        List<Thread> threads = new ArrayList<>();
+        for (int i = 0; i < 50; ++i) {
+            Runnable runner = new Runnable() {
+                public void run() {
+                    try {
+                        latch.await();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    try {
+                        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON)
+                                .stream()
+                                .collect(Collectors.toList());
+                        assertEquals(1, messages.size());
+                    } catch(Exception e) {
+                        synchronized(instance) {
+                            instance[0] = e;
+                        }
+                    }
+                }
+            };
+            Thread thread = new Thread(runner, "Thread" + i);
+            thread.start();
+            threads.add(thread);
+        }
+        latch.countDown(); // Release the latch for threads to run concurrently
+        threads.forEach(t -> {
+            try {
+                t.join();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        if (instance[0] != null) {
+            throw instance[0];
+        }
+    }
+}

--- a/src/test/java/com/networknt/schema/utils/JsonNodesTest.java
+++ b/src/test/java/com/networknt/schema/utils/JsonNodesTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.InputFormat;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.PathType;
+import com.networknt.schema.SchemaValidatorsConfig;
+import com.networknt.schema.SpecVersion.VersionFlag;
+import com.networknt.schema.ValidationMessage;
+import com.networknt.schema.serialization.JsonMapperFactory;
+import com.networknt.schema.serialization.node.LocationJsonNodeFactoryFactory;
+/**
+ * Tests for JsonNodes.
+ */
+public class JsonNodesTest {
+    @Test
+    void location() throws JsonParseException, IOException {
+        String schemaData = "{\r\n"
+                + "  \"$id\": \"https://schema/myschema\",\r\n"
+                + "  \"properties\": {\r\n"
+                + "    \"startDate\": {\r\n"
+                + "      \"format\": \"date\",\r\n"
+                + "      \"minLength\": 6\r\n"
+                + "    }\r\n"
+                + "  }\r\n"
+                + "}";
+        JsonNode jsonNode = JsonNodes.readTree(JsonMapperFactory.getInstance(), schemaData,
+                LocationJsonNodeFactoryFactory.getInstance());
+        JsonNode idNode = jsonNode.at("/$id");
+        JsonLocation location = JsonNodes.tokenLocationOf(idNode);
+        assertEquals(2, location.getLineNr());
+        assertEquals(10, location.getColumnNr());
+
+        JsonNode formatNode = jsonNode.at("/properties/startDate/format");
+        location = JsonNodes.tokenLocationOf(formatNode);
+        assertEquals(5, location.getLineNr());
+        assertEquals(17, location.getColumnNr());
+
+        JsonNode minLengthNode = jsonNode.at("/properties/startDate/minLength");
+        location = JsonNodes.tokenLocationOf(minLengthNode);
+        assertEquals(6, location.getLineNr());
+        assertEquals(20, location.getColumnNr());
+    }
+    
+    @Test
+    void jsonLocation() {
+        String schemaData = "{\r\n"
+                + "  \"$id\": \"https://schema/myschema\",\r\n"
+                + "  \"properties\": {\r\n"
+                + "    \"startDate\": {\r\n"
+                + "      \"format\": \"date\",\r\n"
+                + "      \"minLength\": 6\r\n"
+                + "    }\r\n"
+                + "  }\r\n"
+                + "}";
+        String inputData = "{\r\n"
+                + "  \"startDate\": \"1\"\r\n"
+                + "}";
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012,
+                builder -> builder.jsonNodeFactoryFactory(LocationJsonNodeFactoryFactory.getInstance()));
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.setPathType(PathType.JSON_POINTER);
+        JsonSchema schema = factory.getSchema(schemaData, InputFormat.JSON, config);
+        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON, executionContext -> {
+            executionContext.getExecutionConfig().setFormatAssertionsEnabled(true);
+        });
+        List<ValidationMessage> list = messages.stream().collect(Collectors.toList());
+        ValidationMessage format = list.get(0);
+        JsonLocation formatInstanceNodeTokenLocation = JsonNodes.tokenLocationOf(format.getInstanceNode());
+        JsonLocation formatSchemaNodeTokenLocation = JsonNodes.tokenLocationOf(format.getSchemaNode());
+        ValidationMessage minLength = list.get(1);
+        JsonLocation minLengthInstanceNodeTokenLocation = JsonNodes.tokenLocationOf(minLength.getInstanceNode());
+        JsonLocation minLengthSchemaNodeTokenLocation = JsonNodes.tokenLocationOf(minLength.getSchemaNode());
+
+        assertEquals("format", format.getType());
+
+        assertEquals("date", format.getSchemaNode().asText());
+        assertEquals(5, formatSchemaNodeTokenLocation.getLineNr());
+        assertEquals(17, formatSchemaNodeTokenLocation.getColumnNr());
+
+        assertEquals("1", format.getInstanceNode().asText());
+        assertEquals(2, formatInstanceNodeTokenLocation.getLineNr());
+        assertEquals(16, formatInstanceNodeTokenLocation.getColumnNr());
+
+        assertEquals("minLength", minLength.getType());
+
+        assertEquals("6", minLength.getSchemaNode().asText());
+        assertEquals(6, minLengthSchemaNodeTokenLocation.getLineNr());
+        assertEquals(20, minLengthSchemaNodeTokenLocation.getColumnNr());
+
+        assertEquals("1", minLength.getInstanceNode().asText());
+        assertEquals(2, minLengthInstanceNodeTokenLocation.getLineNr());
+        assertEquals(16, minLengthInstanceNodeTokenLocation.getColumnNr());
+    }
+
+    @Test
+    void yamlLocation() {
+        String schemaData = "---\r\n"
+                + "\"$id\": 'https://schema/myschema'\r\n"
+                + "properties:\r\n"
+                + "  startDate:\r\n"
+                + "    format: 'date'\r\n"
+                + "    minLength: 6\r\n"
+                + "";
+        String inputData = "---\r\n"
+                + "startDate: '1'\r\n"
+                + "";
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012,
+                builder -> builder.jsonNodeFactoryFactory(LocationJsonNodeFactoryFactory.getInstance()));
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.setPathType(PathType.JSON_POINTER);
+        JsonSchema schema = factory.getSchema(schemaData, InputFormat.YAML, config);
+        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.YAML, executionContext -> {
+            executionContext.getExecutionConfig().setFormatAssertionsEnabled(true);
+        });
+        List<ValidationMessage> list = messages.stream().collect(Collectors.toList());
+        ValidationMessage format = list.get(0);
+        JsonLocation formatInstanceNodeTokenLocation = JsonNodes.tokenLocationOf(format.getInstanceNode());
+        JsonLocation formatSchemaNodeTokenLocation = JsonNodes.tokenLocationOf(format.getSchemaNode());
+        ValidationMessage minLength = list.get(1);
+        JsonLocation minLengthInstanceNodeTokenLocation = JsonNodes.tokenLocationOf(minLength.getInstanceNode());
+        JsonLocation minLengthSchemaNodeTokenLocation = JsonNodes.tokenLocationOf(minLength.getSchemaNode());
+
+        assertEquals("format", format.getType());
+
+        assertEquals("date", format.getSchemaNode().asText());
+        assertEquals(5, formatSchemaNodeTokenLocation.getLineNr());
+        assertEquals(13, formatSchemaNodeTokenLocation.getColumnNr());
+
+        assertEquals("1", format.getInstanceNode().asText());
+        assertEquals(2, formatInstanceNodeTokenLocation.getLineNr());
+        assertEquals(12, formatInstanceNodeTokenLocation.getColumnNr());
+
+        assertEquals("minLength", minLength.getType());
+
+        assertEquals("6", minLength.getSchemaNode().asText());
+        assertEquals(6, minLengthSchemaNodeTokenLocation.getLineNr());
+        assertEquals(16, minLengthSchemaNodeTokenLocation.getColumnNr());
+
+        assertEquals("1", minLength.getInstanceNode().asText());
+        assertEquals(2, minLengthInstanceNodeTokenLocation.getLineNr());
+        assertEquals(12, minLengthInstanceNodeTokenLocation.getColumnNr());
+    }
+
+    @Test
+    void missingNode() {
+        JsonNode missing = JsonNodes.readTree(JsonMapperFactory.getInstance(),
+                new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)),
+                LocationJsonNodeFactoryFactory.getInstance());
+        assertTrue(missing.isMissingNode());
+    }
+
+    @Test
+    void types() {
+        String json = "{\r\n"
+                + "  \"properties\": {\r\n"
+                + "    \"number\": 1234.56789,\r\n"
+                + "    \"string\": \"value\",\r\n"
+                + "    \"boolean\": true,\r\n"
+                + "    \"array\": [],\r\n"
+                + "    \"object\": {},\r\n"
+                + "    \"null\": null\r\n"
+                + "  }\r\n"
+                + "}";
+        ObjectMapper objectMapper = JsonMapperFactory.getInstance()
+                .copy()
+                .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+        JsonNode root = JsonNodes.readTree(objectMapper, json, LocationJsonNodeFactoryFactory.getInstance());
+        JsonNode numberNode = root.at("/properties/number");
+        assertEquals(3, JsonNodes.tokenLocationOf(numberNode).getLineNr());
+        JsonNode stringNode = root.at("/properties/string");
+        assertEquals(4, JsonNodes.tokenLocationOf(stringNode).getLineNr());
+        JsonNode booleanNode = root.at("/properties/boolean");
+        assertEquals(5, JsonNodes.tokenLocationOf(booleanNode).getLineNr());
+        JsonNode arrayNode = root.at("/properties/array");
+        assertEquals(6, JsonNodes.tokenLocationOf(arrayNode).getLineNr());
+        JsonNode objectNode = root.at("/properties/object");
+        assertEquals(7, JsonNodes.tokenLocationOf(objectNode).getLineNr());
+        JsonNode nullNode = root.at("/properties/null");
+        assertEquals(8, JsonNodes.tokenLocationOf(nullNode).getLineNr());
+    }
+}


### PR DESCRIPTION
This allows easier tracking of the json node location information such as the line and column number by providing a default implementation that can be configured.

This is not configured by default as it will adversely affect performance.