### PR TITLE
Improve documentation on regular expressions

### DIFF
--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -7,7 +7,7 @@
 [![Draft 6](https://img.shields.io/endpoint?url=https%3A%2F%2Fbowtie.report%2Fbadges%2Fjava-com.networknt-json-schema-validator%2Fcompliance%2Fdraft6.json)](https://bowtie.report/#/dialects/draft6)
 [![Draft 4](https://img.shields.io/endpoint?url=https%3A%2F%2Fbowtie.report%2Fbadges%2Fjava-com.networknt-json-schema-validator%2Fcompliance%2Fdraft4.json)](https://bowtie.report/#/dialects/draft4)
 
-The `pattern` validator by default uses the JDK regular expression implementation which is not ECMA-262 compliant and is thus not compliant with the JSON Schema specification. The library can however be configured to use a ECMA-262 compliant regular expression implementation.
+The `pattern` and `format` `regex` validator by default uses the JDK regular expression implementation which is not ECMA-262 compliant and is thus not compliant with the JSON Schema specification. The library can however be configured to use a ECMA-262 compliant regular expression implementation such as `GraalJS` or `Joni`.
 
 Annotation processing and reporting are implemented. Note that the collection of annotations will have an adverse performance impact.
 
@@ -113,13 +113,24 @@ By default the `pattern` keyword uses the JDK regular expression implementation 
 
 This is not ECMA-262 compliant and is thus not compliant with the JSON Schema specification. This is however the more likely desired behavior as other logic will most likely be using the default JDK regular expression implementation to perform downstream processing.
 
-The library can be configured to use a ECMA-262 compliant regular expression validator which is implemented using [joni](https://github.com/jruby/joni). This can be configured by setting `setEcma262Validator` to `true`.
+The library can be configured to use a ECMA-262 compliant regular expression validator which is implemented using [GraalJS](https://github.com/oracle/graaljs) or [Joni](https://github.com/jruby/joni). This can be configured by setting `setRegularExpressionFactory` to the respective `GraalJSRegularExpressionFactory` or `JoniRegularExpressionFactory` instances.
 
-This also requires adding the `joni` dependency.
+This also requires adding the `org.graalvm.js:js` or `org.jruby.joni:joni` dependency.
 
 ```xml
 <dependency>
     <!-- Used to validate ECMA 262 regular expressions -->
+    <!-- Approximately 50 MB in dependencies -->
+    <!-- GraalJSRegularExpressionFactory -->
+    <groupId>org.graalvm.js</groupId>
+    <artifactId>js</artifactId>
+    <version>${version.graaljs}</version>
+</dependency>
+
+<dependency>
+    <!-- Used to validate ECMA 262 regular expressions -->
+    <!-- Approximately 2 MB in dependencies -->
+    <!-- JoniRegularExpressionFactory -->
     <groupId>org.jruby.joni</groupId>
     <artifactId>joni</artifactId>
     <version>${version.joni}</version>

--- a/src/main/java/com/networknt/schema/regex/JDKRegularExpression.java
+++ b/src/main/java/com/networknt/schema/regex/JDKRegularExpression.java
@@ -14,6 +14,9 @@ class JDKRegularExpression implements RegularExpression {
 
     @Override
     public boolean matches(String value) {
+        /*
+         * Note that the matches function is not used here as it implicitly adds anchors 
+         */
         return this.pattern.matcher(value).find();
     }
 }

--- a/src/test/java/com/networknt/schema/regex/GraalJSRegularExpressionTest.java
+++ b/src/test/java/com/networknt/schema/regex/GraalJSRegularExpressionTest.java
@@ -158,6 +158,23 @@ class GraalJSRegularExpressionTest {
     }
 
     @Test
+    void anchorShouldNotMatchMultilineInput() {
+        RegularExpression regex = new GraalJSRegularExpression("^[a-z]{1,10}$", CONTEXT);
+        assertFalse(regex.matches("abc\n"));
+    }
+
+    /**
+     * This test is because the JDK regex matches function implicitly adds anchors
+     * which isn't expected.
+     */
+    @Test
+    void noImplicitAnchors() {
+        RegularExpression regex = new GraalJSRegularExpression("[a-z]{1,10}", CONTEXT);
+        assertTrue(regex.matches("1abc1"));
+    }
+
+
+    @Test
     void concurrency() throws Exception {
         RegularExpression regex = new GraalJSRegularExpression("\\d", CONTEXT);
         Exception[] instance = new Exception[1];

--- a/src/test/java/com/networknt/schema/regex/JDKRegularExpressionTest.java
+++ b/src/test/java/com/networknt/schema/regex/JDKRegularExpressionTest.java
@@ -15,9 +15,11 @@
  */
 package com.networknt.schema.regex;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,5 +41,22 @@ class JDKRegularExpressionTest {
     void namedBackreference() {
         RegularExpression regex = new JDKRegularExpression("title=(?<quote>[\"'])(.*?)\\k<quote>");
         assertTrue(regex.matches("title=\"Named capturing groups\\' advantages\""));
+    }
+
+    @Test
+    @Disabled
+    void anchorShouldNotMatchMultilineInput() {
+        RegularExpression regex = new JDKRegularExpression("^[a-z]{1,10}$");
+        assertFalse(regex.matches("abc\n"));
+    }
+
+    /**
+     * This test is because the JDK regex matches function implicitly adds anchors
+     * which isn't expected.
+     */
+    @Test
+    void noImplicitAnchors() {
+        RegularExpression regex = new JDKRegularExpression("[a-z]{1,10}");
+        assertTrue(regex.matches("1abc1"));
     }
 }

--- a/src/test/java/com/networknt/schema/regex/JoniRegularExpressionTest.java
+++ b/src/test/java/com/networknt/schema/regex/JoniRegularExpressionTest.java
@@ -17,10 +17,12 @@ package com.networknt.schema.regex;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.joni.exception.SyntaxException;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -152,5 +154,22 @@ class JoniRegularExpressionTest {
     void namedBackreference() {
         RegularExpression regex = new JoniRegularExpression("title=(?<quote>[\"'])(.*?)\\k<quote>");
         assertTrue(regex.matches("title=\"Named capturing groups\\' advantages\""));
+    }
+
+    @Test
+    @Disabled // This test should pass but currently doesn't see issue #495
+    void anchorShouldNotMatchMultilineInput() {
+        RegularExpression regex = new JoniRegularExpression("^[a-z]{1,10}$");
+        assertFalse(regex.matches("abc\n"));
+    }
+
+    /**
+     * This test is because the JDK regex matches function implicitly adds anchors
+     * which isn't expected.
+     */
+    @Test
+    void noImplicitAnchors() {
+        RegularExpression regex = new JoniRegularExpression("[a-z]{1,10}");
+        assertTrue(regex.matches("1abc1"));
     }
 }


### PR DESCRIPTION
Improves the documentation on regular expressions and adds additional tests.

Disabled tests for the current issue for not properly matching anchors when there are newlines have been added for the JDK and Joni implementations. The tests show that GraalJS works. Tests also added that ensures that there is no implicit anchoring is used.