### PR TITLE
Fix NPE when walking a missing node that will have missing properties

### DIFF
--- a/src/main/java/com/networknt/schema/TypeFactory.java
+++ b/src/main/java/com/networknt/schema/TypeFactory.java
@@ -75,6 +75,11 @@ public class TypeFactory {
      * @return the json type
      */
     public static JsonType getValueNodeType(JsonNode node, SchemaValidatorsConfig config) {
+        if (node == null) {
+            // This returns JsonType.UNKNOWN to be consistent with the behavior when
+            // JsonNodeType.MISSING
+            return JsonType.UNKNOWN;
+        }
         JsonNodeType type = node.getNodeType();
         switch (type) {
         case OBJECT:

--- a/src/test/java/com/networknt/schema/JsonWalkTest.java
+++ b/src/test/java/com/networknt/schema/JsonWalkTest.java
@@ -2,6 +2,7 @@ package com.networknt.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.networknt.schema.walk.JsonSchemaWalkListener;
 import com.networknt.schema.walk.WalkEvent;
@@ -108,6 +109,26 @@ class JsonWalkTest {
                 + "          }"
                 + "     }"
                 + "}")));
+    }
+
+    @Test
+    void testWalkMissingNodeWithPropertiesSchema() {
+        String schemaContents = "{\n"
+                + "                \"type\": \"object\",\n"
+                + "                \"properties\": {\n"
+                + "                    \"field\": {\n"
+                + "                    \"anyOf\": [\n"
+                + "                        {\n"
+                + "                        \"type\": \"string\"\n"
+                + "                        }\n"
+                + "                    ]\n"
+                + "                    }\n"
+                + "                }\n"
+                + "            }";
+
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
+        JsonSchema schema = factory.getSchema(schemaContents);
+        schema.walk(MissingNode.getInstance(), true).getValidationMessages();
     }
 
     private InputStream getSchema() {

--- a/src/test/java/com/networknt/schema/JsonWalkTest.java
+++ b/src/test/java/com/networknt/schema/JsonWalkTest.java
@@ -17,6 +17,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.TreeSet;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class JsonWalkTest {
@@ -112,7 +113,7 @@ class JsonWalkTest {
     }
 
     @Test
-    void testWalkMissingNodeWithPropertiesSchema() {
+    void testWalkMissingNodeWithPropertiesSchemaShouldNotThrow() {
         String schemaContents = "{\n"
                 + "                \"type\": \"object\",\n"
                 + "                \"properties\": {\n"
@@ -128,7 +129,8 @@ class JsonWalkTest {
 
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
         JsonSchema schema = factory.getSchema(schemaContents);
-        schema.walk(MissingNode.getInstance(), true).getValidationMessages();
+        JsonNode missingNode = MissingNode.getInstance();
+        assertDoesNotThrow(() -> schema.walk(missingNode, true));
     }
 
     private InputStream getSchema() {


### PR DESCRIPTION
Closes #1151 

Fixes the NPE by having `TypeFactory.getValueNodeType((JsonNode node, SchemaValidatorsConfig config)` handle the case where a `null` was passed in as the node.

I had considered if it should be ensured that the node inputs should always be non null and always replace `null` by `MissingNode` instead. For instance having `PropertiesValidator` set the input as `MissingNode` instead of `null`. But since `JsonNode.get(String fieldName)` returns `null` for missing nodes I wasn't sure it would be appropriate.