### PR TITLE
Fix explicit disabling of format assertions

### DIFF
--- a/src/main/java/com/networknt/schema/SchemaValidatorsConfig.java
+++ b/src/main/java/com/networknt/schema/SchemaValidatorsConfig.java
@@ -817,7 +817,7 @@ public class SchemaValidatorsConfig {
         private String errorMessageKeyword = null;
         private ExecutionContextCustomizer executionContextCustomizer = null;
         private boolean failFast = false;
-        private Boolean formatAssertionsEnabled = false;
+        private Boolean formatAssertionsEnabled = null;
         private boolean nullableKeywordEnabled = false;
         private List<JsonSchemaWalkListener> itemWalkListeners = new ArrayList<>();
         private boolean javaSemantics = false;

--- a/src/main/java/com/networknt/schema/format/BaseFormatJsonValidator.java
+++ b/src/main/java/com/networknt/schema/format/BaseFormatJsonValidator.java
@@ -49,6 +49,8 @@ public abstract class BaseFormatJsonValidator extends BaseJsonValidator {
     protected boolean isAssertionsEnabled(ExecutionContext executionContext) {
         if (Boolean.TRUE.equals(executionContext.getExecutionConfig().getFormatAssertionsEnabled())) {
             return true;
+        } else if (Boolean.FALSE.equals(executionContext.getExecutionConfig().getFormatAssertionsEnabled())) {
+            return false;
         }
         return this.assertionsEnabled;
     }

--- a/src/test/java/com/networknt/schema/FormatValidatorTest.java
+++ b/src/test/java/com/networknt/schema/FormatValidatorTest.java
@@ -233,4 +233,16 @@ class FormatValidatorTest {
         assertTrue(messages.isEmpty());
         
     }
+
+    @Test
+    void draft7DisableFormat() {
+        String schemaData = "{\r\n"
+                + "  \"format\":\"uri\"\r\n"
+                + "}";
+        JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V7).getSchema(schemaData);
+        Set<ValidationMessage> messages = schema.validate("\"hello\"", InputFormat.JSON, executionContext -> {
+            executionContext.getExecutionConfig().setFormatAssertionsEnabled(false);
+        });
+        assertEquals(0, messages.size());
+    }
 }


### PR DESCRIPTION
Closes #1144

This also fixes the `SchemaValidatorsConfig` builder to initialise `formatAssertionsEnabled` to `null` instead of `false`.