### PR TITLE
Fix activeDialect for custom meta schema

### DIFF
--- a/src/main/java/com/networknt/schema/UnevaluatedItemsValidator.java
+++ b/src/main/java/com/networknt/schema/UnevaluatedItemsValidator.java
@@ -44,8 +44,7 @@ public class UnevaluatedItemsValidator extends BaseJsonValidator {
             JsonSchema parentSchema, ValidationContext validationContext) {
         super(schemaLocation, evaluationPath, schemaNode, parentSchema, ValidatorTypeCode.UNEVALUATED_ITEMS,
                 validationContext);
-        isMinV202012 = MinV202012.getVersions().contains(SpecVersionDetector
-                .detectOptionalVersion(validationContext.getMetaSchema().getIri()).orElse(DEFAULT_VERSION));
+        isMinV202012 = MinV202012.getVersions().contains(validationContext.activeDialect().orElse(DEFAULT_VERSION));
         if (schemaNode.isObject() || schemaNode.isBoolean()) {
             this.schema = validationContext.newSchema(schemaLocation, evaluationPath, schemaNode, parentSchema);
         } else {

--- a/src/main/java/com/networknt/schema/ValidationContext.java
+++ b/src/main/java/com/networknt/schema/ValidationContext.java
@@ -107,7 +107,6 @@ public class ValidationContext {
     }
 
     public Optional<VersionFlag> activeDialect() {
-        String metaSchema = getMetaSchema().getIri();
-        return SpecVersionDetector.detectOptionalVersion(metaSchema);
+        return Optional.of(this.metaSchema.getSpecification());
     }
 }

--- a/src/main/java/com/networknt/schema/utils/JsonNodeUtil.java
+++ b/src/main/java/com/networknt/schema/utils/JsonNodeUtil.java
@@ -131,10 +131,7 @@ public class JsonNodeUtil {
     }
 
     private static long detectVersion(ValidationContext validationContext) {
-        String metaSchema = validationContext.getMetaSchema().getIri();
-        return SpecVersionDetector.detectOptionalVersion(metaSchema)
-            .orElse(VersionFlag.V4)
-            .getVersionFlagValue();
+        return validationContext.activeDialect().orElse(VersionFlag.V4).getVersionFlagValue();
     }
 
     /**

--- a/src/test/java/com/networknt/schema/VocabularyTest.java
+++ b/src/test/java/com/networknt/schema/VocabularyTest.java
@@ -82,6 +82,7 @@ public class VocabularyTest {
         messages = schema.validate(inputDataNoValidation, InputFormat.JSON);
         assertEquals(1, messages.size());
         assertEquals("minimum", messages.iterator().next().getType());
+        assertEquals(VersionFlag.V202012, schema.getValidationContext().activeDialect().get());
     }
 
     @Test


### PR DESCRIPTION
Fixes the activeDialect for custom meta schema to return the specification instead of attempting to determine from the iri.