### PR TITLE
add TLDs for testing

### DIFF
--- a/src/main/java/com/networknt/org/apache/commons/validator/routines/DomainValidator.java
+++ b/src/main/java/com/networknt/org/apache/commons/validator/routines/DomainValidator.java
@@ -812,7 +812,7 @@ public class DomainValidator implements Serializable {
         "llp", // llp Dot Registry LLC
         "loan", // loan dot Loan Limited
         "loans", // loans June Woods, LLC
-        "localhost", // RFC reserved for DNC with A record pointing to loop back IP address
+        "localhost", // RFC reserved for DNS with A record pointing to loop back IP address
         "locker", // locker Dish DBS Corporation
         "locus", // locus Locus Analytics LLC
 //        "loft", // loft Annco, Inc.

--- a/src/main/java/com/networknt/org/apache/commons/validator/routines/DomainValidator.java
+++ b/src/main/java/com/networknt/org/apache/commons/validator/routines/DomainValidator.java
@@ -525,6 +525,7 @@ public class DomainValidator implements Serializable {
         "eus", // eus Puntueus Fundazioa
         "events", // events Pioneer Maple, LLC
 //        "everbank", // everbank EverBank
+        "example", // RFC recommended for use in documentation or examples
         "exchange", // exchange Spring Falls, LLC
         "expert", // expert Magic Pass, LLC
         "exposed", // exposed Victor Beach, LLC
@@ -712,6 +713,7 @@ public class DomainValidator implements Serializable {
 //        "intel", // intel Intel Corporation
         "international", // international Wild Way, LLC
         "intuit", // intuit Intuit Administrative Services, Inc.
+        "invalid", // RFC recommended for use to be clearly invalid
         "investments", // investments Holly Glen, LLC
         "ipiranga", // ipiranga Ipiranga Produtos de Petroleo S.A.
         "irish", // irish Dot-Irish LLC
@@ -810,6 +812,7 @@ public class DomainValidator implements Serializable {
         "llp", // llp Dot Registry LLC
         "loan", // loan dot Loan Limited
         "loans", // loans June Woods, LLC
+        "localhost", // RFC reserved for DNC with A record pointing to loop back IP address
         "locker", // locker Dish DBS Corporation
         "locus", // locus Locus Analytics LLC
 //        "loft", // loft Annco, Inc.
@@ -1208,6 +1211,7 @@ public class DomainValidator implements Serializable {
 //        "telefonica", // telefonica Telefónica S.A.
         "temasek", // temasek Temasek Holdings (Private) Limited
         "tennis", // tennis Cotton Bloom, LLC
+        "test", // RFC recommended for use in testing
         "teva", // teva Teva Pharmaceutical Industries Limited
         "thd", // thd Homer TLC, Inc.
         "theater", // theater Blue Tigers, LLC


### PR DESCRIPTION
To resolve [issue#1170](https://github.com/networknt/json-schema-validator/issues/1170)

Adding TLDs for testing per RFC documentation seen [here](https://www.rfc-editor.org/rfc/rfc2606.html?utm_source=chatgpt.com#section-2)

Which notes:

```
To safely satisfy these needs, four domain names are reserved as
   listed and described below.

                   .test
                .example
                .invalid
              .localhost

      ".test" is recommended for use in testing of current or new DNS
      related code.

      ".example" is recommended for use in documentation or as examples.

      ".invalid" is intended for use in online construction of domain
      names that are sure to be invalid and which it is obvious at a
      glance are invalid.

      The ".localhost" TLD has traditionally been statically defined in
      host DNS implementations as having an A record pointing to the
      loop back IP address and is reserved for such use.  Any other use
      would conflict with widely deployed code which assumes this use.
```