### PR TITLE
Set requires static for optional and excludable dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,6 +440,14 @@
                         !com.networknt.org*;
                         *;
                       </exports>
+                      <requires>
+                        static com.ethlo.time;
+                        static com.fasterxml.jackson.dataformat.yaml;
+                        static org.jruby.jcodings;
+                        static org.jruby.joni;
+                        static org.graalvm.sdk;
+                        *;
+                      </requires>
                       <!-- declare services consumed by the artifact -->
                       <addServiceUses>true</addServiceUses>
                     </moduleInfo>


### PR DESCRIPTION
Closes #1153, closes #1154

`jar --describe-module --file json-schema-validator-1.5.5.jar --release 9`

```java
exports com.networknt.schema
exports com.networknt.schema.annotation
exports com.networknt.schema.format
exports com.networknt.schema.i18n
exports com.networknt.schema.oas
exports com.networknt.schema.output
exports com.networknt.schema.regex
exports com.networknt.schema.resource
exports com.networknt.schema.result
exports com.networknt.schema.serialization
exports com.networknt.schema.serialization.node
exports com.networknt.schema.utils
exports com.networknt.schema.walk
requires com.ethlo.time static
requires com.fasterxml.jackson.annotation
requires com.fasterxml.jackson.core
requires com.fasterxml.jackson.databind
requires com.fasterxml.jackson.dataformat.yaml static
requires java.base mandated
requires org.graalvm.sdk static
requires org.jruby.jcodings static
requires org.jruby.joni static
requires org.slf4j
```