### PR TITLE
Fix iri, iri-reference, uri and uri-reference

### DIFF
--- a/src/main/java/com/networknt/schema/format/AbstractRFC3986Format.java
+++ b/src/main/java/com/networknt/schema/format/AbstractRFC3986Format.java
@@ -2,6 +2,7 @@ package com.networknt.schema.format;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.regex.Pattern;
 
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.Format;
@@ -10,13 +11,15 @@ import com.networknt.schema.Format;
  * {@link AbstractFormat} for RFC 3986.
  */
 public abstract class AbstractRFC3986Format implements Format {
+    private static final Pattern VALID = Pattern.compile("([A-Za-z0-9+-\\.]*:)?//|[A-Za-z0-9+-\\.]+:");
+
     @Override
     public final boolean matches(ExecutionContext executionContext, String value) {
         try {
             URI uri = new URI(value);
             return validate(uri);
         } catch (URISyntaxException e) {
-            return false;
+            return handleException(e);
         }
     }
 
@@ -28,4 +31,16 @@ public abstract class AbstractRFC3986Format implements Format {
      */
     protected abstract boolean validate(URI uri);
 
+    /**
+     * Determines if the uri matches the format.
+     *
+     * @param e the URISyntaxException
+     * @return false if it does not match
+     */
+    protected boolean handleException(URISyntaxException e) {
+        if (VALID.matcher(e.getInput()).matches()) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/test/java/com/networknt/schema/format/IriFormatTest.java
+++ b/src/test/java/com/networknt/schema/format/IriFormatTest.java
@@ -82,4 +82,39 @@ class IriFormatTest {
         assertTrue(messages.isEmpty());
     }
 
+    @Test
+    void noAuthorityShouldPass() {
+        String schemaData = "{\r\n"
+                + "  \"format\": \"iri\"\r\n"
+                + "}";
+
+        SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        Set<ValidationMessage> messages = schema.validate("\"http://\"", InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
+
+    @Test
+    void noSchemeNoAuthorityShouldPass() {
+        String schemaData = "{\r\n"
+                + "  \"format\": \"iri\"\r\n"
+                + "}";
+
+        SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        Set<ValidationMessage> messages = schema.validate("\"//\"", InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
+
+    @Test
+    void noPathShouldPass() {
+        String schemaData = "{\r\n"
+                + "  \"format\": \"iri\"\r\n"
+                + "}";
+
+        SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        Set<ValidationMessage> messages = schema.validate("\"about:\"", InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
 }

--- a/src/test/java/com/networknt/schema/format/IriReferenceFormatTest.java
+++ b/src/test/java/com/networknt/schema/format/IriReferenceFormatTest.java
@@ -82,4 +82,40 @@ class IriReferenceFormatTest {
         assertTrue(messages.isEmpty());
     }
 
+    @Test
+    void noAuthorityShouldPass() {
+        String schemaData = "{\r\n"
+                + "  \"format\": \"iri-reference\"\r\n"
+                + "}";
+
+        SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        Set<ValidationMessage> messages = schema.validate("\"http://\"", InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
+
+    @Test
+    void noSchemeNoAuthorityShouldPass() {
+        String schemaData = "{\r\n"
+                + "  \"format\": \"iri-reference\"\r\n"
+                + "}";
+
+        SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        Set<ValidationMessage> messages = schema.validate("\"//\"", InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
+
+    @Test
+    void noPathShouldPass() {
+        String schemaData = "{\r\n"
+                + "  \"format\": \"iri-reference\"\r\n"
+                + "}";
+
+        SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        Set<ValidationMessage> messages = schema.validate("\"about:\"", InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
+
 }

--- a/src/test/java/com/networknt/schema/format/UriFormatTest.java
+++ b/src/test/java/com/networknt/schema/format/UriFormatTest.java
@@ -81,4 +81,40 @@ class UriFormatTest {
                 InputFormat.JSON);
         assertFalse(messages.isEmpty());
     }
+
+    @Test
+    void noAuthorityShouldPass() {
+        String schemaData = "{\r\n"
+                + "  \"format\": \"uri\"\r\n"
+                + "}";
+
+        SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        Set<ValidationMessage> messages = schema.validate("\"http://\"", InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
+
+    @Test
+    void noSchemeNoAuthorityShouldPass() {
+        String schemaData = "{\r\n"
+                + "  \"format\": \"uri\"\r\n"
+                + "}";
+
+        SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        Set<ValidationMessage> messages = schema.validate("\"//\"", InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
+
+    @Test
+    void noPathShouldPass() {
+        String schemaData = "{\r\n"
+                + "  \"format\": \"uri\"\r\n"
+                + "}";
+
+        SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        Set<ValidationMessage> messages = schema.validate("\"about:\"", InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
 }

--- a/src/test/java/com/networknt/schema/format/UriReferenceFormatTest.java
+++ b/src/test/java/com/networknt/schema/format/UriReferenceFormatTest.java
@@ -82,4 +82,39 @@ class UriReferenceFormatTest {
         assertFalse(messages.isEmpty());
     }
 
+    @Test
+    void noAuthorityShouldPass() {
+        String schemaData = "{\r\n"
+                + "  \"format\": \"uri-reference\"\r\n"
+                + "}";
+
+        SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        Set<ValidationMessage> messages = schema.validate("\"http://\"", InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
+
+    @Test
+    void noSchemeNoAuthorityShouldPass() {
+        String schemaData = "{\r\n"
+                + "  \"format\": \"uri-reference\"\r\n"
+                + "}";
+
+        SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        Set<ValidationMessage> messages = schema.validate("\"//\"", InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
+
+    @Test
+    void noPathShouldPass() {
+        String schemaData = "{\r\n"
+                + "  \"format\": \"uri-reference\"\r\n"
+                + "}";
+
+        SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
+        Set<ValidationMessage> messages = schema.validate("\"about:\"", InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
 }


### PR DESCRIPTION
Closes #1070 

This fixes `iri`, `iri-reference`, `uri` and `uri-reference` formats to allow inputs conforming to RFC 3986 / RFC 3987 for which `URI` will throw a syntax error as it implements RFC 2396.

In particular inputs like `http://`, `//` and `about:` are now accepted.

A more complete and proper fix will likely require an additional library like Apache Jena IRI but will defer this until it is really needed.