### PR TITLE
Bump jackson-databind from 2.17.0 to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.itu>1.10.2</version.itu>
-    <version.jackson>2.17.0</version.jackson>
+    <version.jackson>2.17.1</version.jackson>
     <version.joni>2.2.1</version.joni>
     <version.logback>1.3.14</version.logback> <!-- 1.4.x and above is not Java 8 compatible -->
     <version.slf4j>2.0.13</version.slf4j>
@@ -81,7 +81,7 @@
 
     <version.hamcrest>2.2</version.hamcrest>
     <version.junit>5.10.2</version.junit>
-    <version.undertow>2.2.31.Final</version.undertow>
+    <version.undertow>2.2.31.Final</version.undertow> <!-- 2.3.x and above is not Java 8 compatible -->
 
     <version.jacoco-maven-plugin>0.8.12</version.jacoco-maven-plugin>
     <version.maven-compiler-plugin>3.13.0</version.maven-compiler-plugin>


### PR DESCRIPTION
The notable change from 2.17.0 to 2.17.1 is to change default recycler pool back to threadLocalPool as there were reported performance issues.