### PR TITLE
Fix for ignoring the result of scheme mapping

### DIFF
--- a/src/main/java/com/networknt/schema/resource/DefaultSchemaLoader.java
+++ b/src/main/java/com/networknt/schema/resource/DefaultSchemaLoader.java
@@ -51,7 +51,7 @@ public class DefaultSchemaLoader implements SchemaLoader {
                 mappedResult = mapped;
             }
         }
-        AbsoluteIri mapped = META_SCHEMA_MAPPER.map(absoluteIri);
+        AbsoluteIri mapped = META_SCHEMA_MAPPER.map(mappedResult);
         if (mapped != null) {
             mappedResult = mapped;
         }


### PR DESCRIPTION
When loading a schema that uses the "$schema" property set to "http://json-schema.org/schema#" that references the latest version of the specification, the following exception is thrown

``java.io.FileNotFoundException: classpath:schema``

Afterwards I decided to add mapping for such a case, but it still throws the same exception
``` java
final VersionFlag versionFlag = VersionFlag.V7;
final String schemaIri = JsonSchemaFactory.checkVersion(versionFlag).getInstance().getIri();

final JsonSchemaFactory jsonSchemaFactory = JsonSchemaFactory.getInstance(versionFlag, builder ->
     builder.schemaMappers(schemaMappers -> schemaMappers.mappings(Map.of("http://json-schema.org/schema", schemaIri)))
);
```

It turned out that the code of the DefaultSchemaLoader class ignores the mapping result
``` java
...
AbsoluteIri mappedResult = absoluteIri; <-----
for (SchemaMapper mapper : schemaMappers) {
    AbsoluteIri mapped = mapper.map(mappedResult);
    if (mapped != null) {
         mappedResult = mapped;
       }
    }
    AbsoluteIri mapped = META_SCHEMA_MAPPER.map(absoluteIri); <----
    if (mapped != null) {
        mappedResult = mapped;
    }
...
```