### PR TITLE
Fix schema location with hash in fragment

### DIFF
--- a/src/main/java/com/networknt/schema/SchemaLocation.java
+++ b/src/main/java/com/networknt/schema/SchemaLocation.java
@@ -114,14 +114,16 @@ public class SchemaLocation {
         if ("#".equals(iri)) {
             return DOCUMENT;
         }
-        String[] iriParts = iri.split("#");
         AbsoluteIri absoluteIri = null;
         JsonNodePath fragment = JSON_POINTER;
-        if (iriParts.length > 0) {
-            absoluteIri = AbsoluteIri.of(iriParts[0]);
-        }
-        if (iriParts.length > 1) {
-            fragment = Fragment.of(iriParts[1]);
+        int index = iri.indexOf('#');
+        if (index == -1) {
+            absoluteIri = AbsoluteIri.of(iri);
+        } else {
+            absoluteIri = AbsoluteIri.of(iri.substring(0, index));
+            if (iri.length() > index + 1) {
+                fragment = Fragment.of(iri.substring(index + 1));
+            }
         }
         return new SchemaLocation(absoluteIri, fragment);
     }

--- a/src/test/java/com/networknt/schema/SchemaLocationTest.java
+++ b/src/test/java/com/networknt/schema/SchemaLocationTest.java
@@ -231,4 +231,28 @@ class SchemaLocationTest {
                 SchemaLocation.of("https://example.com/schemas/address/#street_address").hashCode());
     }
 
+    @Test
+    void hashInFragment() {
+        SchemaLocation location = SchemaLocation.of("https://example.com/example.yaml#/paths/~1subscribe/post/callbacks/myEvent/{request.body#~1callbackUrl}/post/requestBody/content/application~1json/schema");
+        assertEquals("/paths/~1subscribe/post/callbacks/myEvent/{request.body#~1callbackUrl}/post/requestBody/content/application~1json/schema", location.getFragment().toString());
+    }
+
+    @Test
+    void trailingHash() {
+        SchemaLocation location = SchemaLocation.of("https://example.com/example.yaml#");
+        assertEquals("", location.getFragment().toString());
+    }
+
+    @Test
+    void equalsEqualsNoFragment() {
+        assertEquals(SchemaLocation.of("https://example.com/example.yaml#"),
+                SchemaLocation.of("https://example.com/example.yaml"));
+    }
+
+    @Test
+    void equalsEqualsNoFragmentToString() {
+        assertEquals(SchemaLocation.of("https://example.com/example.yaml#").toString(),
+                SchemaLocation.of("https://example.com/example.yaml").toString());
+    }
+
 }


### PR DESCRIPTION
This fixes the case where the schema location has a `#` in the fragment for example `https://example.com/example.yaml#/paths/~1subscribe/post/callbacks/myEvent/{request.body#~1callbackUrl}/post/requestBody/content/application~1json/schema`.