### PR TITLE
Fix uri and uri-reference incorrect validation failure

### DIFF
--- a/src/main/java/com/networknt/schema/format/UriFormat.java
+++ b/src/main/java/com/networknt/schema/format/UriFormat.java
@@ -13,7 +13,7 @@ public class UriFormat extends AbstractRFC3986Format {
             // Java URI accepts non ASCII characters and this is not a valid in RFC3986
             result = uri.toString().codePoints().allMatch(ch -> ch < 0x7F);
             if (result) {
-                String query = uri.getQuery();
+                String query = uri.getRawQuery();
                 if (query != null) {
                     // [ and ] must be percent encoded
                     if (query.indexOf('[') != -1 || query.indexOf(']') != -1) {

--- a/src/main/java/com/networknt/schema/format/UriReferenceFormat.java
+++ b/src/main/java/com/networknt/schema/format/UriReferenceFormat.java
@@ -11,7 +11,7 @@ public class UriReferenceFormat extends AbstractRFC3986Format {
         // Java URI accepts non ASCII characters and this is not a valid in RFC3986
         boolean result = uri.toString().codePoints().allMatch(ch -> ch < 0x7F);
         if (result) {
-            String query = uri.getQuery();
+            String query = uri.getRawQuery();
             if (query != null) {
                 // [ and ] must be percent encoded
                 if (query.indexOf('[') != -1 || query.indexOf(']') != -1) {

--- a/src/test/java/com/networknt/schema/format/UriFormatTest.java
+++ b/src/test/java/com/networknt/schema/format/UriFormatTest.java
@@ -56,7 +56,21 @@ class UriFormatTest {
                 InputFormat.JSON);
         assertFalse(messages.isEmpty());
     }
-    
+
+    @Test
+    void queryWithEncodedBracketsShouldPass() {
+        String schemaData = "{\r\n"
+                + "  \"format\": \"uri\"\r\n"
+                + "}";
+
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.setFormatAssertionsEnabled(true);
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter%5Btest%5D=1\"",
+                InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
+
     @Test
     void iriShouldFail() {
         String schemaData = "{\r\n"
@@ -70,5 +84,4 @@ class UriFormatTest {
                 InputFormat.JSON);
         assertFalse(messages.isEmpty());
     }
-
 }

--- a/src/test/java/com/networknt/schema/format/UriReferenceFormatTest.java
+++ b/src/test/java/com/networknt/schema/format/UriReferenceFormatTest.java
@@ -58,6 +58,20 @@ class UriReferenceFormatTest {
     }
 
     @Test
+    void queryWithEncodedBracketsShouldPass() {
+        String schemaData = "{\r\n"
+                + "  \"format\": \"uri-reference\"\r\n"
+                + "}";
+
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        config.setFormatAssertionsEnabled(true);
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter%5Btest%5D=1\"",
+                InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
+
+    @Test
     void iriShouldFail() {
         String schemaData = "{\r\n"
                 + "  \"format\": \"uri-reference\"\r\n"


### PR DESCRIPTION
Fix `uri` and `uri-reference` formats incorrect validation failure for properly `%`-encoded `[` and `]` characters. This is the same issue that the `iri` and `iri-reference` formats had.