### PR TITLE
Refactor set to list in execution context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <groupId>com.networknt</groupId>
   <artifactId>json-schema-validator</artifactId>
-  <version>1.5.9</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <name>JsonSchemaValidator</name>
   <description>A json schema validator that supports draft v4, v6, v7, v2019-09 and v2020-12</description>

--- a/src/main/java/com/networknt/schema/AdditionalPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/AdditionalPropertiesValidator.java
@@ -81,17 +81,17 @@ public class AdditionalPropertiesValidator extends BaseJsonValidator {
     }
 
     @Override
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation) {
-        return validate(executionContext, node, rootNode, instanceLocation, false);
+        validate(executionContext, node, rootNode, instanceLocation, false);
     }
 
-    protected Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+    protected void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation, boolean walk) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
         if (!node.isObject()) {
             // ignore no object
-            return Collections.emptySet();
+            return;
         }
 
         Set<String> matchedInstancePropertyNames = null;
@@ -108,8 +108,6 @@ public class AdditionalPropertiesValidator extends BaseJsonValidator {
             }
         }
 
-        Set<ValidationMessage> errors = null;
-
         for (Iterator<Entry<String, JsonNode>> it = node.fields(); it.hasNext(); ) {
             Entry<String, JsonNode> entry = it.next();
             String pname = entry.getKey();
@@ -119,25 +117,18 @@ public class AdditionalPropertiesValidator extends BaseJsonValidator {
             }
             if (!allowedProperties.contains(pname) && !handledByPatternProperties(pname)) {
                 if (!allowAdditionalProperties) {
-                    if (errors == null) {
-                        errors = new LinkedHashSet<>();
-                    }
-                    errors.add(message().instanceNode(node).property(pname)
+                    executionContext.addError(message().instanceNode(node).property(pname)
                             .instanceLocation(instanceLocation)
                             .locale(executionContext.getExecutionConfig().getLocale())
                             .failFast(executionContext.isFailFast()).arguments(pname).build());
                 } else {
                     if (additionalPropertiesSchema != null) {
-                        Set<ValidationMessage> results = !walk
-                                ? additionalPropertiesSchema.validate(executionContext, entry.getValue(), rootNode,
-                                        instanceLocation.append(pname))
-                                : additionalPropertiesSchema.walk(executionContext, entry.getValue(), rootNode,
-                                        instanceLocation.append(pname), true);
-                        if (!results.isEmpty()) {
-                            if (errors == null) {
-                                errors = new LinkedHashSet<>();
-                            }
-                            errors.addAll(results);
+                        if (!walk) {
+                            additionalPropertiesSchema.validate(executionContext, entry.getValue(), rootNode,
+                                    instanceLocation.append(pname));
+                        } else {
+                            additionalPropertiesSchema.walk(executionContext, entry.getValue(), rootNode,
+                                    instanceLocation.append(pname), true);   
                         }
                     }
                 }
@@ -149,18 +140,18 @@ public class AdditionalPropertiesValidator extends BaseJsonValidator {
                     .value(matchedInstancePropertyNames != null ? matchedInstancePropertyNames : Collections.emptySet())
                     .build());
         }
-        return errors == null ? Collections.emptySet() : Collections.unmodifiableSet(errors);
     }
 
     @Override
-    public Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
+    public void walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
         if (shouldValidateSchema && node != null) {
-            return validate(executionContext, node, rootNode, instanceLocation, true);
+            validate(executionContext, node, rootNode, instanceLocation, true);
+            return;
         }
 
         if (node == null || !node.isObject()) {
             // ignore no object
-            return Collections.emptySet();
+            return;
         }
 
         // Else continue walking.
@@ -179,7 +170,6 @@ public class AdditionalPropertiesValidator extends BaseJsonValidator {
                 }
             }
         }
-        return Collections.emptySet();
     }
 
     private boolean handledByPatternProperties(String pname) {

--- a/src/main/java/com/networknt/schema/AllOfValidator.java
+++ b/src/main/java/com/networknt/schema/AllOfValidator.java
@@ -20,7 +20,6 @@ import java.util.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.networknt.schema.utils.SetView;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,31 +51,19 @@ public class AllOfValidator extends BaseJsonValidator {
     }
 
     @Override
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
-        return validate(executionContext, node, rootNode, instanceLocation, false);
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+        validate(executionContext, node, rootNode, instanceLocation, false);
     }
 
-    protected Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean walk) {
+    protected void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean walk) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
-        SetView<ValidationMessage> childSchemaErrors = null;
-
         for (JsonSchema schema : this.schemas) {
-            Set<ValidationMessage> localErrors = null;
-
             if (!walk) {
-                localErrors = schema.validate(executionContext, node, rootNode, instanceLocation);
+                schema.validate(executionContext, node, rootNode, instanceLocation);
             } else {
-                localErrors = schema.walk(executionContext, node, rootNode, instanceLocation, true);
+                schema.walk(executionContext, node, rootNode, instanceLocation, true);
             }
-            
-            if (localErrors != null && !localErrors.isEmpty()) {
-                if (childSchemaErrors == null) {
-                    childSchemaErrors = new SetView<>();
-                }
-                childSchemaErrors.union(localErrors);
-            }
-
             if (this.validationContext.getConfig().isDiscriminatorKeywordEnabled()) {
                 final Iterator<JsonNode> arrayElements = this.schemaNode.elements();
                 while (arrayElements.hasNext()) {
@@ -106,21 +93,19 @@ public class AllOfValidator extends BaseJsonValidator {
                 }
             }
         }
-
-        return childSchemaErrors != null ? childSchemaErrors : Collections.emptySet();
     }
 
     @Override
-    public Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
+    public void walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
         if (shouldValidateSchema && node != null) {
-            return validate(executionContext, node, rootNode, instanceLocation, true);
+            validate(executionContext, node, rootNode, instanceLocation, true);
+            return;
         }
         for (JsonSchema schema : this.schemas) {
             // Walk through the schema
             schema.walk(executionContext, node, rootNode, instanceLocation, false);
         }
-        return Collections.emptySet();
-    }
+   }
 
     @Override
     public void preloadJsonSchema() {

--- a/src/main/java/com/networknt/schema/AnnotationKeyword.java
+++ b/src/main/java/com/networknt/schema/AnnotationKeyword.java
@@ -18,9 +18,6 @@ package com.networknt.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import java.util.Collections;
-import java.util.Set;
-
 /**
  * Used for Keywords that have no validation aspect, but are part of the metaschema, where annotations may need to be collected.
  */
@@ -33,7 +30,7 @@ public class AnnotationKeyword extends AbstractKeyword {
         }
 
         @Override
-        public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+        public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
             if (collectAnnotations(executionContext)) {
                 Object value = getAnnotationValue(getSchemaNode());
                 if (value != null) {
@@ -41,7 +38,6 @@ public class AnnotationKeyword extends AbstractKeyword {
                             annotation -> annotation.instanceLocation(instanceLocation).value(value));
                 }
             }
-            return Collections.emptySet();
         }
 
         private Object getAnnotationValue(JsonNode schemaNode) {

--- a/src/main/java/com/networknt/schema/ConstValidator.java
+++ b/src/main/java/com/networknt/schema/ConstValidator.java
@@ -19,9 +19,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Set;
-
 /**
  * {@link JsonValidator} for const.
  */
@@ -33,20 +30,19 @@ public class ConstValidator extends BaseJsonValidator implements JsonValidator {
         super(schemaLocation, evaluationPath, schemaNode, parentSchema, ValidatorTypeCode.CONST, validationContext);
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         if (schemaNode.isNumber() && node.isNumber()) {
             if (schemaNode.decimalValue().compareTo(node.decimalValue()) != 0) {
-                return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+                executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                         .locale(executionContext.getExecutionConfig().getLocale())
                         .failFast(executionContext.isFailFast()).arguments(schemaNode.asText(), node.asText())
                         .build());
             }
         } else if (!schemaNode.equals(node)) {
-            return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+            executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                     .locale(executionContext.getExecutionConfig().getLocale()).arguments(schemaNode.asText(), node.asText()).build());
         }
-        return Collections.emptySet();
     }
 }

--- a/src/main/java/com/networknt/schema/ContentEncodingValidator.java
+++ b/src/main/java/com/networknt/schema/ContentEncodingValidator.java
@@ -22,8 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Base64;
-import java.util.Collections;
-import java.util.Set;
+
 /**
  * {@link JsonValidator} for contentEncoding.
  * <p>
@@ -64,14 +63,14 @@ public class ContentEncodingValidator extends BaseJsonValidator {
     }
 
     @Override
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         // Ignore non-strings
         JsonType nodeType = TypeFactory.getValueNodeType(node, this.validationContext.getConfig());
         if (nodeType != JsonType.STRING) {
-            return Collections.emptySet();
+            return;
         }
         
         if (collectAnnotations(executionContext)) {
@@ -80,11 +79,10 @@ public class ContentEncodingValidator extends BaseJsonValidator {
         }
 
         if (!matches(node.asText())) {
-            return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+            executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                     .locale(executionContext.getExecutionConfig().getLocale())
                     .failFast(executionContext.isFailFast()).arguments(this.contentEncoding)
                     .build());
         }
-        return Collections.emptySet();
     }
 }

--- a/src/main/java/com/networknt/schema/ContentMediaTypeValidator.java
+++ b/src/main/java/com/networknt/schema/ContentMediaTypeValidator.java
@@ -18,8 +18,6 @@ package com.networknt.schema;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.Collections;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
@@ -88,14 +86,14 @@ public class ContentMediaTypeValidator extends BaseJsonValidator {
     }
 
     @Override
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         // Ignore non-strings
         JsonType nodeType = TypeFactory.getValueNodeType(node, this.validationContext.getConfig());
         if (nodeType != JsonType.STRING) {
-            return Collections.emptySet();
+            return;
         }
 
         if (collectAnnotations(executionContext)) {
@@ -104,11 +102,10 @@ public class ContentMediaTypeValidator extends BaseJsonValidator {
         }
 
         if (!matches(node.asText())) {
-            return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+            executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                     .locale(executionContext.getExecutionConfig().getLocale())
                     .failFast(executionContext.isFailFast()).arguments(this.contentMediaType)
                     .build());
         }
-        return Collections.emptySet();
     }
 }

--- a/src/main/java/com/networknt/schema/DependenciesValidator.java
+++ b/src/main/java/com/networknt/schema/DependenciesValidator.java
@@ -62,10 +62,8 @@ public class DependenciesValidator extends BaseJsonValidator implements JsonVali
         }
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
-
-        Set<ValidationMessage> errors = null;
 
         for (Iterator<String> it = node.fieldNames(); it.hasNext(); ) {
             String pname = it.next();
@@ -73,10 +71,7 @@ public class DependenciesValidator extends BaseJsonValidator implements JsonVali
             if (deps != null && !deps.isEmpty()) {
                 for (String field : deps) {
                     if (node.get(field) == null) {
-                        if (errors == null) {
-                            errors = new LinkedHashSet<>();
-                        }
-                        errors.add(message().instanceNode(node).property(pname).instanceLocation(instanceLocation)
+                        executionContext.addError(message().instanceNode(node).property(pname).instanceLocation(instanceLocation)
                                 .locale(executionContext.getExecutionConfig().getLocale())
                                 .failFast(executionContext.isFailFast())
                                 .arguments(propertyDeps.toString()).build());
@@ -85,16 +80,9 @@ public class DependenciesValidator extends BaseJsonValidator implements JsonVali
             }
             JsonSchema schema = schemaDeps.get(pname);
             if (schema != null) {
-                Set<ValidationMessage> schemaDepsErrors = schema.validate(executionContext, node, rootNode, instanceLocation);
-                if (!schemaDepsErrors.isEmpty()) {
-                    if (errors == null) {
-                        errors = new LinkedHashSet<>();
-                    }
-                    errors.addAll(schemaDepsErrors);
-                }
+                schema.validate(executionContext, node, rootNode, instanceLocation);
             }
         }
-        return errors == null || errors.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(errors);
     }
 
     @Override

--- a/src/main/java/com/networknt/schema/DependentRequired.java
+++ b/src/main/java/com/networknt/schema/DependentRequired.java
@@ -46,10 +46,8 @@ public class DependentRequired extends BaseJsonValidator implements JsonValidato
         }
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
-
-        Set<ValidationMessage> errors = new LinkedHashSet<>();
 
         for (Iterator<String> it = node.fieldNames(); it.hasNext(); ) {
             String pname = it.next();
@@ -57,7 +55,7 @@ public class DependentRequired extends BaseJsonValidator implements JsonValidato
             if (dependencies != null && !dependencies.isEmpty()) {
                 for (String field : dependencies) {
                     if (node.get(field) == null) {
-                        errors.add(message().instanceNode(node).property(pname).instanceLocation(instanceLocation)
+                        executionContext.addError(message().instanceNode(node).property(pname).instanceLocation(instanceLocation)
                                 .locale(executionContext.getExecutionConfig().getLocale())
                                 .failFast(executionContext.isFailFast()).arguments(field, pname)
                                 .build());
@@ -65,8 +63,6 @@ public class DependentRequired extends BaseJsonValidator implements JsonValidato
                 }
             }
         }
-
-        return Collections.unmodifiableSet(errors);
     }
 
 }

--- a/src/main/java/com/networknt/schema/DependentSchemas.java
+++ b/src/main/java/com/networknt/schema/DependentSchemas.java
@@ -44,32 +44,26 @@ public class DependentSchemas extends BaseJsonValidator {
     }
 
     @Override
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation) {
-        return validate(executionContext, node, rootNode, instanceLocation, false);
+        validate(executionContext, node, rootNode, instanceLocation, false);
     }
 
-    protected Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+    protected void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation, boolean walk) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
-        Set<ValidationMessage> errors = null;
         for (Iterator<String> it = node.fieldNames(); it.hasNext(); ) {
             String pname = it.next();
             JsonSchema schema = this.schemaDependencies.get(pname);
             if (schema != null) {
-                Set<ValidationMessage> schemaDependenciesErrors = !walk
-                        ? schema.validate(executionContext, node, rootNode, instanceLocation)
-                        : schema.walk(executionContext, node, rootNode, instanceLocation, true);
-                if (!schemaDependenciesErrors.isEmpty()) {
-                    if (errors == null) {
-                        errors = new LinkedHashSet<>();
-                    }
-                    errors.addAll(schemaDependenciesErrors);
+                if(!walk) {
+                    schema.validate(executionContext, node, rootNode, instanceLocation);
+                } else {
+                    schema.walk(executionContext, node, rootNode, instanceLocation, true);   
                 }
             }
         }
-        return errors == null || errors.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(errors);
     }
 
     @Override
@@ -78,14 +72,14 @@ public class DependentSchemas extends BaseJsonValidator {
     }
 
     @Override
-    public Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
+    public void walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
         if (shouldValidateSchema) {
-            return validate(executionContext, node, rootNode, instanceLocation, true);
+            validate(executionContext, node, rootNode, instanceLocation, true);
+            return;
         }
         for (JsonSchema schema : this.schemaDependencies.values()) {
             schema.walk(executionContext, node, rootNode, instanceLocation, false);
         }
-        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/DiscriminatorValidator.java
+++ b/src/main/java/com/networknt/schema/DiscriminatorValidator.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -59,9 +58,9 @@ public class DiscriminatorValidator extends BaseJsonValidator {
     }
 
     @Override
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation) {
-        return Collections.emptySet();
+        // Do nothing
     }
 
     /**

--- a/src/main/java/com/networknt/schema/DynamicRefValidator.java
+++ b/src/main/java/com/networknt/schema/DynamicRefValidator.java
@@ -20,8 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -92,7 +90,7 @@ public class DynamicRefValidator extends BaseJsonValidator {
     }
 
     @Override
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
         JsonSchema refSchema = this.schema.getSchema();
         if (refSchema == null) {
@@ -102,11 +100,11 @@ public class DynamicRefValidator extends BaseJsonValidator {
                     .arguments(schemaNode.asText()).build();
             throw new InvalidSchemaRefException(validationMessage);
         }
-        return refSchema.validate(executionContext, node, rootNode, instanceLocation);
+        refSchema.validate(executionContext, node, rootNode, instanceLocation);
     }
 
     @Override
-    public Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
+    public void walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
         // This is important because if we use same JsonSchemaFactory for creating multiple JSONSchema instances,
         // these schemas will be cached along with config. We have to replace the config for cached $ref references
@@ -132,10 +130,10 @@ public class DynamicRefValidator extends BaseJsonValidator {
                 }
             }
             if (circularDependency) {
-                return Collections.emptySet();
+                return;
             }
         }
-        return refSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
+        refSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
     }
 
 	public JsonSchemaRef getSchemaRef() {

--- a/src/main/java/com/networknt/schema/EnumValidator.java
+++ b/src/main/java/com/networknt/schema/EnumValidator.java
@@ -89,7 +89,7 @@ public class EnumValidator extends BaseJsonValidator implements JsonValidator {
         }
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         if (node.isNumber()) {
@@ -98,12 +98,10 @@ public class EnumValidator extends BaseJsonValidator implements JsonValidator {
             node = processArrayNode((ArrayNode) node);
         }
         if (!nodes.contains(node) && !( this.validationContext.getConfig().isTypeLoose() && isTypeLooseContainsInEnum(node))) {
-            return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+            executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                     .locale(executionContext.getExecutionConfig().getLocale())
                     .failFast(executionContext.isFailFast()).arguments(error).build());
         }
-
-        return Collections.emptySet();
     }
 
     /**

--- a/src/main/java/com/networknt/schema/ExclusiveMaximumValidator.java
+++ b/src/main/java/com/networknt/schema/ExclusiveMaximumValidator.java
@@ -24,8 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Collections;
-import java.util.Set;
 
 /**
  * {@link JsonValidator} for exclusiveMaximum.
@@ -97,20 +95,19 @@ public class ExclusiveMaximumValidator extends BaseJsonValidator {
         }
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         if (!JsonNodeUtil.isNumber(node, validationContext.getConfig())) {
             // maximum only applies to numbers
-            return Collections.emptySet();
+            return;
         }
 
         if (typedMaximum.crossesThreshold(node)) {
-            return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+            executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                     .locale(executionContext.getExecutionConfig().getLocale())
                     .failFast(executionContext.isFailFast())
                     .arguments(typedMaximum.thresholdValue()).build());
         }
-        return Collections.emptySet();
     }
 }

--- a/src/main/java/com/networknt/schema/ExclusiveMinimumValidator.java
+++ b/src/main/java/com/networknt/schema/ExclusiveMinimumValidator.java
@@ -24,8 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Collections;
-import java.util.Set;
 
 /**
  * {@link JsonValidator} for exclusiveMinimum.
@@ -104,21 +102,20 @@ public class ExclusiveMinimumValidator extends BaseJsonValidator {
         }
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         if (!JsonNodeUtil.isNumber(node, this.validationContext.getConfig())) {
             // minimum only applies to numbers
-            return Collections.emptySet();
+            return;
         }
 
         if (typedMinimum.crossesThreshold(node)) {
-            return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+            executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                     .locale(executionContext.getExecutionConfig().getLocale())
                     .failFast(executionContext.isFailFast())
                     .arguments(typedMinimum.thresholdValue()).build());
         }
-        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/ExecutionContext.java
+++ b/src/main/java/com/networknt/schema/ExecutionContext.java
@@ -19,6 +19,9 @@ package com.networknt.schema;
 import com.networknt.schema.annotation.JsonNodeAnnotations;
 import com.networknt.schema.result.JsonNodeResults;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Stack;
 
 /**
@@ -30,6 +33,7 @@ public class ExecutionContext {
     private Stack<DiscriminatorContext> discriminatorContexts = null;
     private JsonNodeAnnotations annotations = null;
     private JsonNodeResults results = null;
+    private List<ValidationMessage> errors = new ArrayList<>();
     
     /**
      * This is used during the execution to determine if the validator should fail fast.
@@ -172,5 +176,21 @@ public class ExecutionContext {
 
     public void leaveDiscriminatorContextImmediately(@SuppressWarnings("unused") JsonNodePath instanceLocation) {
         this.discriminatorContexts.pop();
+    }
+
+    public List<ValidationMessage> getErrors() {
+        return this.errors;
+    }
+
+    public void addError(ValidationMessage error) {
+        if (this.isFailFast()) {
+            this.errors = Collections.singletonList(error);
+            throw new FailFastAssertionException(error);
+        }
+        this.errors.add(error);
+    }
+
+    public void setErrors(List<ValidationMessage> errors) {
+        this.errors = errors;
     }
 }

--- a/src/main/java/com/networknt/schema/FailFastAssertionException.java
+++ b/src/main/java/com/networknt/schema/FailFastAssertionException.java
@@ -17,8 +17,8 @@
 package com.networknt.schema;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * Thrown when an assertion happens and the evaluation can fail fast.
@@ -32,15 +32,15 @@ import java.util.Set;
 public class FailFastAssertionException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
-    private final ValidationMessage validationMessage;
+    private final ValidationMessage error;
 
     /**
      * Constructor.
      *
-     * @param validationMessage the validation message
+     * @param error the validation message
      */
-    public FailFastAssertionException(ValidationMessage validationMessage) {
-        this.validationMessage = Objects.requireNonNull(validationMessage);
+    public FailFastAssertionException(ValidationMessage error) {
+        this.error = Objects.requireNonNull(error);
     }
 
     /**
@@ -48,8 +48,8 @@ public class FailFastAssertionException extends RuntimeException {
      * 
      * @return the validation message
      */
-    public ValidationMessage getValidationMessage() {
-        return this.validationMessage;
+    public ValidationMessage getError() {
+        return this.error;
     }
 
     /**
@@ -57,13 +57,13 @@ public class FailFastAssertionException extends RuntimeException {
      * 
      * @return the validation message
      */
-    public Set<ValidationMessage> getValidationMessages() {
-        return Collections.singleton(this.validationMessage);
+    public List<ValidationMessage> getErrors() {
+        return Collections.singletonList(this.error);
     }
 
     @Override
     public String getMessage() {
-        return this.validationMessage != null ? this.validationMessage.getMessage() : super.getMessage();
+        return this.error != null ? this.error.getMessage() : super.getMessage();
     }
 
     @Override

--- a/src/main/java/com/networknt/schema/FalseValidator.java
+++ b/src/main/java/com/networknt/schema/FalseValidator.java
@@ -19,9 +19,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Set;
-
 /**
  * {@link JsonValidator} for false.
  */
@@ -35,10 +32,10 @@ public class FalseValidator extends BaseJsonValidator implements JsonValidator {
         this.reason = this.evaluationPath.getParent().getName(-1);
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
         // For the false validator, it is always not valid
-        return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+        executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                 .locale(executionContext.getExecutionConfig().getLocale())
                 .failFast(executionContext.isFailFast()).arguments(reason).build());
     }

--- a/src/main/java/com/networknt/schema/Format.java
+++ b/src/main/java/com/networknt/schema/Format.java
@@ -16,8 +16,6 @@
 
 package com.networknt.schema;
 
-import java.util.Collections;
-import java.util.Set;
 import java.util.function.Supplier;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -139,20 +137,17 @@ public interface Format {
      * @param assertionsEnabled if assertions are enabled
      * @param message the message builder
      * @param formatValidator the format validator
-     * @return the messages
      */
-    default Set<ValidationMessage> validate(ExecutionContext executionContext, ValidationContext validationContext,
+    default void validate(ExecutionContext executionContext, ValidationContext validationContext,
             JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean assertionsEnabled,
             Supplier<MessageSourceValidationMessage.Builder> message,
             FormatValidator formatValidator) {
         if (assertionsEnabled) {
             if (!matches(executionContext, validationContext, node, rootNode, instanceLocation, assertionsEnabled,
                     formatValidator)) {
-                return Collections
-                        .singleton(message.get()
+                executionContext.addError(message.get()
                                 .arguments(this.getName(), this.getErrorMessageDescription(), node.asText()).build());
             }
         }
-        return Collections.emptySet();
     }
 }

--- a/src/main/java/com/networknt/schema/JsonSchemaException.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaException.java
@@ -17,42 +17,42 @@
 package com.networknt.schema;
 
 import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 
 /**
  * Represents an error when processing the JsonSchema.
  */
 public class JsonSchemaException extends RuntimeException {
     private static final long serialVersionUID = -7805792737596582110L;
-    private final ValidationMessage validationMessage;
+    private final ValidationMessage error;
 
-    public JsonSchemaException(ValidationMessage validationMessage) {
-        this.validationMessage = validationMessage;
+    public JsonSchemaException(ValidationMessage error) {
+        this.error = error;
     }
 
     public JsonSchemaException(String message) {
         super(message);
-        this.validationMessage = null;
+        this.error = null;
     }
 
     public JsonSchemaException(Throwable throwable) {
         super(throwable);
-        this.validationMessage = null;
+        this.error = null;
     }
 
     @Override
     public String getMessage() {
-        return this.validationMessage != null ? this.validationMessage.getMessage() : super.getMessage();
+        return this.error != null ? this.error.getMessage() : super.getMessage();
     }
 
-    public ValidationMessage getValidationMessage() {
-        return this.validationMessage;
+    public ValidationMessage getError() {
+        return this.error;
     }
 
-    public Set<ValidationMessage> getValidationMessages() {
-        if (validationMessage == null) {
-            return Collections.emptySet();
+    public List<ValidationMessage> getErrors() {
+        if (error == null) {
+            return Collections.emptyList();
         }
-        return Collections.singleton(validationMessage);
+        return Collections.singletonList(error);
     }
 }

--- a/src/main/java/com/networknt/schema/JsonSchemaValidator.java
+++ b/src/main/java/com/networknt/schema/JsonSchemaValidator.java
@@ -16,9 +16,6 @@
 
 package com.networknt.schema;
 
-import java.util.Collections;
-import java.util.Set;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.walk.JsonSchemaWalker;
 
@@ -33,11 +30,8 @@ public interface JsonSchemaValidator extends JsonSchemaWalker {
      * @param node     JsonNode
      * @param rootNode JsonNode
      * @param instanceLocation JsonNodePath
-     *
-     * @return A list of ValidationMessage if there is any validation error, or an empty
-     * list if there is no error.
      */
-    Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+    void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation);
 
     /**
@@ -45,14 +39,15 @@ public interface JsonSchemaValidator extends JsonSchemaWalker {
      * validate method if shouldValidateSchema is enabled.
      */
     @Override
-    default Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+    default void walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation, boolean shouldValidateSchema) {
         if (node == null) {
             // Note that null is not the same as NullNode
-            return Collections.emptySet();
+            return;
         }
-        return shouldValidateSchema ? validate(executionContext, node, rootNode, instanceLocation)
-                : Collections.emptySet();
+        if (shouldValidateSchema) {
+            validate(executionContext, node, rootNode, instanceLocation);
+        }
     }
 
     /**

--- a/src/main/java/com/networknt/schema/MaxItemsValidator.java
+++ b/src/main/java/com/networknt/schema/MaxItemsValidator.java
@@ -20,9 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Set;
-
 /**
  * {@link JsonValidator} for maxItems.
  */
@@ -41,24 +38,22 @@ public class MaxItemsValidator extends BaseJsonValidator implements JsonValidato
         }
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         if (node.isArray()) {
             if (node.size() > this.max) {
-                return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+                executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                         .locale(executionContext.getExecutionConfig().getLocale())
                         .failFast(executionContext.isFailFast()).arguments(this.max, node.size()).build());
             }
         } else if (this.validationContext.getConfig().isTypeLoose()) {
             if (1 > this.max) {
-                return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+                executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                         .locale(executionContext.getExecutionConfig().getLocale())
                         .failFast(executionContext.isFailFast()).arguments(this.max, 1).build());
             }
         }
-
-        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/MaxLengthValidator.java
+++ b/src/main/java/com/networknt/schema/MaxLengthValidator.java
@@ -20,9 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Set;
-
 /**
  * {@link JsonValidator} for maxLength.
  */
@@ -40,20 +37,19 @@ public class MaxLengthValidator extends BaseJsonValidator implements JsonValidat
         }
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         JsonType nodeType = TypeFactory.getValueNodeType(node, this.validationContext.getConfig());
         if (nodeType != JsonType.STRING) {
             // ignore no-string typs
-            return Collections.emptySet();
+            return;
         }
         if (node.textValue().codePointCount(0, node.textValue().length()) > this.maxLength) {
-            return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+            executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                     .locale(executionContext.getExecutionConfig().getLocale())
                     .failFast(executionContext.isFailFast()).arguments(this.maxLength).build());
         }
-        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/MaxPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/MaxPropertiesValidator.java
@@ -20,9 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Set;
-
 /**
  * {@link JsonValidator}for maxProperties.
  */
@@ -41,18 +38,16 @@ public class MaxPropertiesValidator extends BaseJsonValidator implements JsonVal
         }
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         if (node.isObject()) {
             if (node.size() > max) {
-                return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+                executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                         .locale(executionContext.getExecutionConfig().getLocale())
                         .failFast(executionContext.isFailFast()).arguments(max).build());
             }
         }
-
-        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/MaximumValidator.java
+++ b/src/main/java/com/networknt/schema/MaximumValidator.java
@@ -24,8 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Collections;
-import java.util.Set;
 
 /**
  * {@link JsonValidator} for maxmimum.
@@ -109,20 +107,19 @@ public class MaximumValidator extends BaseJsonValidator {
         }
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         if (!JsonNodeUtil.isNumber(node, this.validationContext.getConfig())) {
             // maximum only applies to numbers
-            return Collections.emptySet();
+            return;
         }
 
         if (this.typedMaximum.crossesThreshold(node)) {
-            return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+            executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                     .locale(executionContext.getExecutionConfig().getLocale())
                     .failFast(executionContext.isFailFast())
                     .arguments(this.typedMaximum.thresholdValue()).build());
         }
-        return Collections.emptySet();
     }
 }

--- a/src/main/java/com/networknt/schema/MinItemsValidator.java
+++ b/src/main/java/com/networknt/schema/MinItemsValidator.java
@@ -20,9 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Set;
-
 /**
  * {@link JsonValidator} for minItems.
  */
@@ -38,25 +35,23 @@ public class MinItemsValidator extends BaseJsonValidator implements JsonValidato
         }
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         if (node.isArray()) {
             if (node.size() < min) {
-                return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+                executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                         .locale(executionContext.getExecutionConfig().getLocale())
                         .failFast(executionContext.isFailFast()).arguments(min, node.size())
                         .build());
             }
         } else if (this.validationContext.getConfig().isTypeLoose()) {
             if (1 < min) {
-                return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+                executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                         .locale(executionContext.getExecutionConfig().getLocale())
                         .failFast(executionContext.isFailFast()).arguments(min, 1).build());
             }
         }
-
-        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/MinLengthValidator.java
+++ b/src/main/java/com/networknt/schema/MinLengthValidator.java
@@ -20,9 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Set;
-
 /**
  * {@link JsonValidator} for minLength.
  */
@@ -39,21 +36,20 @@ public class MinLengthValidator extends BaseJsonValidator implements JsonValidat
         }
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         JsonType nodeType = TypeFactory.getValueNodeType(node, this.validationContext.getConfig());
         if (nodeType != JsonType.STRING) {
             // ignore non-string types
-            return Collections.emptySet();
+            return;
         }
 
         if (node.textValue().codePointCount(0, node.textValue().length()) < minLength) {
-            return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+            executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                     .locale(executionContext.getExecutionConfig().getLocale())
                     .failFast(executionContext.isFailFast()).arguments(minLength).build());
         }
-        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/MinMaxContainsValidator.java
+++ b/src/main/java/com/networknt/schema/MinMaxContainsValidator.java
@@ -2,10 +2,8 @@ package com.networknt.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * {@link JsonValidator} for {@literal maxContains} and {@literal minContains} in a schema.
@@ -59,16 +57,18 @@ public class MinMaxContainsValidator extends BaseJsonValidator {
     }
 
     @Override
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation) {
-        return this.analysis != null ? this.analysis.stream()
-                .map(analysis -> message().instanceNode(node)
-                        .instanceLocation(instanceLocation)
-                        .messageKey(analysis.getMessageKey()).locale(executionContext.getExecutionConfig().getLocale())
-                        .failFast(executionContext.isFailFast())
-                        .type(analysis.getMessageKey())
-                        .arguments(parentSchema.getSchemaNode().toString()).build())
-                .collect(Collectors.toCollection(LinkedHashSet::new)) : Collections.emptySet();
+        if (this.analysis != null) {
+            this.analysis.stream()
+            .map(analysis -> message().instanceNode(node)
+                    .instanceLocation(instanceLocation)
+                    .messageKey(analysis.getMessageKey()).locale(executionContext.getExecutionConfig().getLocale())
+                    .failFast(executionContext.isFailFast())
+                    .type(analysis.getMessageKey())
+                    .arguments(parentSchema.getSchemaNode().toString()).build())
+            .forEach(executionContext::addError);
+        }
     }
     
     public static class Analysis {

--- a/src/main/java/com/networknt/schema/MinPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/MinPropertiesValidator.java
@@ -20,9 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Set;
-
 /**
  * {@link JsonValidator} for minProperties.
  */
@@ -41,18 +38,16 @@ public class MinPropertiesValidator extends BaseJsonValidator implements JsonVal
         }
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         if (node.isObject()) {
             if (node.size() < min) {
-                return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+                executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                         .locale(executionContext.getExecutionConfig().getLocale())
                         .failFast(executionContext.isFailFast()).arguments(min).build());
             }
         }
-
-        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/MinimumValidator.java
+++ b/src/main/java/com/networknt/schema/MinimumValidator.java
@@ -24,8 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Collections;
-import java.util.Set;
 
 /**
  * {@link JsonValidator} for minimum.
@@ -116,21 +114,20 @@ public class MinimumValidator extends BaseJsonValidator {
         }
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         if (!JsonNodeUtil.isNumber(node, this.validationContext.getConfig())) {
             // minimum only applies to numbers
-            return Collections.emptySet();
+            return;
         }
 
         if (this.typedMinimum.crossesThreshold(node)) {
-            return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+            executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                     .locale(executionContext.getExecutionConfig().getLocale())
                     .failFast(executionContext.isFailFast())
                     .arguments(this.typedMinimum.thresholdValue()).build());
         }
-        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/MultipleOfValidator.java
+++ b/src/main/java/com/networknt/schema/MultipleOfValidator.java
@@ -23,8 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
-import java.util.Collections;
-import java.util.Set;
 
 /**
  * {@link JsonValidator} for multipleOf.
@@ -40,21 +38,20 @@ public class MultipleOfValidator extends BaseJsonValidator implements JsonValida
         this.divisor = getDivisor(schemaNode);
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
         if (this.divisor != null) {
             BigDecimal dividend = getDividend(node);
             if (dividend != null) {
                 if (dividend.divideAndRemainder(this.divisor)[1].abs().compareTo(BigDecimal.ZERO) > 0) {
-                    return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+                    executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                             .locale(executionContext.getExecutionConfig().getLocale())
                             .failFast(executionContext.isFailFast()).arguments(this.divisor)
                             .build());
                 }
             }
         }
-        return Collections.emptySet();
     }
 
     /**

--- a/src/main/java/com/networknt/schema/NonValidationKeyword.java
+++ b/src/main/java/com/networknt/schema/NonValidationKeyword.java
@@ -18,10 +18,8 @@ package com.networknt.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map.Entry;
-import java.util.Set;
 
 /**
  * Used for Keywords that have no validation aspect, but are part of the metaschema.
@@ -51,8 +49,8 @@ public class NonValidationKeyword extends AbstractKeyword {
         }
 
         @Override
-        public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
-            return Collections.emptySet();
+        public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+            // Do nothing
         }
     }
 

--- a/src/main/java/com/networknt/schema/NotAllowedValidator.java
+++ b/src/main/java/com/networknt/schema/NotAllowedValidator.java
@@ -43,26 +43,19 @@ public class NotAllowedValidator extends BaseJsonValidator implements JsonValida
         }
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
-
-        Set<ValidationMessage> errors = null;
 
         for (String fieldName : fieldNames) {
             JsonNode propertyNode = node.get(fieldName);
 
             if (propertyNode != null) {
-                if (errors == null) {
-                    errors = new LinkedHashSet<>();
-                }
-                errors.add(message().property(fieldName).instanceNode(node)
+                executionContext.addError(message().property(fieldName).instanceNode(node)
                         .instanceLocation(instanceLocation.append(fieldName))
                         .locale(executionContext.getExecutionConfig().getLocale())
                         .failFast(executionContext.isFailFast()).arguments(fieldName).build());
             }
         }
-
-        return errors == null ? Collections.emptySet() : Collections.unmodifiableSet(errors);
     }
 
 }

--- a/src/main/java/com/networknt/schema/OutputFormat.java
+++ b/src/main/java/com/networknt/schema/OutputFormat.java
@@ -15,7 +15,6 @@
  */
 package com.networknt.schema;
 
-import java.util.Set;
 import java.util.function.Function;
 
 import com.networknt.schema.output.HierarchicalOutputUnitFormatter;
@@ -45,13 +44,12 @@ public interface OutputFormat<T> {
      * Formats the validation results.
      * 
      * @param jsonSchema         the schema
-     * @param validationMessages the validation messages
      * @param executionContext   the execution context
      * @param validationContext  the validation context
      * 
      * @return the result
      */
-    T format(JsonSchema jsonSchema, Set<ValidationMessage> validationMessages,
+    T format(JsonSchema jsonSchema, 
             ExecutionContext executionContext, ValidationContext validationContext);
 
     /**
@@ -90,16 +88,16 @@ public interface OutputFormat<T> {
     /**
      * The Default output format.
      */
-    class Default implements OutputFormat<Set<ValidationMessage>> {
+    class Default implements OutputFormat<java.util.List<ValidationMessage>> {
         @Override
         public void customize(ExecutionContext executionContext, ValidationContext validationContext) {
             executionContext.getExecutionConfig().setAnnotationCollectionEnabled(false);
         }
 
         @Override
-        public Set<ValidationMessage> format(JsonSchema jsonSchema,
-                Set<ValidationMessage> validationMessages, ExecutionContext executionContext, ValidationContext validationContext) {
-            return validationMessages;
+        public java.util.List<ValidationMessage> format(JsonSchema jsonSchema,
+                ExecutionContext executionContext, ValidationContext validationContext) {
+            return executionContext.getErrors();
         }
     }
 
@@ -114,9 +112,9 @@ public interface OutputFormat<T> {
         }
 
         @Override
-        public OutputFlag format(JsonSchema jsonSchema, Set<ValidationMessage> validationMessages,
+        public OutputFlag format(JsonSchema jsonSchema, 
                 ExecutionContext executionContext, ValidationContext validationContext) {
-            return new OutputFlag(validationMessages.isEmpty());
+            return new OutputFlag(executionContext.getErrors().isEmpty());
         }
     }
 
@@ -131,9 +129,9 @@ public interface OutputFormat<T> {
         }
 
         @Override
-        public java.lang.Boolean format(JsonSchema jsonSchema, Set<ValidationMessage> validationMessages,
+        public java.lang.Boolean format(JsonSchema jsonSchema, 
                 ExecutionContext executionContext, ValidationContext validationContext) {
-            return validationMessages.isEmpty();
+            return executionContext.getErrors().isEmpty();
         }
     }
     
@@ -161,9 +159,9 @@ public interface OutputFormat<T> {
         }
 
         @Override
-        public OutputUnit format(JsonSchema jsonSchema, Set<ValidationMessage> validationMessages,
+        public OutputUnit format(JsonSchema jsonSchema,
                 ExecutionContext executionContext, ValidationContext validationContext) {
-            return ListOutputUnitFormatter.format(validationMessages, executionContext, validationContext,
+            return ListOutputUnitFormatter.format(executionContext.getErrors(), executionContext, validationContext,
                     this.assertionMapper);
         }
     }
@@ -192,9 +190,9 @@ public interface OutputFormat<T> {
         }
 
         @Override
-        public OutputUnit format(JsonSchema jsonSchema, Set<ValidationMessage> validationMessages,
+        public OutputUnit format(JsonSchema jsonSchema, 
                 ExecutionContext executionContext, ValidationContext validationContext) {
-            return HierarchicalOutputUnitFormatter.format(jsonSchema, validationMessages, executionContext,
+            return HierarchicalOutputUnitFormatter.format(jsonSchema, executionContext.getErrors(), executionContext,
                     validationContext, this.assertionMapper);
         }
     }
@@ -210,9 +208,8 @@ public interface OutputFormat<T> {
         }
 
         @Override
-        public ValidationResult format(JsonSchema jsonSchema,
-                Set<ValidationMessage> validationMessages, ExecutionContext executionContext, ValidationContext validationContext) {
-            return new ValidationResult(validationMessages, executionContext);
+        public ValidationResult format(JsonSchema jsonSchema,ExecutionContext executionContext, ValidationContext validationContext) {
+            return new ValidationResult(executionContext);
         }
     }
 }

--- a/src/main/java/com/networknt/schema/PatternValidator.java
+++ b/src/main/java/com/networknt/schema/PatternValidator.java
@@ -21,9 +21,7 @@ import com.networknt.schema.regex.RegularExpression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.Optional;
-import java.util.Set;
 
 public class PatternValidator extends BaseJsonValidator {
     private static final Logger logger = LoggerFactory.getLogger(PatternValidator.class);
@@ -48,19 +46,20 @@ public class PatternValidator extends BaseJsonValidator {
     }
 
     @Override
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         JsonType nodeType = TypeFactory.getValueNodeType(node, this.validationContext.getConfig());
         if (nodeType != JsonType.STRING) {
-            return Collections.emptySet();
+            return;
         }
 
         try {
             if (!matches(node.asText())) {
-                return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+                executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                         .locale(executionContext.getExecutionConfig().getLocale())
                         .failFast(executionContext.isFailFast()).arguments(this.pattern).build());
+                return;
             }
         } catch (JsonSchemaException | FailFastAssertionException e) {
             throw e;
@@ -68,7 +67,5 @@ public class PatternValidator extends BaseJsonValidator {
             logger.error("Failed to apply pattern '{}' at {}: {}", this.pattern, instanceLocation, e.getMessage());
             throw e;
         }
-
-        return Collections.emptySet();
     }
 }

--- a/src/main/java/com/networknt/schema/ReadOnlyValidator.java
+++ b/src/main/java/com/networknt/schema/ReadOnlyValidator.java
@@ -16,9 +16,6 @@
 
 package com.networknt.schema;
 
-import java.util.Collections;
-import java.util.Set;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,14 +37,14 @@ public class ReadOnlyValidator extends BaseJsonValidator {
     }
 
     @Override
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
         if (this.readOnly) {
-            return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+            executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                     .locale(executionContext.getExecutionConfig().getLocale())
                     .failFast(executionContext.isFailFast()).build());
         }
-        return Collections.emptySet();
+        return;
     }
 
 }

--- a/src/main/java/com/networknt/schema/RecursiveRefValidator.java
+++ b/src/main/java/com/networknt/schema/RecursiveRefValidator.java
@@ -20,8 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -87,7 +85,7 @@ public class RecursiveRefValidator extends BaseJsonValidator {
     }
     
     @Override
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
         JsonSchema refSchema = this.schema.getSchema();
         if (refSchema == null) {
@@ -97,11 +95,11 @@ public class RecursiveRefValidator extends BaseJsonValidator {
                     .arguments(schemaNode.asText()).build();
             throw new InvalidSchemaRefException(validationMessage);
         }
-        return refSchema.validate(executionContext, node, rootNode, instanceLocation);
+         refSchema.validate(executionContext, node, rootNode, instanceLocation);
     }
 
     @Override
-    public Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
+    public void walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
         // This is important because if we use same JsonSchemaFactory for creating multiple JSONSchema instances,
         // these schemas will be cached along with config. We have to replace the config for cached $ref references
@@ -127,10 +125,10 @@ public class RecursiveRefValidator extends BaseJsonValidator {
                 }
             }
             if (circularDependency) {
-                return Collections.emptySet();
+                return;
             }
         }
-        return refSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
+        refSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
     }
 
     public JsonSchemaRef getSchemaRef() {

--- a/src/main/java/com/networknt/schema/RefValidator.java
+++ b/src/main/java/com/networknt/schema/RefValidator.java
@@ -20,8 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -176,7 +174,7 @@ public class RefValidator extends BaseJsonValidator {
     }
 
     @Override
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
         JsonSchema refSchema = this.schema.getSchema();
         if (refSchema == null) {
@@ -186,11 +184,11 @@ public class RefValidator extends BaseJsonValidator {
                     .arguments(schemaNode.asText()).build();
             throw new InvalidSchemaRefException(validationMessage);
         }
-        return refSchema.validate(executionContext, node, rootNode, instanceLocation);
+        refSchema.validate(executionContext, node, rootNode, instanceLocation);
     }
 
     @Override
-    public Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
+    public void walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
         // This is important because if we use same JsonSchemaFactory for creating multiple JSONSchema instances,
         // these schemas will be cached along with config. We have to replace the config for cached $ref references
@@ -216,10 +214,10 @@ public class RefValidator extends BaseJsonValidator {
                 }
             }
             if (circularDependency) {
-                return Collections.emptySet();
+                return;
             }
         }
-        return refSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
+        refSchema.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
     }
 
 	public JsonSchemaRef getSchemaRef() {

--- a/src/main/java/com/networknt/schema/RequiredValidator.java
+++ b/src/main/java/com/networknt/schema/RequiredValidator.java
@@ -42,14 +42,12 @@ public class RequiredValidator extends BaseJsonValidator implements JsonValidato
         }
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         if (!node.isObject()) {
-            return Collections.emptySet();
+            return;
         }
-
-        Set<ValidationMessage> errors = null;
 
         for (String fieldName : fieldNames) {
             JsonNode propertyNode = node.get(fieldName);
@@ -68,21 +66,16 @@ public class RequiredValidator extends BaseJsonValidator implements JsonValidato
                         continue;
                     }
                 }
-                if (errors == null) {
-                    errors = new LinkedHashSet<>();
-                }
                 /**
                  * Note that for the required validation the instanceLocation does not contain the missing property
                  * <p>
                  * @see <a href="https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-01#name-basic">Basic</a>
                  */
-                errors.add(message().instanceNode(node).property(fieldName).instanceLocation(instanceLocation)
+                executionContext.addError(message().instanceNode(node).property(fieldName).instanceLocation(instanceLocation)
                         .locale(executionContext.getExecutionConfig().getLocale())
                         .failFast(executionContext.isFailFast()).arguments(fieldName).build());
             }
         }
-
-        return errors == null ? Collections.emptySet() : Collections.unmodifiableSet(errors);
     }
 
     protected JsonNode getFieldKeyword(String fieldName, String keyword) {

--- a/src/main/java/com/networknt/schema/TrueValidator.java
+++ b/src/main/java/com/networknt/schema/TrueValidator.java
@@ -19,9 +19,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Set;
-
 /**
  * {@link JsonValidator} for true.
  */
@@ -32,9 +29,8 @@ public class TrueValidator extends BaseJsonValidator implements JsonValidator {
         super(schemaLocation, evaluationPath, schemaNode, parentSchema, ValidatorTypeCode.TRUE, validationContext);
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
         // For the true validator, it is always valid which means there is no ValidationMessage.
-        return Collections.emptySet();
     }
 }

--- a/src/main/java/com/networknt/schema/TypeValidator.java
+++ b/src/main/java/com/networknt/schema/TypeValidator.java
@@ -21,8 +21,6 @@ import com.networknt.schema.utils.JsonNodeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
-
 /**
  * {@link JsonValidator} for type.
  */
@@ -51,20 +49,20 @@ public class TypeValidator extends BaseJsonValidator {
     }
 
     @Override
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         if (this.schemaType == JsonType.UNION) {
-            return this.unionTypeValidator.validate(executionContext, node, rootNode, instanceLocation);
+            this.unionTypeValidator.validate(executionContext, node, rootNode, instanceLocation);
+            return;
         }
 
         if (!equalsToSchemaType(node)) {
             JsonType nodeType = TypeFactory.getValueNodeType(node, this.validationContext.getConfig());
-            return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+            executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                     .locale(executionContext.getExecutionConfig().getLocale())
                     .failFast(executionContext.isFailFast())
                     .arguments(nodeType.toString(), this.schemaType.toString()).build());
         }
-        return Collections.emptySet();
     }
 }

--- a/src/main/java/com/networknt/schema/UnevaluatedPropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/UnevaluatedPropertiesValidator.java
@@ -45,9 +45,9 @@ public class UnevaluatedPropertiesValidator extends BaseJsonValidator {
     }
 
     @Override
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         if (!node.isObject()) {
-            return Collections.emptySet();
+            return;
         }
 
         debug(logger, executionContext, node, rootNode, instanceLocation);
@@ -106,7 +106,6 @@ public class UnevaluatedPropertiesValidator extends BaseJsonValidator {
             }
         }
 
-        Set<ValidationMessage> messages = new LinkedHashSet<>();
         // Save flag as nested schema evaluation shouldn't trigger fail fast
         boolean failFast = executionContext.isFailFast();
         try {
@@ -117,13 +116,13 @@ public class UnevaluatedPropertiesValidator extends BaseJsonValidator {
                     evaluatedProperties.add(fieldName);
                     if (this.schemaNode.isBoolean() && this.schemaNode.booleanValue() == false) {
                         // All fails as "unevaluatedProperties: false"
-                        messages.add(message().instanceNode(node).instanceLocation(instanceLocation).property(fieldName)
+                        executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation).property(fieldName)
                                 .arguments(fieldName).locale(executionContext.getExecutionConfig().getLocale())
                                 .failFast(executionContext.isFailFast()).build());
                     } else {
                         // Schema errors will be reported as is
-                        messages.addAll(this.schema.validate(executionContext, node.get(fieldName), node,
-                                instanceLocation.append(fieldName)));
+                        this.schema.validate(executionContext, node.get(fieldName), node,
+                                instanceLocation.append(fieldName));
                     }
                 }
             }
@@ -134,6 +133,6 @@ public class UnevaluatedPropertiesValidator extends BaseJsonValidator {
                 .put(JsonNodeAnnotation.builder().instanceLocation(instanceLocation).evaluationPath(this.evaluationPath)
                         .schemaLocation(this.schemaLocation).keyword(getKeyword()).value(evaluatedProperties).build());
 
-        return messages == null || messages.isEmpty() ? Collections.emptySet() : messages;
+        return;
     }
 }

--- a/src/main/java/com/networknt/schema/UniqueItemsValidator.java
+++ b/src/main/java/com/networknt/schema/UniqueItemsValidator.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -41,21 +40,19 @@ public class UniqueItemsValidator extends BaseJsonValidator implements JsonValid
         }
     }
 
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
 
         if (unique) {
             Set<JsonNode> set = new HashSet<>();
             for (JsonNode n : node) {
                 if (!set.add(n)) {
-                    return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+                    executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                             .locale(executionContext.getExecutionConfig().getLocale())
                             .failFast(executionContext.isFailFast()).build());
                 }
             }
         }
-
-        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/ValidationResult.java
+++ b/src/main/java/com/networknt/schema/ValidationResult.java
@@ -15,25 +15,21 @@
  */
 package com.networknt.schema;
 
-import java.util.Set;
+import java.util.List;
 
 /**
  * Represents a validation result.
  */
 public class ValidationResult {
-
-    private final Set<ValidationMessage> validationMessages;
-
     private final ExecutionContext executionContext;
 
-    public ValidationResult(Set<ValidationMessage> validationMessages, ExecutionContext executionContext) {
+    public ValidationResult(ExecutionContext executionContext) {
         super();
-        this.validationMessages = validationMessages;
         this.executionContext = executionContext;
     }
 
-    public Set<ValidationMessage> getValidationMessages() {
-        return validationMessages;
+    public List<ValidationMessage> getValidationMessages() {
+        return getExecutionContext().getErrors();
     }
 
     public ExecutionContext getExecutionContext() {

--- a/src/main/java/com/networknt/schema/WriteOnlyValidator.java
+++ b/src/main/java/com/networknt/schema/WriteOnlyValidator.java
@@ -1,8 +1,5 @@
 package com.networknt.schema;
 
-import java.util.Collections;
-import java.util.Set;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,14 +21,13 @@ public class WriteOnlyValidator extends BaseJsonValidator {
     }
 
     @Override
-    public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+    public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
         debug(logger, executionContext, node, rootNode, instanceLocation);
         if (this.writeOnly) {
-            return Collections.singleton(message().instanceNode(node).instanceLocation(instanceLocation)
+            executionContext.addError(message().instanceNode(node).instanceLocation(instanceLocation)
                     .locale(executionContext.getExecutionConfig().getLocale())
                     .failFast(executionContext.isFailFast()).build());
         } 
-        return Collections.emptySet();
     }
 
 }

--- a/src/main/java/com/networknt/schema/output/HierarchicalOutputUnitFormatter.java
+++ b/src/main/java/com/networknt/schema/output/HierarchicalOutputUnitFormatter.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
@@ -107,7 +108,7 @@ public class HierarchicalOutputUnitFormatter {
         return root;
     }
 
-    public static OutputUnit format(JsonSchema jsonSchema, Set<ValidationMessage> validationMessages,
+    public static OutputUnit format(JsonSchema jsonSchema, List<ValidationMessage> validationMessages,
             ExecutionContext executionContext, ValidationContext validationContext,
             Function<ValidationMessage, Object> assertionMapper) {
         OutputUnit root = new OutputUnit();

--- a/src/main/java/com/networknt/schema/output/ListOutputUnitFormatter.java
+++ b/src/main/java/com/networknt/schema/output/ListOutputUnitFormatter.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
-import java.util.Set;
 
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.ValidationContext;
@@ -91,7 +90,7 @@ public class ListOutputUnitFormatter {
         return root;
     }
 
-    public static OutputUnit format(Set<ValidationMessage> validationMessages, ExecutionContext executionContext,
+    public static OutputUnit format(List<ValidationMessage> validationMessages, ExecutionContext executionContext,
             ValidationContext validationContext, Function<ValidationMessage, Object> assertionMapper) {
         OutputUnit root = new OutputUnit();
         root.setValid(validationMessages.isEmpty());

--- a/src/main/java/com/networknt/schema/output/OutputUnitData.java
+++ b/src/main/java/com/networknt/schema/output/OutputUnitData.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 
 import com.networknt.schema.ExecutionContext;
@@ -73,7 +72,7 @@ public class OutputUnitData {
     }
 
     @SuppressWarnings("unchecked")
-    public static OutputUnitData from(Set<ValidationMessage> validationMessages, ExecutionContext executionContext,
+    public static OutputUnitData from(List<ValidationMessage> validationMessages, ExecutionContext executionContext,
             Function<ValidationMessage, Object> assertionMapper) {
         OutputUnitData data = new OutputUnitData();
 

--- a/src/main/java/com/networknt/schema/walk/AbstractWalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/AbstractWalkListenerRunner.java
@@ -8,7 +8,6 @@ import com.networknt.schema.JsonValidator;
 import com.networknt.schema.ValidationMessage;
 
 import java.util.List;
-import java.util.Set;
 
 public abstract class AbstractWalkListenerRunner implements WalkListenerRunner {
 
@@ -36,7 +35,7 @@ public abstract class AbstractWalkListenerRunner implements WalkListenerRunner {
     }
 
     protected void runPostWalkListeners(List<JsonSchemaWalkListener> walkListeners, WalkEvent walkEvent,
-                                        Set<ValidationMessage> validationMessages) {
+                                        List<ValidationMessage> validationMessages) {
         if (walkListeners != null) {
             for (JsonSchemaWalkListener walkListener : walkListeners) {
                 walkListener.onWalkEnd(walkEvent, validationMessages);

--- a/src/main/java/com/networknt/schema/walk/DefaultItemWalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/DefaultItemWalkListenerRunner.java
@@ -8,7 +8,6 @@ import com.networknt.schema.JsonValidator;
 import com.networknt.schema.ValidationMessage;
 
 import java.util.List;
-import java.util.Set;
 
 public class DefaultItemWalkListenerRunner extends AbstractWalkListenerRunner {
 
@@ -28,7 +27,7 @@ public class DefaultItemWalkListenerRunner extends AbstractWalkListenerRunner {
 
     @Override
     public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
-            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema, JsonValidator validator, Set<ValidationMessage> validationMessages) {
+            JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema, JsonValidator validator, List<ValidationMessage> validationMessages) {
         WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation,
                 schema, validator);
         runPostWalkListeners(itemWalkListeners, walkEvent, validationMessages);

--- a/src/main/java/com/networknt/schema/walk/DefaultKeywordWalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/DefaultKeywordWalkListenerRunner.java
@@ -5,7 +5,6 @@ import com.networknt.schema.*;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class DefaultKeywordWalkListenerRunner extends AbstractWalkListenerRunner {
 
@@ -34,7 +33,7 @@ public class DefaultKeywordWalkListenerRunner extends AbstractWalkListenerRunner
 
     @Override
     public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode, JsonNode rootNode, JsonNodePath instanceLocation,
-            JsonSchema schema, JsonValidator validator, Set<ValidationMessage> validationMessages) {
+            JsonSchema schema, JsonValidator validator, List<ValidationMessage> validationMessages) {
         WalkEvent keywordWalkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, schema, validator);
         // Run Listeners that are setup only for this keyword.
         List<JsonSchemaWalkListener> currentKeywordListeners = keywordWalkListenersMap.get(keyword);

--- a/src/main/java/com/networknt/schema/walk/DefaultPropertyWalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/DefaultPropertyWalkListenerRunner.java
@@ -8,7 +8,6 @@ import com.networknt.schema.JsonValidator;
 import com.networknt.schema.ValidationMessage;
 
 import java.util.List;
-import java.util.Set;
 
 public class DefaultPropertyWalkListenerRunner extends AbstractWalkListenerRunner {
 
@@ -27,7 +26,7 @@ public class DefaultPropertyWalkListenerRunner extends AbstractWalkListenerRunne
 
     @Override
     public void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode, JsonNode rootNode, JsonNodePath instanceLocation,
-            JsonSchema schema, JsonValidator validator, Set<ValidationMessage> validationMessages) {
+            JsonSchema schema, JsonValidator validator, List<ValidationMessage> validationMessages) {
         WalkEvent walkEvent = constructWalkEvent(executionContext, keyword, instanceNode, rootNode, instanceLocation, schema, validator);
         runPostWalkListeners(propertyWalkListeners, walkEvent, validationMessages);
 

--- a/src/main/java/com/networknt/schema/walk/JsonSchemaWalkListener.java
+++ b/src/main/java/com/networknt/schema/walk/JsonSchemaWalkListener.java
@@ -2,7 +2,7 @@ package com.networknt.schema.walk;
 
 import com.networknt.schema.ValidationMessage;
 
-import java.util.Set;
+import java.util.List;
 
 /**
  * 
@@ -13,5 +13,5 @@ public interface JsonSchemaWalkListener {
 
 	WalkFlow onWalkStart(WalkEvent walkEvent);
 
-	void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages);
+	void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages);
 }

--- a/src/main/java/com/networknt/schema/walk/JsonSchemaWalker.java
+++ b/src/main/java/com/networknt/schema/walk/JsonSchemaWalker.java
@@ -4,9 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.BaseJsonValidator;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.JsonNodePath;
-import com.networknt.schema.ValidationMessage;
-
-import java.util.Set;
 
 public interface JsonSchemaWalker {
 	/**
@@ -26,8 +23,7 @@ public interface JsonSchemaWalker {
 	 * @param rootNode             JsonNode
 	 * @param instanceLocation     JsonNodePath
 	 * @param shouldValidateSchema boolean
-	 * @return a set of validation messages if shouldValidateSchema is true.
 	 */
-    Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+    void walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             JsonNodePath instanceLocation, boolean shouldValidateSchema);
 }

--- a/src/main/java/com/networknt/schema/walk/WalkListenerRunner.java
+++ b/src/main/java/com/networknt/schema/walk/WalkListenerRunner.java
@@ -7,7 +7,7 @@ import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonValidator;
 import com.networknt.schema.ValidationMessage;
 
-import java.util.Set;
+import java.util.List;
 
 public interface WalkListenerRunner {
 
@@ -15,6 +15,6 @@ public interface WalkListenerRunner {
                                 JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema, JsonValidator validator);
 
     void runPostWalkListeners(ExecutionContext executionContext, String keyword, JsonNode instanceNode,
-                              JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema, JsonValidator validator, Set<ValidationMessage> validationMessages);
+                              JsonNode rootNode, JsonNodePath instanceLocation, JsonSchema schema, JsonValidator validator, List<ValidationMessage> errors);
 
 }

--- a/src/test/java/com/networknt/schema/AbstractJsonSchemaTest.java
+++ b/src/test/java/com/networknt/schema/AbstractJsonSchemaTest.java
@@ -7,8 +7,8 @@ import com.networknt.schema.serialization.JsonMapperFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -25,13 +25,13 @@ abstract class AbstractJsonSchemaTest {
     private static final String ASSERT_MSG_ERROR_CODE = "Validation result should contain {0} error code";
     private static final String ASSERT_MSG_TYPE = "Validation result should contain {0} type";
 
-    protected Set<ValidationMessage> validate(String dataPath) {
+    protected List<ValidationMessage> validate(String dataPath) {
         JsonNode dataNode = getJsonNodeFromPath(dataPath);
         return getJsonSchemaFromDataNode(dataNode).validate(dataNode);
     }
 
     protected void assertValidatorType(String filename, ValidatorTypeCode validatorTypeCode) {
-        Set<ValidationMessage> validationMessages = validate(getDataTestFolder() + filename);
+        List<ValidationMessage> validationMessages = validate(getDataTestFolder() + filename);
 
         assertTrue(
                 validationMessages.stream().anyMatch(vm -> validatorTypeCode.getErrorCode().equals(vm.getCode())),

--- a/src/test/java/com/networknt/schema/AbstractJsonSchemaTestSuite.java
+++ b/src/test/java/com/networknt/schema/AbstractJsonSchemaTestSuite.java
@@ -55,7 +55,7 @@ abstract class AbstractJsonSchemaTestSuite {
     }
 
     private static void executeTest(JsonSchema schema, TestSpec testSpec) {
-        Set<ValidationMessage> errors = schema.validate(testSpec.getData(), OutputFormat.DEFAULT, (executionContext, validationContext) -> {
+        List<ValidationMessage> errors = schema.validate(testSpec.getData(), OutputFormat.DEFAULT, (executionContext, validationContext) -> {
             if (testSpec.getTestCase().getSource().getPath().getParent().toString().endsWith("format")) {
                 executionContext.getExecutionConfig().setFormatAssertionsEnabled(true);
             }

--- a/src/test/java/com/networknt/schema/AdditionalPropertiesValidatorTest.java
+++ b/src/test/java/com/networknt/schema/AdditionalPropertiesValidatorTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -52,7 +52,7 @@ class AdditionalPropertiesValidatorTest {
                 + "  \"foo\":\"hello\",\r\n"
                 + "  \"bar\":\"world\"\r\n"
                 + "}";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertFalse(messages.isEmpty());
         ValidationMessage message = messages.iterator().next();
         assertEquals("/additionalProperties", message.getEvaluationPath().toString());
@@ -87,7 +87,7 @@ class AdditionalPropertiesValidatorTest {
                 + "  \"foo\":\"hello\",\r\n"
                 + "  \"bar\":\"world\"\r\n"
                 + "}";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertFalse(messages.isEmpty());
         ValidationMessage message = messages.iterator().next();
         assertEquals("/additionalProperties/type", message.getEvaluationPath().toString());

--- a/src/test/java/com/networknt/schema/AllOfValidatorTest.java
+++ b/src/test/java/com/networknt/schema/AllOfValidatorTest.java
@@ -35,7 +35,7 @@ class AllOfValidatorTest {
                 + "}";
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
         JsonSchemaException ex = assertThrows(JsonSchemaException.class, () -> factory.getSchema(schemaData));
-        assertEquals("type", ex.getValidationMessage().getMessageKey());
+        assertEquals("type", ex.getError().getMessageKey());
     }
 
     @Test

--- a/src/test/java/com/networknt/schema/AnyOfValidatorTest.java
+++ b/src/test/java/com/networknt/schema/AnyOfValidatorTest.java
@@ -35,7 +35,7 @@ class AnyOfValidatorTest {
                 + "}";
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
         JsonSchemaException ex = assertThrows(JsonSchemaException.class, () -> factory.getSchema(schemaData));
-        assertEquals("type", ex.getValidationMessage().getMessageKey());
+        assertEquals("type", ex.getError().getMessageKey());
     }
 
     @Test

--- a/src/test/java/com/networknt/schema/CollectorContextTest.java
+++ b/src/test/java/com/networknt/schema/CollectorContextTest.java
@@ -109,9 +109,9 @@ class CollectorContextTest {
         ObjectMapper objectMapper = new ObjectMapper();
         ExecutionContext executionContext = jsonSchemaForCombine.createExecutionContext();
         executionContext.getExecutionConfig().setFormatAssertionsEnabled(true);
-        Set<ValidationMessage> messages = jsonSchemaForCombine.validate(executionContext, objectMapper
+        jsonSchemaForCombine.validate(executionContext, objectMapper
                 .readTree("{\"property1\":\"sample1\",\"property2\":\"sample2\",\"property3\":\"sample3\" }"));
-        ValidationResult validationResult = new ValidationResult(messages, executionContext);
+        ValidationResult validationResult = new ValidationResult(executionContext);
         CollectorContext collectorContext = validationResult.getCollectorContext();
         collectorContext.loadCollectors();
         Assertions.assertEquals(((List<String>) collectorContext.get(SAMPLE_COLLECTOR)).size(), 1);
@@ -285,19 +285,17 @@ class CollectorContextTest {
         }
 
         @Override
-        public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+        public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
                 JsonNodePath instanceLocation) {
             CollectorContext collectorContext = executionContext.getCollectorContext();
             CustomCollector customCollector = (CustomCollector) collectorContext.getCollectorMap().computeIfAbsent(SAMPLE_COLLECTOR,
                     key -> new CustomCollector());
             customCollector.combine(node.textValue());
-            return Collections.emptySet();
         }
 
         @Override
-        public Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
+        public void walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
             // Ignore this method for testing.
-            return null;
         }
     }
 
@@ -360,7 +358,7 @@ class CollectorContextTest {
 
         @SuppressWarnings("unchecked")
         @Override
-        public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+        public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
             // Get an instance of collector context.
             CollectorContext collectorContext = executionContext.getCollectorContext();
             // If collector type is not added to context add one.
@@ -369,22 +367,20 @@ class CollectorContextTest {
             synchronized(returnList) {
                 returnList.add(node.textValue());
             }
-            return Collections.emptySet();
         }
 
         @Override
-        public Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
+        public void walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation, boolean shouldValidateSchema) {
             // Ignore this method for testing.
-            return null;
         }
     }
 
     private ValidationResult validate(String jsonData) throws Exception {
         ObjectMapper objectMapper = new ObjectMapper();
         ExecutionContext executionContext = this.jsonSchema.createExecutionContext();
-        Set<ValidationMessage> messages = this.jsonSchema.validate(executionContext, objectMapper.readTree(jsonData));
+        this.jsonSchema.validate(executionContext, objectMapper.readTree(jsonData));
         executionContext.getCollectorContext().loadCollectors();
-        return new ValidationResult(messages, executionContext);
+        return new ValidationResult(executionContext);
     }
 
     private Map<String, String> getDatasourceMap() {
@@ -432,17 +428,16 @@ class CollectorContextTest {
         }
 
         @Override
-        public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+        public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
             // Get an instance of collector context.
             CollectorContext collectorContext = executionContext.getCollectorContext();
             AtomicInteger count = (AtomicInteger) collectorContext.getCollectorMap().computeIfAbsent("collect",
                     (key) -> new AtomicInteger(0));
             count.incrementAndGet();
-            return Collections.emptySet();
         }
 
         @Override
-        public Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+        public void walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
                 JsonNodePath instanceLocation, boolean shouldValidateSchema) {
             if (!shouldValidateSchema) {
                 CollectorContext collectorContext = executionContext.getCollectorContext();
@@ -450,7 +445,7 @@ class CollectorContextTest {
                         (key) -> new AtomicInteger(0));
                 count.incrementAndGet();
             }
-            return super.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
+            super.walk(executionContext, node, rootNode, instanceLocation, shouldValidateSchema);
         }
     }
 

--- a/src/test/java/com/networknt/schema/ConstValidatorTest.java
+++ b/src/test/java/com/networknt/schema/ConstValidatorTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +41,7 @@ class ConstValidatorTest {
                 .build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
         String inputData = "\"bb\"";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(": must be the constant value 'aa' but is 'bb'", messages.iterator().next().getMessage());
     }
 
@@ -55,7 +55,7 @@ class ConstValidatorTest {
                 .build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
         String inputData = "2";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(": must be the constant value '1' but is '2'", messages.iterator().next().getMessage());
     }
 
@@ -67,7 +67,7 @@ class ConstValidatorTest {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
         String inputData = "\"aa\"";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 
@@ -79,7 +79,7 @@ class ConstValidatorTest {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
         String inputData = "1234.56789";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 
@@ -91,7 +91,7 @@ class ConstValidatorTest {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
         String inputData = "\"1234.56789\"";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertFalse(messages.isEmpty());
     }
 

--- a/src/test/java/com/networknt/schema/CustomMetaSchemaTest.java
+++ b/src/test/java/com/networknt/schema/CustomMetaSchemaTest.java
@@ -22,9 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -59,21 +57,19 @@ class CustomMetaSchemaTest {
             }
 
             @Override
-            public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+            public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
                 String value = node.asText();
                 int idx = enumValues.indexOf(value);
                 if (idx < 0) {
                     throw new IllegalArgumentException("value not found in enum. value: " + value + " enum: " + enumValues);
                 }
                 String valueName = enumNames.get(idx);
-                Set<ValidationMessage> messages = new HashSet<>();
                 ValidationMessage validationMessage = ValidationMessage.builder().type(keyword)
                         .schemaNode(node)
                         .instanceNode(node)
                         .code("tests.example.enumNames").message("{0}: enumName is {1}").instanceLocation(instanceLocation)
                         .arguments(valueName).build();
-                messages.add(validationMessage);
-                return messages;
+                executionContext.addError(validationMessage);
             }
         }
 
@@ -130,7 +126,7 @@ class CustomMetaSchemaTest {
                 "  \"enumNames\": [\"Foo !\", \"Bar !\"]\n" +
                 "}");
 
-        Set<ValidationMessage> messages = schema.validate(objectMapper.readTree("\"foo\""));
+        List<ValidationMessage> messages = schema.validate(objectMapper.readTree("\"foo\""));
         assertEquals(1, messages.size());
 
         ValidationMessage message = messages.iterator().next();

--- a/src/test/java/com/networknt/schema/CustomUriTest.java
+++ b/src/test/java/com/networknt/schema/CustomUriTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Set;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,7 +24,7 @@ class CustomUriTest {
         final JsonNode value = mapper.readTree("{\"customAnyOf\": null,\"customOneOf\": null}");
 
         /* When */
-        final Set<ValidationMessage> errors = schema.validate(value);
+        final List<ValidationMessage> errors = schema.validate(value);
 
         /* Then */
         assertThat(errors.isEmpty(), is(true));

--- a/src/test/java/com/networknt/schema/DateTimeDSTTest.java
+++ b/src/test/java/com/networknt/schema/DateTimeDSTTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 
 class DateTimeDSTTest {
     protected JsonSchema getJsonSchemaFromStreamContentV7(InputStream schemaContent) {
@@ -28,7 +28,7 @@ class DateTimeDSTTest {
         JsonSchema schema = getJsonSchemaFromStreamContentV7(schemaInputStream);
         InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
         JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertEquals(0, errors.size());
     }
 }

--- a/src/test/java/com/networknt/schema/DependentRequiredTest.java
+++ b/src/test/java/com/networknt/schema/DependentRequiredTest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,7 +35,7 @@ class DependentRequiredTest {
     @Test
     void shouldReturnNoErrorMessagesForObjectWithoutOptionalField() throws IOException {
 
-        Set<ValidationMessage> messages = whenValidate("{}");
+        List<ValidationMessage> messages = whenValidate("{}");
 
         assertThat(messages, empty());
     }
@@ -43,7 +43,7 @@ class DependentRequiredTest {
     @Test
     void shouldReturnErrorMessageForObjectWithoutDependentRequiredField() throws IOException {
 
-        Set<ValidationMessage> messages = whenValidate("{ \"optional\": \"present\" }");
+        List<ValidationMessage> messages = whenValidate("{ \"optional\": \"present\" }");
 
         assertThat(
             messages.stream().map(ValidationMessage::getMessage).collect(Collectors.toList()),
@@ -53,13 +53,13 @@ class DependentRequiredTest {
     @Test
     void shouldReturnNoErrorMessagesForObjectWithOptionalAndDependentRequiredFieldSet() throws JsonProcessingException {
 
-        Set<ValidationMessage> messages =
+        List<ValidationMessage> messages =
             whenValidate("{ \"optional\": \"present\", \"requiredWhenOptionalPresent\": \"present\" }");
 
         assertThat(messages, empty());
     }
 
-    private static Set<ValidationMessage> whenValidate(String content) throws JsonProcessingException {
+    private static List<ValidationMessage> whenValidate(String content) throws JsonProcessingException {
         return schema.validate(mapper.readTree(content));
     }
 

--- a/src/test/java/com/networknt/schema/DiscriminatorValidatorTest.java
+++ b/src/test/java/com/networknt/schema/DiscriminatorValidatorTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -119,7 +118,7 @@ class DiscriminatorValidatorTest {
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().discriminatorKeywordEnabled(true).build();
         JsonSchema schema = factory.getSchema(schemaData, config);
-        Set<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 
@@ -151,7 +150,7 @@ class DiscriminatorValidatorTest {
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().discriminatorKeywordEnabled(true).build();
         JsonSchema schema = factory.getSchema(schemaData, config);
-        Set<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 
@@ -244,7 +243,7 @@ class DiscriminatorValidatorTest {
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().discriminatorKeywordEnabled(true).build();
         JsonSchema schema = factory.getSchema(schemaData, config);
-        Set<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
         assertEquals(1, messages.size());
     }
 
@@ -337,7 +336,7 @@ class DiscriminatorValidatorTest {
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().discriminatorKeywordEnabled(true).build();
         JsonSchema schema = factory.getSchema(schemaData, config);
-        Set<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
         assertEquals(1, messages.size());
     }
 
@@ -427,7 +426,7 @@ class DiscriminatorValidatorTest {
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().discriminatorKeywordEnabled(true).build();
         JsonSchema schema = factory.getSchema(schemaData, config);
-        Set<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
         // Only the oneOf and the error in the BedRoom discriminator is reported
         // the mismatch in Kitchen is not reported
         assertEquals(2, messages.size());
@@ -523,7 +522,7 @@ class DiscriminatorValidatorTest {
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().discriminatorKeywordEnabled(true).build();
         JsonSchema schema = factory.getSchema(schemaData, config);
-        Set<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
         // Only the oneOf and the error in the BedRoom discriminator is reported
         // the mismatch in Kitchen is not reported
         assertEquals(2, messages.size());
@@ -623,7 +622,7 @@ class DiscriminatorValidatorTest {
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().discriminatorKeywordEnabled(true).build();
         JsonSchema schema = factory.getSchema(schemaData, config);
-        Set<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
         // Only the oneOf and the error in the BedRoom discriminator is reported
         // the mismatch in Kitchen is not reported
         assertEquals(2, messages.size());
@@ -678,7 +677,7 @@ class DiscriminatorValidatorTest {
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().discriminatorKeywordEnabled(true).build();
         JsonSchema schema = factory.getSchema(schemaData, config);
-        Set<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
         assertEquals(3, messages.size());
         List<ValidationMessage> list = messages.stream().collect(Collectors.toList());
         assertEquals("oneOf", list.get(0).getType());
@@ -774,7 +773,7 @@ class DiscriminatorValidatorTest {
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().discriminatorKeywordEnabled(true).build();
         JsonSchema schema = factory.getSchema(schemaData, config);
-        Set<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages =  schema.validate(inputData, InputFormat.JSON);
         List<ValidationMessage> list = messages.stream().collect(Collectors.toList());
         assertEquals("required", list.get(0).getType());
     }

--- a/src/test/java/com/networknt/schema/DurationFormatValidatorTest.java
+++ b/src/test/java/com/networknt/schema/DurationFormatValidatorTest.java
@@ -16,13 +16,12 @@
 
 package com.networknt.schema;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Set;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -38,7 +37,7 @@ class DurationFormatValidatorTest {
         final JsonSchemaFactory validatorFactory = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909)).build();
         final JsonSchema validatorSchema = validatorFactory.getSchema(schema);
 
-        Set<ValidationMessage> messages = validatorSchema.validate(validTargetNode);
+        List<ValidationMessage> messages = validatorSchema.validate(validTargetNode);
         assertEquals(0, messages.size());
 
         messages = validatorSchema.validate(invalidTargetNode, OutputFormat.DEFAULT, (executionContext, validationContext) -> {

--- a/src/test/java/com/networknt/schema/ExampleTest.java
+++ b/src/test/java/com/networknt/schema/ExampleTest.java
@@ -17,7 +17,7 @@ package com.networknt.schema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +41,7 @@ class ExampleTest {
                 + "}";
         // The example-main.json schema defines $schema with Draft 07
         assertEquals(SchemaId.V7, schema.getValidationContext().getMetaSchema().getIri());
-        Set<ValidationMessage> assertions = schema.validate(input, InputFormat.JSON);
+        List<ValidationMessage> assertions = schema.validate(input, InputFormat.JSON);
         assertEquals(1, assertions.size());
         
         // The example-ref.json schema defines $schema with Draft 2019-09
@@ -64,7 +64,7 @@ class ExampleTest {
                 + "}";
         // The example-main.json schema defines $schema with Draft 07
         assertEquals(SchemaId.V7, schema.getValidationContext().getMetaSchema().getIri());
-        Set<ValidationMessage> assertions = schema.validate(input, InputFormat.JSON);
+        List<ValidationMessage> assertions = schema.validate(input, InputFormat.JSON);
         assertEquals(1, assertions.size());
         
         // The example-ref.json schema defines $schema with Draft 2019-09

--- a/src/test/java/com/networknt/schema/ExclusiveMinimumValidatorTest.java
+++ b/src/test/java/com/networknt/schema/ExclusiveMinimumValidatorTest.java
@@ -18,7 +18,7 @@ package com.networknt.schema;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -48,7 +48,7 @@ class ExclusiveMinimumValidatorTest {
         String inputData = "{\"value1\":0}";
         String validData = "{\"value1\":0.1}";
         
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(1, messages.size());
         assertEquals(1, messages.stream().filter(m -> "minimum".equals(m.getType())).count());
         

--- a/src/test/java/com/networknt/schema/FormatValidatorTest.java
+++ b/src/test/java/com/networknt/schema/FormatValidatorTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -42,7 +42,7 @@ class FormatValidatorTest {
                 + "  \"format\":\"unknown\"\r\n"
                 + "}";
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData);
-        Set<ValidationMessage> messages = schema.validate("\"hello\"", InputFormat.JSON, executionContext -> {
+        List<ValidationMessage> messages = schema.validate("\"hello\"", InputFormat.JSON, executionContext -> {
             executionContext.getExecutionConfig().setFormatAssertionsEnabled(true);
         });
         assertEquals(0, messages.size());
@@ -55,7 +55,7 @@ class FormatValidatorTest {
                 + "}";
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().strict("format", true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"hello\"", InputFormat.JSON, executionContext -> {
+        List<ValidationMessage> messages = schema.validate("\"hello\"", InputFormat.JSON, executionContext -> {
             executionContext.getExecutionConfig().setFormatAssertionsEnabled(true);
         });
         assertEquals(1, messages.size());
@@ -88,7 +88,7 @@ class FormatValidatorTest {
                         builder -> builder
                                 .schemaLoaders(schemaLoaders -> schemaLoaders.schemas(Collections.singletonMap("https://www.example.com/format-assertion/schema", metaSchemaData))))
                 .getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"hello\"", InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate("\"hello\"", InputFormat.JSON);
         assertEquals(1, messages.size());
         assertEquals("format.unknown", messages.iterator().next().getMessageKey());
     }
@@ -144,7 +144,7 @@ class FormatValidatorTest {
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = factory.getSchema(formatSchema, config);
-        Set<ValidationMessage> messages = schema.validate("\"inval!i:d^(abc]\"", InputFormat.JSON, executionConfiguration -> {
+        List<ValidationMessage> messages = schema.validate("\"inval!i:d^(abc]\"", InputFormat.JSON, executionConfiguration -> {
             executionConfiguration.getExecutionConfig().setFormatAssertionsEnabled(true);
         });
         assertFalse(messages.isEmpty());
@@ -173,7 +173,7 @@ class FormatValidatorTest {
                 + "}";
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = factory.getSchema(formatSchema, config);
-        Set<ValidationMessage> messages = schema.validate("\"inval!i:d^(abc]\"", InputFormat.JSON, executionConfiguration -> {
+        List<ValidationMessage> messages = schema.validate("\"inval!i:d^(abc]\"", InputFormat.JSON, executionConfiguration -> {
             executionConfiguration.getExecutionConfig().setFormatAssertionsEnabled(true);
         });
         assertFalse(messages.isEmpty());
@@ -222,7 +222,7 @@ class FormatValidatorTest {
                 + "}";
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = factory.getSchema(formatSchema, config);
-        Set<ValidationMessage> messages = schema.validate("123451", InputFormat.JSON, executionConfiguration -> {
+        List<ValidationMessage> messages = schema.validate("123451", InputFormat.JSON, executionConfiguration -> {
             executionConfiguration.getExecutionConfig().setFormatAssertionsEnabled(true);
         });
         assertFalse(messages.isEmpty());
@@ -240,7 +240,7 @@ class FormatValidatorTest {
                 + "  \"format\":\"uri\"\r\n"
                 + "}";
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V7).getSchema(schemaData);
-        Set<ValidationMessage> messages = schema.validate("\"hello\"", InputFormat.JSON, executionContext -> {
+        List<ValidationMessage> messages = schema.validate("\"hello\"", InputFormat.JSON, executionContext -> {
             executionContext.getExecutionConfig().setFormatAssertionsEnabled(false);
         });
         assertEquals(0, messages.size());

--- a/src/test/java/com/networknt/schema/IfValidatorTest.java
+++ b/src/test/java/com/networknt/schema/IfValidatorTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -57,7 +56,7 @@ class IfValidatorTest {
                     }
 
                     @Override
-                    public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+                    public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                         @SuppressWarnings("unchecked")
                         List<WalkEvent> types = (List<WalkEvent>) walkEvent.getExecutionContext()
                                 .getCollectorContext()
@@ -100,7 +99,7 @@ class IfValidatorTest {
                     }
 
                     @Override
-                    public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+                    public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                         @SuppressWarnings("unchecked")
                         List<WalkEvent> types = (List<WalkEvent>) walkEvent.getExecutionContext()
                                 .getCollectorContext()
@@ -143,7 +142,7 @@ class IfValidatorTest {
                     }
 
                     @Override
-                    public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+                    public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                         @SuppressWarnings("unchecked")
                         List<WalkEvent> types = (List<WalkEvent>) walkEvent.getExecutionContext()
                                 .getCollectorContext()
@@ -184,7 +183,7 @@ class IfValidatorTest {
                     }
 
                     @Override
-                    public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+                    public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                         @SuppressWarnings("unchecked")
                         List<WalkEvent> types = (List<WalkEvent>) walkEvent.getExecutionContext()
                                 .getCollectorContext()

--- a/src/test/java/com/networknt/schema/Issue255Test.java
+++ b/src/test/java/com/networknt/schema/Issue255Test.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 
 class Issue255Test {
     protected JsonSchema getJsonSchemaFromStreamContent(InputStream schemaContent) {
@@ -43,7 +43,7 @@ class Issue255Test {
         JsonSchema schema = getJsonSchemaFromStreamContent(schemaInputStream);
         InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
         JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertEquals(2, errors.size());
     }
 }

--- a/src/test/java/com/networknt/schema/Issue285Test.java
+++ b/src/test/java/com/networknt/schema/Issue285Test.java
@@ -5,9 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.Arrays;
-import java.util.Set;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -58,7 +57,7 @@ class Issue285Test {
     @Test
     void nestedValidation() throws IOException {
         JsonSchema jsonSchema = schemaFactory.getSchema(schemaStr);
-        Set<ValidationMessage> validationMessages = jsonSchema.validate(mapper.readTree(person));
+        List<ValidationMessage> validationMessages = jsonSchema.validate(mapper.readTree(person));
 
         System.err.println("\n" + Arrays.toString(validationMessages.toArray()));
 
@@ -99,7 +98,7 @@ class Issue285Test {
     void nestedTypeValidation() throws IOException {
         SchemaLocation uri = SchemaLocation.of("https://json-schema.org/draft/2019-09/schema");
         JsonSchema jsonSchema = schemaFactory.getSchema(uri);
-        Set<ValidationMessage> validationMessages = jsonSchema.validate(mapper.readTree(invalidNestedSchema));
+        List<ValidationMessage> validationMessages = jsonSchema.validate(mapper.readTree(invalidNestedSchema));
 
         System.err.println("\n" + Arrays.toString(validationMessages.toArray()));
 
@@ -122,7 +121,7 @@ class Issue285Test {
     void typeValidation() throws IOException {
         SchemaLocation uri = SchemaLocation.of("https://json-schema.org/draft/2019-09/schema");
         JsonSchema jsonSchema = schemaFactory.getSchema(uri);
-        Set<ValidationMessage> validationMessages = jsonSchema.validate(mapper.readTree(invalidSchema));
+        List<ValidationMessage> validationMessages = jsonSchema.validate(mapper.readTree(invalidSchema));
 
         System.err.println("\n" + Arrays.toString(validationMessages.toArray()));
 

--- a/src/test/java/com/networknt/schema/Issue295Test.java
+++ b/src/test/java/com/networknt/schema/Issue295Test.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 
 class Issue295Test {
     protected JsonSchema getJsonSchemaFromStreamContentV7(InputStream schemaContent) {
@@ -28,7 +28,7 @@ class Issue295Test {
         JsonSchema schema = getJsonSchemaFromStreamContentV7(schemaInputStream);
         InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
         JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertEquals(0, errors.size());
     }
 }

--- a/src/test/java/com/networknt/schema/Issue313Test.java
+++ b/src/test/java/com/networknt/schema/Issue313Test.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 
 class Issue313Test {
     protected JsonSchema getJsonSchemaFromStreamContentV7(InputStream schemaContent) {
@@ -35,7 +35,7 @@ class Issue313Test {
         JsonSchema schema = getJsonSchemaFromStreamContentV201909(schemaInputStream);
         InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
         JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertEquals(2, errors.size());
     }
 
@@ -47,7 +47,7 @@ class Issue313Test {
         JsonSchema schema = getJsonSchemaFromStreamContentV7(schemaInputStream);
         InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
         JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertEquals(2, errors.size());
     }
 

--- a/src/test/java/com/networknt/schema/Issue327Test.java
+++ b/src/test/java/com/networknt/schema/Issue327Test.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 
 class Issue327Test {
     protected JsonSchema getJsonSchemaFromStreamContentV7(InputStream schemaContent) {
@@ -28,7 +28,7 @@ class Issue327Test {
         JsonSchema schema = getJsonSchemaFromStreamContentV7(schemaInputStream);
         InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
         JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertEquals(0, errors.size());
     }
 }

--- a/src/test/java/com/networknt/schema/Issue342Test.java
+++ b/src/test/java/com/networknt/schema/Issue342Test.java
@@ -1,7 +1,7 @@
 package com.networknt.schema;
 
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ class Issue342Test {
         JsonSchema schema = getJsonSchemaFromStreamContentV7(schemaInputStream);
         InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
         JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertEquals(1, errors.size());
         final ValidationMessage error = errors.iterator().next();
         Assertions.assertEquals("$", error.getInstanceLocation().toString());

--- a/src/test/java/com/networknt/schema/Issue366FailFastTest.java
+++ b/src/test/java/com/networknt/schema/Issue366FailFastTest.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,7 +50,7 @@ class Issue366FailFastTest {
         List<JsonNode> testNodes = node.findValues("tests");
         JsonNode testNode = testNodes.get(0).get(0);
         JsonNode dataNode = testNode.get("data");
-        Set<ValidationMessage> errors = jsonSchema.validate(dataNode);
+        List<ValidationMessage> errors = jsonSchema.validate(dataNode);
         assertTrue(errors.isEmpty());
     }
 
@@ -64,7 +63,7 @@ class Issue366FailFastTest {
         List<JsonNode> testNodes = node.findValues("tests");
         JsonNode testNode = testNodes.get(0).get(1);
         JsonNode dataNode = testNode.get("data");
-        Set<ValidationMessage> errors = jsonSchema.validate(dataNode);
+        List<ValidationMessage> errors = jsonSchema.validate(dataNode);
         assertTrue(errors.isEmpty());
     }
 

--- a/src/test/java/com/networknt/schema/Issue366FailSlowTest.java
+++ b/src/test/java/com/networknt/schema/Issue366FailSlowTest.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,7 +51,7 @@ class Issue366FailSlowTest {
         List<JsonNode> testNodes = node.findValues("tests");
         JsonNode testNode = testNodes.get(0).get(0);
         JsonNode dataNode = testNode.get("data");
-        Set<ValidationMessage> errors = jsonSchema.validate(dataNode);
+        List<ValidationMessage> errors = jsonSchema.validate(dataNode);
         assertTrue(errors.isEmpty());
     }
 
@@ -65,7 +64,7 @@ class Issue366FailSlowTest {
         List<JsonNode> testNodes = node.findValues("tests");
         JsonNode testNode = testNodes.get(0).get(1);
         JsonNode dataNode = testNode.get("data");
-        Set<ValidationMessage> errors = jsonSchema.validate(dataNode);
+        List<ValidationMessage> errors = jsonSchema.validate(dataNode);
         assertTrue(errors.isEmpty());
     }
 
@@ -78,7 +77,7 @@ class Issue366FailSlowTest {
         List<JsonNode> testNodes = node.findValues("tests");
         JsonNode testNode = testNodes.get(0).get(2);
         JsonNode dataNode = testNode.get("data");
-        Set<ValidationMessage> errors = jsonSchema.validate(dataNode);
+        List<ValidationMessage> errors = jsonSchema.validate(dataNode);
 	    assertFalse(errors.isEmpty());
         assertEquals(errors.size(), 1);
     }
@@ -92,7 +91,7 @@ class Issue366FailSlowTest {
         List<JsonNode> testNodes = node.findValues("tests");
         JsonNode testNode = testNodes.get(0).get(3);
         JsonNode dataNode = testNode.get("data");
-        Set<ValidationMessage> errors = jsonSchema.validate(dataNode);
+        List<ValidationMessage> errors = jsonSchema.validate(dataNode);
 	    assertFalse(errors.isEmpty());
         assertEquals(errors.size(), 3);
     }

--- a/src/test/java/com/networknt/schema/Issue375Test.java
+++ b/src/test/java/com/networknt/schema/Issue375Test.java
@@ -22,7 +22,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -46,7 +45,7 @@ class Issue375Test {
         JsonSchema schema = getJsonSchemaFromStreamContent(schemaInputStream);
         InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
         JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         List<String> errorMessages = new ArrayList<String>();
         for (ValidationMessage error: errors) {
             errorMessages.add(error.getMessage());

--- a/src/test/java/com/networknt/schema/Issue383Test.java
+++ b/src/test/java/com/networknt/schema/Issue383Test.java
@@ -1,7 +1,7 @@
 package com.networknt.schema;
 
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ class Issue383Test {
         JsonSchema schema = getJsonSchemaFromStreamContentV7(schemaInputStream);
         InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
         JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertEquals(0, errors.size());
     }
 }

--- a/src/test/java/com/networknt/schema/Issue396Test.java
+++ b/src/test/java/com/networknt/schema/Issue396Test.java
@@ -2,6 +2,7 @@ package com.networknt.schema;
 
 import java.io.InputStream;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -38,7 +39,7 @@ class Issue396Test {
                 expected.add(entry.getKey());
         });
 
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         final Set<String> actual = errors.stream().map(ValidationMessage::getProperty).map(Object::toString).collect(Collectors.toSet());
         Assertions.assertEquals(expected, actual);
     }

--- a/src/test/java/com/networknt/schema/Issue404Test.java
+++ b/src/test/java/com/networknt/schema/Issue404Test.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 
 class Issue404Test {
     protected JsonSchema getJsonSchemaFromStreamContentV7(InputStream schemaContent) {
@@ -28,7 +28,7 @@ class Issue404Test {
         JsonSchema schema = getJsonSchemaFromStreamContentV7(schemaInputStream);
         InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
         JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertEquals(0, errors.size());
     }
 

--- a/src/test/java/com/networknt/schema/Issue426Test.java
+++ b/src/test/java/com/networknt/schema/Issue426Test.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 
 /**
  * Validating custom message
@@ -30,7 +30,7 @@ class Issue426Test {
         JsonSchema schema = getJsonSchemaFromStreamContentV7(schemaInputStream);
         InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
         JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertEquals(2, errors.size());
         final JsonNode message = schema.schemaNode.get("message");
         for(ValidationMessage error : errors) {

--- a/src/test/java/com/networknt/schema/Issue451Test.java
+++ b/src/test/java/com/networknt/schema/Issue451Test.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Validating anyOf walker
@@ -77,7 +77,7 @@ class Issue451Test {
         }
 
         @Override
-        public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+        public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
 
         }
 

--- a/src/test/java/com/networknt/schema/Issue456Test.java
+++ b/src/test/java/com/networknt/schema/Issue456Test.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 
 class Issue456Test {
 
@@ -29,7 +29,7 @@ class Issue456Test {
         JsonSchema schema = getJsonSchemaFromStreamContentV7(schemaInputStream);
         InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
         JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertEquals(0, errors.size());
     }
 
@@ -41,7 +41,7 @@ class Issue456Test {
         JsonSchema schema = getJsonSchemaFromStreamContentV7(schemaInputStream);
         InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
         JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertEquals(0, errors.size());
     }
 

--- a/src/test/java/com/networknt/schema/Issue461Test.java
+++ b/src/test/java/com/networknt/schema/Issue461Test.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Set;
+import java.util.List;
 
 class Issue461Test {
     protected ObjectMapper mapper = JsonMapperFactory.getInstance();
@@ -42,7 +42,7 @@ class Issue461Test {
 
         @Override
         public void onWalkEnd(final WalkEvent walkEvent,
-                              final Set<ValidationMessage> validationMessages) {
+                              final List<ValidationMessage> validationMessages) {
         }
     }
 }

--- a/src/test/java/com/networknt/schema/Issue467Test.java
+++ b/src/test/java/com/networknt/schema/Issue467Test.java
@@ -23,6 +23,7 @@ import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -53,7 +54,7 @@ class Issue467Test {
                     }
 
                     @Override
-                    public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> set) {
+                    public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> set) {
                     }
                 })
                 .build();
@@ -78,7 +79,7 @@ class Issue467Test {
                     }
 
                     @Override
-                    public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> set) {
+                    public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> set) {
                     }
                 })
                 .build();

--- a/src/test/java/com/networknt/schema/Issue471Test.java
+++ b/src/test/java/com/networknt/schema/Issue471Test.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.io.InputStream;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Collectors;
 
 class Issue471Test {
@@ -69,11 +69,11 @@ class Issue471Test {
         InputStream dataInputStream = Issue471Test.class.getResourceAsStream(DATA_PATH);
         JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
 
-        Set<ValidationMessage> validationMessages = schema.validate(node);
+        List<ValidationMessage> validationMessages = schema.validate(node);
         return convertValidationMessagesToMap(validationMessages);
     }
 
-    private Map<String, String> convertValidationMessagesToMap(Set<ValidationMessage> validationMessages) {
+    private Map<String, String> convertValidationMessagesToMap(List<ValidationMessage> validationMessages) {
         return validationMessages.stream().collect(Collectors.toMap(m -> m.getInstanceLocation().toString(), ValidationMessage::getMessage));
     }
 

--- a/src/test/java/com/networknt/schema/Issue475Test.java
+++ b/src/test/java/com/networknt/schema/Issue475Test.java
@@ -17,7 +17,7 @@ package com.networknt.schema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -55,7 +55,7 @@ class Issue475Test {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = jsonSchemaFactory.getSchema(SchemaLocation.of(SchemaId.V4), config);
 
-        Set<ValidationMessage> assertions = schema.validate(JsonMapperFactory.getInstance().readTree(INVALID_INPUT));
+        List<ValidationMessage> assertions = schema.validate(JsonMapperFactory.getInstance().readTree(INVALID_INPUT));
         assertEquals(2, assertions.size());
         
         assertions = schema.validate(JsonMapperFactory.getInstance().readTree(VALID_INPUT));
@@ -69,7 +69,7 @@ class Issue475Test {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = jsonSchemaFactory.getSchema(SchemaLocation.of(SchemaId.V6), config);
 
-        Set<ValidationMessage> assertions = schema.validate(JsonMapperFactory.getInstance().readTree(INVALID_INPUT));
+        List<ValidationMessage> assertions = schema.validate(JsonMapperFactory.getInstance().readTree(INVALID_INPUT));
         assertEquals(2, assertions.size());
         
         assertions = schema.validate(JsonMapperFactory.getInstance().readTree(VALID_INPUT));
@@ -83,7 +83,7 @@ class Issue475Test {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = jsonSchemaFactory.getSchema(SchemaLocation.of(SchemaId.V7), config);
 
-        Set<ValidationMessage> assertions = schema.validate(JsonMapperFactory.getInstance().readTree(INVALID_INPUT));
+        List<ValidationMessage> assertions = schema.validate(JsonMapperFactory.getInstance().readTree(INVALID_INPUT));
         assertEquals(2, assertions.size());
         
         assertions = schema.validate(JsonMapperFactory.getInstance().readTree(VALID_INPUT));
@@ -97,7 +97,7 @@ class Issue475Test {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = jsonSchemaFactory.getSchema(SchemaLocation.of(SchemaId.V201909), config);
 
-        Set<ValidationMessage> assertions = schema.validate(JsonMapperFactory.getInstance().readTree(INVALID_INPUT));
+        List<ValidationMessage> assertions = schema.validate(JsonMapperFactory.getInstance().readTree(INVALID_INPUT));
         assertEquals(2, assertions.size());
         
         assertions = schema.validate(JsonMapperFactory.getInstance().readTree(VALID_INPUT));
@@ -111,7 +111,7 @@ class Issue475Test {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = jsonSchemaFactory.getSchema(SchemaLocation.of(SchemaId.V202012), config);
 
-        Set<ValidationMessage> assertions = schema.validate(JsonMapperFactory.getInstance().readTree(INVALID_INPUT));
+        List<ValidationMessage> assertions = schema.validate(JsonMapperFactory.getInstance().readTree(INVALID_INPUT));
         assertEquals(2, assertions.size());
         
         assertions = schema.validate(JsonMapperFactory.getInstance().readTree(VALID_INPUT));

--- a/src/test/java/com/networknt/schema/Issue493Test.java
+++ b/src/test/java/com/networknt/schema/Issue493Test.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.InputStream;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.hamcrest.Matchers;
@@ -36,7 +37,7 @@ class Issue493Test
         InputStream schemaInputStream = Issue493Test.class.getResourceAsStream(schemaPath1);
         JsonSchema schema = factory.getSchema(schemaInputStream);
         JsonNode node = getJsonNodeFromJsonData("/data/issue493-valid-1.json");
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertTrue(errors.isEmpty());
     }
 
@@ -48,7 +49,7 @@ class Issue493Test
         InputStream schemaInputStream = Issue493Test.class.getResourceAsStream(schemaPath1);
         JsonSchema schema = factory.getSchema(schemaInputStream);
         JsonNode node = getJsonNodeFromJsonData("/data/issue493-valid-2.json");
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertTrue(errors.isEmpty());
     }
 
@@ -60,7 +61,7 @@ class Issue493Test
         InputStream schemaInputStream = Issue493Test.class.getResourceAsStream(schemaPath1);
         JsonSchema schema = factory.getSchema(schemaInputStream);
         JsonNode node = getJsonNodeFromJsonData("/data/issue493-invalid-1.json");
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertEquals(2, errors.size());
 
         Set<String> allErrorMessages = new HashSet<>();
@@ -80,7 +81,7 @@ class Issue493Test
         InputStream schemaInputStream = Issue493Test.class.getResourceAsStream(schemaPath1);
         JsonSchema schema = factory.getSchema(schemaInputStream);
         JsonNode node = getJsonNodeFromJsonData("/data/issue493-invalid-2.json");
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertEquals(3, errors.size());
 
         Set<String> allErrorMessages = new HashSet<>();

--- a/src/test/java/com/networknt/schema/Issue550Test.java
+++ b/src/test/java/com/networknt/schema/Issue550Test.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 
 
 class Issue550Test {
@@ -30,7 +30,7 @@ class Issue550Test {
         JsonSchema schema = getJsonSchemaFromStreamContentV7(schemaPath);
         JsonNode node = getJsonNodeFromStreamContent(dataPath);
 
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         ValidationMessage validationMessage = errors.stream().findFirst().get();
 
         Assertions.assertEquals("https://example.com/person.schema.json#/properties/age/minimum", validationMessage.getSchemaLocation().toString());
@@ -44,7 +44,7 @@ class Issue550Test {
         JsonSchema schema = getJsonSchemaFromStreamContentV7(schemaPath);
         JsonNode node = getJsonNodeFromStreamContent(dataPath);
 
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         ValidationMessage validationMessage = errors.stream().findFirst().get();
 
         // Instead of capturing all subSchema within oneOf, a pointer to oneOf should be provided.

--- a/src/test/java/com/networknt/schema/Issue575Test.java
+++ b/src/test/java/com/networknt/schema/Issue575Test.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -79,7 +79,7 @@ class Issue575Test {
     @ParameterizedTest
     @MethodSource("validTimeZoneOffsets")
     void testValidTimeZoneOffsets(String jsonObject) throws JsonProcessingException {
-        Set<ValidationMessage> errors = schema.validate(new ObjectMapper().readTree(jsonObject));
+        List<ValidationMessage> errors = schema.validate(new ObjectMapper().readTree(jsonObject));
         Assertions.assertTrue(errors.isEmpty());
     }
 
@@ -121,7 +121,7 @@ class Issue575Test {
     @ParameterizedTest
     @MethodSource("invalidTimeRepresentations")
     void testInvalidTimeRepresentations(String jsonObject) throws JsonProcessingException {
-        Set<ValidationMessage> errors = schema.validate(new ObjectMapper().readTree(jsonObject), OutputFormat.DEFAULT, (executionContext, validationContext) -> {
+        List<ValidationMessage> errors = schema.validate(new ObjectMapper().readTree(jsonObject), OutputFormat.DEFAULT, (executionContext, validationContext) -> {
             executionContext.getExecutionConfig().setFormatAssertionsEnabled(true);
         });
         Assertions.assertFalse(errors.isEmpty());

--- a/src/test/java/com/networknt/schema/Issue606Test.java
+++ b/src/test/java/com/networknt/schema/Issue606Test.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 
 class Issue606Test {
     protected JsonSchema getJsonSchemaFromStreamContentV7(InputStream schemaContent) {
@@ -28,7 +28,7 @@ class Issue606Test {
         JsonSchema schema = getJsonSchemaFromStreamContentV7(schemaInputStream);
         InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
         JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertEquals(0, errors.size());
     }
 }

--- a/src/test/java/com/networknt/schema/Issue650Test.java
+++ b/src/test/java/com/networknt/schema/Issue650Test.java
@@ -1,7 +1,7 @@
 package com.networknt.schema;
 
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -46,7 +46,7 @@ class Issue650Test {
         JsonNode node = mapper.valueToTree(model);
 
         // validate:
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
 
         // check result:
         Assertions.assertTrue(errors.isEmpty());

--- a/src/test/java/com/networknt/schema/Issue662Test.java
+++ b/src/test/java/com/networknt/schema/Issue662Test.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Set;
 
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -24,21 +23,21 @@ class Issue662Test extends BaseJsonSchemaValidatorTest {
     @Test
     void testNoErrorsForEmptyObject() throws IOException {
         JsonNode node = getJsonNodeFromClasspath(resource("emptyObject.json"));
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         assertTrue(errors.isEmpty(), "No validation errors for empty optional object");
     }
 
     @Test
     void testNoErrorsForValidObject() throws IOException {
         JsonNode node = getJsonNodeFromClasspath(resource("validObject.json"));
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         assertTrue(errors.isEmpty(), "No validation errors for a valid optional object");
     }
 
     @Test
     void testCorrectErrorForInvalidValue() throws IOException {
         JsonNode node = getJsonNodeFromClasspath(resource("objectInvalidValue.json"));
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         List<String> errorMessages = errors.stream()
             .map(v -> v.getEvaluationPath() + " = " + v.getMessage())
             .collect(toList());

--- a/src/test/java/com/networknt/schema/Issue665Test.java
+++ b/src/test/java/com/networknt/schema/Issue665Test.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 
 class Issue665Test extends BaseJsonSchemaValidatorTest {
 
@@ -16,9 +16,9 @@ class Issue665Test extends BaseJsonSchemaValidatorTest {
         JsonSchema schema = getJsonSchemaFromClasspath("draft7/urn/issue665.json", SpecVersion.VersionFlag.V7);
         Assertions.assertNotNull(schema);
         Assertions.assertDoesNotThrow(schema::initializeValidators);
-        Set<ValidationMessage> messages = schema.validate(getJsonNodeFromStringContent(
+        List<ValidationMessage> messages = schema.validate(getJsonNodeFromStringContent(
                 "{\"myData\": {\"value\": \"hello\"}}"));
-        Assertions.assertEquals(messages, Collections.emptySet());
+        Assertions.assertTrue(messages.isEmpty());
     }
 
     @Test
@@ -36,9 +36,9 @@ class Issue665Test extends BaseJsonSchemaValidatorTest {
             JsonSchema schema = factory.getSchema(is);
             Assertions.assertNotNull(schema);
             Assertions.assertDoesNotThrow(schema::initializeValidators);
-            Set<ValidationMessage> messages = schema.validate(getJsonNodeFromStringContent(
+            List<ValidationMessage> messages = schema.validate(getJsonNodeFromStringContent(
                     "{\"myData\": {\"value\": \"hello\"}}"));
-            Assertions.assertEquals(messages, Collections.emptySet());
+            Assertions.assertTrue(messages.isEmpty());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/src/test/java/com/networknt/schema/Issue686Test.java
+++ b/src/test/java/com/networknt/schema/Issue686Test.java
@@ -8,9 +8,9 @@ import com.networknt.schema.i18n.ResourceBundleMessageSource;
 import org.junit.jupiter.api.Test;
 
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -59,7 +59,7 @@ class Issue686Test {
     }
 
     private void verify(SchemaValidatorsConfig config, String expectedMessage) throws JsonProcessingException {
-        Set<ValidationMessage> messages = getSchema(config).validate(new ObjectMapper().readTree(" { \"foo\": 123 } "));
+        List<ValidationMessage> messages = getSchema(config).validate(new ObjectMapper().readTree(" { \"foo\": 123 } "));
         assertEquals(1, messages.size());
         assertEquals(expectedMessage, messages.iterator().next().getMessage());
     }

--- a/src/test/java/com/networknt/schema/Issue687Test.java
+++ b/src/test/java/com/networknt/schema/Issue687Test.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -83,7 +83,7 @@ class Issue687Test {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().pathType(pathType).build();
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909);
         JsonSchema schema = factory.getSchema(Issue687Test.class.getResourceAsStream(schemaPath), config);
-        Set<ValidationMessage> messages = schema.validate(new ObjectMapper().readTree(content));
+        List<ValidationMessage> messages = schema.validate(new ObjectMapper().readTree(content));
         assertEquals(expectedMessagePaths.length, messages.size());
         for (String expectedPath: expectedMessagePaths) {
             assertTrue(messages.stream().anyMatch(msg -> expectedPath.equals(msg.getInstanceLocation().toString())));
@@ -124,7 +124,7 @@ class Issue687Test {
                         "        }\n" +
                         "    }\n" +
                         "}"), schemaValidatorsConfig);
-        Set<ValidationMessage> validationMessages = schema.validate(mapper.readTree("{\""+propertyName+"\": 1}"));
+        List<ValidationMessage> validationMessages = schema.validate(mapper.readTree("{\""+propertyName+"\": 1}"));
         assertEquals(1, validationMessages.size());
         assertEquals(expectedPath, validationMessages.iterator().next().getInstanceLocation().toString());
     }

--- a/src/test/java/com/networknt/schema/Issue724Test.java
+++ b/src/test/java/com/networknt/schema/Issue724Test.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -78,7 +77,7 @@ class Issue724Test {
         }
 
         @Override
-        public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+        public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
             // nothing to do here
         }
     }

--- a/src/test/java/com/networknt/schema/Issue784Test.java
+++ b/src/test/java/com/networknt/schema/Issue784Test.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Set;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -56,7 +56,7 @@ class Issue784Test {
     }
 
 
-    private Set<ValidationMessage> validate(JsonSchema jsonSchema, String myDateTimeContent) throws JsonProcessingException {
+    private List<ValidationMessage> validate(JsonSchema jsonSchema, String myDateTimeContent) throws JsonProcessingException {
         return jsonSchema.validate(new ObjectMapper().readTree(" { \"my-date-time\": \"" + myDateTimeContent + "\" } "));
     }
 

--- a/src/test/java/com/networknt/schema/Issue824Test.java
+++ b/src/test/java/com/networknt/schema/Issue824Test.java
@@ -2,7 +2,7 @@ package com.networknt.schema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,8 +26,8 @@ class Issue824Test {
                 "}");
 
         // Validate same JSON schema against v2019-09 spec schema twice
-        final Set<ValidationMessage> validationErrors1 = v201909SpecSchema.validate(invalidSchema);
-        final Set<ValidationMessage> validationErrors2 = v201909SpecSchema.validate(invalidSchema);
+        final List<ValidationMessage> validationErrors1 = v201909SpecSchema.validate(invalidSchema);
+        final List<ValidationMessage> validationErrors2 = v201909SpecSchema.validate(invalidSchema);
 
         // Validation errors should be the same
         assertEquals(validationErrors1, validationErrors2);

--- a/src/test/java/com/networknt/schema/Issue832Test.java
+++ b/src/test/java/com/networknt/schema/Issue832Test.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 class Issue832Test {
     private class NoMatchFormat implements Format {
@@ -56,7 +55,7 @@ class Issue832Test {
         JsonSchema schema = factory.getSchema(schemaInputStream);
         InputStream dataInputStream = getClass().getResourceAsStream(dataPath);
         JsonNode node = getJsonNodeFromStreamContent(dataInputStream);
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         // Both the custom no_match format and the standard email format should fail.
         // This ensures that both the standard and custom formatters have been invoked.
         Assertions.assertEquals(2, errors.size());

--- a/src/test/java/com/networknt/schema/Issue857Test.java
+++ b/src/test/java/com/networknt/schema/Issue857Test.java
@@ -17,7 +17,7 @@ package com.networknt.schema;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -50,7 +50,7 @@ class Issue857Test {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().failFast(true).build();
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
-        Set<ValidationMessage> result = factory.getSchema(schema, config).validate(input, InputFormat.JSON);
+        List<ValidationMessage> result = factory.getSchema(schema, config).validate(input, InputFormat.JSON);
         assertTrue(result.isEmpty());
     }
 }

--- a/src/test/java/com/networknt/schema/Issue927Test.java
+++ b/src/test/java/com/networknt/schema/Issue927Test.java
@@ -17,7 +17,7 @@ package com.networknt.schema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -127,7 +127,7 @@ class Issue927Test {
                 + "    ]\r\n"
                 + "  }\r\n"
                 + "}";
-        Set<ValidationMessage> messages = jsonSchema.validate(input, InputFormat.JSON);
+        List<ValidationMessage> messages = jsonSchema.validate(input, InputFormat.JSON);
         assertEquals(0, messages.size());
     }
 

--- a/src/test/java/com/networknt/schema/Issue939Test.java
+++ b/src/test/java/com/networknt/schema/Issue939Test.java
@@ -18,7 +18,7 @@ package com.networknt.schema;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -50,7 +50,7 @@ class Issue939Test {
                 + "        }";
         JsonSchema jsonSchema = JsonSchemaFactory.getInstance(VersionFlag.V7).getSchema(schema);
         assertDoesNotThrow(() -> jsonSchema.initializeValidators());
-        Set<ValidationMessage> assertions = jsonSchema
+        List<ValidationMessage> assertions = jsonSchema
                 .validate("{\"someUuid\":\"invalid\"}", InputFormat.JSON);
         assertEquals(2, assertions.size());
     }

--- a/src/test/java/com/networknt/schema/ItemsValidator202012Test.java
+++ b/src/test/java/com/networknt/schema/ItemsValidator202012Test.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -49,7 +48,7 @@ class ItemsValidator202012Test {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = factory.getSchema(schemaData, config);
         String inputData = "[1, \"x\"]";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertFalse(messages.isEmpty());
         ValidationMessage message = messages.iterator().next();
         assertEquals("/items/type", message.getEvaluationPath().toString());
@@ -76,7 +75,7 @@ class ItemsValidator202012Test {
             }
 
             @Override
-            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+            public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                 @SuppressWarnings("unchecked")
                 List<WalkEvent> items = (List<WalkEvent>) walkEvent.getExecutionContext()
                         .getCollectorContext()
@@ -115,7 +114,7 @@ class ItemsValidator202012Test {
             }
 
             @Override
-            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+            public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                 @SuppressWarnings("unchecked")
                 List<WalkEvent> items = (List<WalkEvent>) walkEvent.getExecutionContext()
                         .getCollectorContext()

--- a/src/test/java/com/networknt/schema/ItemsValidatorTest.java
+++ b/src/test/java/com/networknt/schema/ItemsValidatorTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -52,7 +51,7 @@ class ItemsValidatorTest {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = factory.getSchema(schemaData, config);
         String inputData = "[1, \"x\"]";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertFalse(messages.isEmpty());
         ValidationMessage message = messages.iterator().next();
         assertEquals("/items/type", message.getEvaluationPath().toString());
@@ -79,7 +78,7 @@ class ItemsValidatorTest {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = factory.getSchema(schemaData, config);
         String inputData = "[ null, 2, 3, \"foo\" ]";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertFalse(messages.isEmpty());
         ValidationMessage message = messages.iterator().next();
         assertEquals("/additionalItems/type", message.getEvaluationPath().toString());
@@ -106,7 +105,7 @@ class ItemsValidatorTest {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = factory.getSchema(schemaData, config);
         String inputData = "[ null, 2, 3, \"foo\" ]";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertFalse(messages.isEmpty());
         ValidationMessage message = messages.iterator().next();
         assertEquals("/additionalItems", message.getEvaluationPath().toString());
@@ -133,7 +132,7 @@ class ItemsValidatorTest {
             }
 
             @Override
-            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+            public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                 @SuppressWarnings("unchecked")
                 List<WalkEvent> items = (List<WalkEvent>) walkEvent.getExecutionContext()
                         .getCollectorContext()
@@ -169,7 +168,7 @@ class ItemsValidatorTest {
             }
 
             @Override
-            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+            public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                 @SuppressWarnings("unchecked")
                 List<WalkEvent> items = (List<WalkEvent>) walkEvent.getExecutionContext()
                         .getCollectorContext()
@@ -211,7 +210,7 @@ class ItemsValidatorTest {
             }
 
             @Override
-            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+            public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                 @SuppressWarnings("unchecked")
                 List<WalkEvent> items = (List<WalkEvent>) walkEvent.getExecutionContext()
                         .getCollectorContext()
@@ -261,7 +260,7 @@ class ItemsValidatorTest {
             }
 
             @Override
-            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+            public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                 @SuppressWarnings("unchecked")
                 List<WalkEvent> items = (List<WalkEvent>) walkEvent.getExecutionContext()
                         .getCollectorContext()
@@ -318,7 +317,7 @@ class ItemsValidatorTest {
                     }
 
                     @Override
-                    public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+                    public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                         @SuppressWarnings("unchecked")
                         List<WalkEvent> items = (List<WalkEvent>) walkEvent.getExecutionContext()
                                 .getCollectorContext()

--- a/src/test/java/com/networknt/schema/JsonWalkApplyDefaultsTest.java
+++ b/src/test/java/com/networknt/schema/JsonWalkApplyDefaultsTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Collectors;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -79,7 +79,7 @@ class JsonWalkApplyDefaultsTest {
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode inputNode = objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("data/walk-data-default.json"));
         JsonNode inputNodeOriginal = objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("data/walk-data-default.json"));
-        Set<ValidationMessage> validationMessages;
+        List<ValidationMessage> validationMessages;
         switch (method) {
             case "walkWithEmptyStrategy": {
                 JsonSchema jsonSchema = createSchema(new ApplyDefaultsStrategy(false, false, false));

--- a/src/test/java/com/networknt/schema/JsonWalkTest.java
+++ b/src/test/java/com/networknt/schema/JsonWalkTest.java
@@ -13,9 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.LinkedHashSet;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -168,14 +166,14 @@ class JsonWalkTest {
             }
 
             @Override
-            public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
-                return new TreeSet<>();
+            public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, JsonNodePath instanceLocation) {
+                return;
             }
 
             @Override
-            public Set<ValidationMessage> walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+            public void walk(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
                     JsonNodePath instanceLocation, boolean shouldValidateSchema) {
-                return new LinkedHashSet<ValidationMessage>();
+                return;
             }
         }
     }
@@ -199,7 +197,7 @@ class JsonWalkTest {
         }
 
         @Override
-        public void onWalkEnd(WalkEvent keywordWalkEvent, Set<ValidationMessage> validationMessages) {
+        public void onWalkEnd(WalkEvent keywordWalkEvent, List<ValidationMessage> validationMessages) {
 
         }
     }
@@ -220,7 +218,7 @@ class JsonWalkTest {
         }
 
         @Override
-        public void onWalkEnd(WalkEvent keywordWalkEvent, Set<ValidationMessage> validationMessages) {
+        public void onWalkEnd(WalkEvent keywordWalkEvent, List<ValidationMessage> validationMessages) {
 
         }
     }
@@ -237,7 +235,7 @@ class JsonWalkTest {
         }
 
         @Override
-        public void onWalkEnd(WalkEvent keywordWalkEvent, Set<ValidationMessage> validationMessages) {
+        public void onWalkEnd(WalkEvent keywordWalkEvent, List<ValidationMessage> validationMessages) {
 
         }
     }

--- a/src/test/java/com/networknt/schema/LocaleTest.java
+++ b/src/test/java/com/networknt/schema/LocaleTest.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -58,7 +57,8 @@ class LocaleTest {
         ExecutionContext executionContext = jsonSchema.createExecutionContext();
         assertEquals(config.getLocale(), executionContext.getExecutionConfig().getLocale());
         executionContext.getExecutionConfig().setLocale(locale);
-        Set<ValidationMessage> messages = jsonSchema.validate(executionContext, rootNode);
+        jsonSchema.validate(executionContext, rootNode);
+        List<ValidationMessage> messages = executionContext.getErrors();
         assertEquals(1, messages.size());
         assertEquals("/foo: integer trouvé, string attendu", messages.iterator().next().getMessage());
 
@@ -66,7 +66,8 @@ class LocaleTest {
         executionContext = jsonSchema.createExecutionContext();
         assertEquals(config.getLocale(), executionContext.getExecutionConfig().getLocale());
         executionContext.getExecutionConfig().setLocale(locale);
-        messages = jsonSchema.validate(executionContext, rootNode);
+        jsonSchema.validate(executionContext, rootNode);
+        messages = executionContext.getErrors();
         assertEquals(1, messages.size());
         assertEquals("/foo: integer trovato, string previsto", messages.iterator().next().getMessage());
     }
@@ -92,7 +93,7 @@ class LocaleTest {
             JsonSchema jsonSchema = JsonSchemaFactory.getInstance(VersionFlag.V7)
                     .getSchema(JsonMapperFactory.getInstance().readTree(schema));
             String input = "1";
-            Set<ValidationMessage> messages = jsonSchema.validate(input, InputFormat.JSON);
+            List<ValidationMessage> messages = jsonSchema.validate(input, InputFormat.JSON);
             assertEquals(1, messages.size());
             assertEquals("$: integer gefunden, object erwartet", messages.iterator().next().toString());
             
@@ -158,7 +159,7 @@ class LocaleTest {
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V7).getSchema(schemaData);
         List<Locale> locales = Locales.getSupportedLocales();
         for (Locale locale : locales) {
-            Set<ValidationMessage> messages = schema.validate("\"aaaaaa\"", InputFormat.JSON, executionContext -> {
+            List<ValidationMessage> messages = schema.validate("\"aaaaaa\"", InputFormat.JSON, executionContext -> {
                 executionContext.getExecutionConfig().setLocale(locale);
             });
             String msg = messages.iterator().next().toString();

--- a/src/test/java/com/networknt/schema/MaximumValidatorTest.java
+++ b/src/test/java/com/networknt/schema/MaximumValidatorTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.Set;
+import java.util.List;
 
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -189,13 +189,13 @@ class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
             // Schema and document parsed with just double
             JsonSchema v = factory.getSchema(mapper.readTree(schema), config);
             JsonNode doc = mapper.readTree(value);
-            Set<ValidationMessage> messages = v.validate(doc);
+            List<ValidationMessage> messages = v.validate(doc);
             assertTrue(messages.isEmpty(), format("Maximum %s and value %s are interpreted as Infinity, thus no schema violation should be reported", maximum, value));
 
             // document parsed with BigDecimal
 
             doc = bigDecimalMapper.readTree(value);
-            Set<ValidationMessage> messages2 = v.validate(doc);
+            List<ValidationMessage> messages2 = v.validate(doc);
             if (Double.valueOf(maximum).equals(Double.POSITIVE_INFINITY)) {
                 assertTrue(messages2.isEmpty(), format("Maximum %s and value %s are equal, thus no schema violation should be reported", maximum, value));
             } else {
@@ -205,7 +205,7 @@ class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
 
             // schema and document parsed with BigDecimal
             v = factory.getSchema(bigDecimalMapper.readTree(schema), config);
-            Set<ValidationMessage> messages3 = v.validate(doc);
+            List<ValidationMessage> messages3 = v.validate(doc);
             //when the schema and value are both using BigDecimal, the value should be parsed in same mechanism.
             String theValue = value.toLowerCase().replace("\"", "");
             if (maximum.toLowerCase().equals(theValue)) {
@@ -228,7 +228,7 @@ class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
         JsonNode doc = mapper.readTree(content);
         JsonSchema v = factory.getSchema(mapper.readTree(schema));
 
-        Set<ValidationMessage> messages = v.validate(doc);
+        List<ValidationMessage> messages = v.validate(doc);
         assertTrue(messages.isEmpty(), "Validation should succeed as by default double values are used by mapper");
 
         doc = bigDecimalMapper.readTree(content);
@@ -260,7 +260,7 @@ class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
         JsonNode doc = mapper.readTree(content);
         JsonSchema v = factory.getSchema(mapper.readTree(schema));
 
-        Set<ValidationMessage> messages = v.validate(doc);
+        List<ValidationMessage> messages = v.validate(doc);
         assertTrue(messages.isEmpty(), "Validation should succeed as by default double values are used by mapper");
 
         doc = bigDecimalMapper.readTree(content);
@@ -299,7 +299,7 @@ class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
             JsonSchema v = factory.getSchema(mapper.readTree(schema), config);
             JsonNode doc = mapper.readTree(value);
 
-            Set<ValidationMessage> messages = v.validate(doc);
+            List<ValidationMessage> messages = v.validate(doc);
             assertTrue(messages.isEmpty(), format(MaximumValidatorTest.POSITIVE_TEST_CASE_TEMPLATE, maximum, value));
         }
     }
@@ -319,7 +319,7 @@ class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
             JsonSchema v = factory.getSchema(mapper.readTree(schema));
             JsonNode doc = mapper2.readTree(value);
 
-            Set<ValidationMessage> messages = v.validate(doc);
+            List<ValidationMessage> messages = v.validate(doc);
             assertFalse(messages.isEmpty(), format(MaximumValidatorTest.NEGATIVE_TEST_CASE_TEMPLATE, value, maximum));
         }
     }

--- a/src/test/java/com/networknt/schema/MessageTest.java
+++ b/src/test/java/com/networknt/schema/MessageTest.java
@@ -17,8 +17,7 @@ package com.networknt.schema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -42,15 +41,13 @@ class MessageTest {
         }
 
         @Override
-        public Set<ValidationMessage> validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
+        public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
                 JsonNodePath instanceLocation) {
             if (!node.asText().equals(value)) {
-                return Collections
-                        .singleton(message().message("{0}: must be equal to ''{1}''")
+                executionContext.addError(message().message("{0}: must be equal to ''{1}''")
                                 .arguments(value)
                                 .instanceLocation(instanceLocation).instanceNode(node).build());
             }
-            return Collections.emptySet();
         }
     }
     
@@ -79,7 +76,7 @@ class MessageTest {
                 + "  \"equals\": \"helloworld\"\r\n"
                 + "}";
         JsonSchema schema = factory.getSchema(schemaData);
-        Set<ValidationMessage> messages = schema.validate("\"helloworlda\"", InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate("\"helloworlda\"", InputFormat.JSON);
         assertEquals(1, messages.size());
         assertEquals("$: must be equal to 'helloworld'", messages.iterator().next().getMessage());
         

--- a/src/test/java/com/networknt/schema/MetaSchemaValidationTest.java
+++ b/src/test/java/com/networknt/schema/MetaSchemaValidationTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -46,7 +46,7 @@ class MetaSchemaValidationTest {
                             builder -> builder.schemaMappers(schemaMappers -> schemaMappers
                                     .mapPrefix("https://spec.openapis.org/oas/3.1", "classpath:oas/3.1")))
                     .getSchema(SchemaLocation.of("https://spec.openapis.org/oas/3.1/schema-base/2022-10-07"), config);
-            Set<ValidationMessage> messages = schema.validate(inputData);
+            List<ValidationMessage> messages = schema.validate(inputData);
             assertEquals(0, messages.size());
         }
     }

--- a/src/test/java/com/networknt/schema/MinimumValidatorTest.java
+++ b/src/test/java/com/networknt/schema/MinimumValidatorTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -177,12 +177,12 @@ class MinimumValidatorTest {
             // Schema and document parsed with just double
             JsonSchema v = factory.getSchema(mapper.readTree(schema), config);
             JsonNode doc = mapper.readTree(value);
-            Set<ValidationMessage> messages = v.validate(doc);
+            List<ValidationMessage> messages = v.validate(doc);
             assertTrue(messages.isEmpty(), format("Minimum %s and value %s are interpreted as Infinity, thus no schema violation should be reported", minimum, value));
 
             // document parsed with BigDecimal
             doc = bigDecimalMapper.readTree(value);
-            Set<ValidationMessage> messages2 = v.validate(doc);
+            List<ValidationMessage> messages2 = v.validate(doc);
 
             //when the schema and value are both using BigDecimal, the value should be parsed in same mechanism.
             if (Double.valueOf(minimum).equals(Double.NEGATIVE_INFINITY)) {
@@ -197,7 +197,7 @@ class MinimumValidatorTest {
 
             // schema and document parsed with BigDecimal
             v = factory.getSchema(bigDecimalMapper.readTree(schema), config);
-            Set<ValidationMessage> messages3 = v.validate(doc);
+            List<ValidationMessage> messages3 = v.validate(doc);
             //when the schema and value are both using BigDecimal, the value should be parsed in same mechanism.
             String theValue = value.toLowerCase().replace("\"", "");
             if (minimum.toLowerCase().equals(theValue)) {
@@ -220,7 +220,7 @@ class MinimumValidatorTest {
         JsonNode doc = mapper.readTree(content);
         JsonSchema v = factory.getSchema(mapper.readTree(schema));
 
-        Set<ValidationMessage> messages = v.validate(doc);
+        List<ValidationMessage> messages = v.validate(doc);
         assertTrue(messages.isEmpty(), "Validation should succeed as by default double values are used by mapper");
 
         doc = bigDecimalMapper.readTree(content);
@@ -250,7 +250,7 @@ class MinimumValidatorTest {
         JsonNode doc = mapper.readTree(content);
         JsonSchema v = factory.getSchema(mapper.readTree(schema));
 
-        Set<ValidationMessage> messages = v.validate(doc);
+        List<ValidationMessage> messages = v.validate(doc);
         assertTrue(messages.isEmpty(), "Validation should succeed as by default double values are used by mapper");
 
         doc = bigDecimalMapper.readTree(content);
@@ -273,7 +273,7 @@ class MinimumValidatorTest {
             JsonSchema v = factory.getSchema(mapper.readTree(schema));
             JsonNode doc = mapper2.readTree(value);
 
-            Set<ValidationMessage> messages = v.validate(doc);
+            List<ValidationMessage> messages = v.validate(doc);
             assertFalse(messages.isEmpty(), format(MinimumValidatorTest.NEGATIVE_MESSAGE_TEMPLATE, value, minimum));
         }
     }
@@ -292,7 +292,7 @@ class MinimumValidatorTest {
             JsonSchema v = factory.getSchema(mapper.readTree(schema), config);
             JsonNode doc = bigIntegerMapper.readTree(value);
 
-            Set<ValidationMessage> messages = v.validate(doc);
+            List<ValidationMessage> messages = v.validate(doc);
             assertTrue(messages.isEmpty(), format(MinimumValidatorTest.POSITIVT_MESSAGE_TEMPLATE, value, minimum));
         }
     }

--- a/src/test/java/com/networknt/schema/MultipleOfValidatorTest.java
+++ b/src/test/java/com/networknt/schema/MultipleOfValidatorTest.java
@@ -17,7 +17,7 @@ package com.networknt.schema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -52,7 +52,7 @@ class MultipleOfValidatorTest {
         String inputData = "{\"value1\":123.892,\"value2\":123456.2934,\"value3\":123.123}";
         String validData = "{\"value1\":123.89,\"value2\":123456,\"value3\":123.010}";
         
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(3, messages.size());
         assertEquals(3, messages.stream().filter(m -> "multipleOf".equals(m.getType())).count());
         
@@ -69,7 +69,7 @@ class MultipleOfValidatorTest {
         String validTypeLooseInputData = "{\"value1\":\"123.89\",\"value2\":\"123456.29\",\"value3\":123.12}";
         
         // Without type loose this has 2 type and 1 multipleOf errors
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(3, messages.size());
         assertEquals(2, messages.stream().filter(m -> "type".equals(m.getType())).count());
         assertEquals(1, messages.stream().filter(m -> "multipleOf".equals(m.getType())).count());

--- a/src/test/java/com/networknt/schema/OneOfValidatorTest.java
+++ b/src/test/java/com/networknt/schema/OneOfValidatorTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -66,7 +65,7 @@ class OneOfValidatorTest {
                 + "  \"world\" : \"test\"\r\n"
                 + "}";
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData);
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(3, messages.size()); // even if more than 1 matches the mismatch errors are still reported
         List<ValidationMessage> assertions = messages.stream().collect(Collectors.toList());
         assertEquals("oneOf", assertions.get(0).getType());
@@ -107,7 +106,7 @@ class OneOfValidatorTest {
                 + "  \"test\" : 1\r\n"
                 + "}";
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData);
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(4, messages.size());
         List<ValidationMessage> assertions = messages.stream().collect(Collectors.toList());
         assertEquals("oneOf", assertions.get(0).getType());
@@ -140,7 +139,7 @@ class OneOfValidatorTest {
                 + "}";
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
         JsonSchemaException ex = assertThrows(JsonSchemaException.class, () -> factory.getSchema(schemaData));
-        assertEquals("type", ex.getValidationMessage().getMessageKey());
+        assertEquals("type", ex.getError().getMessageKey());
     }
 
     /**
@@ -305,7 +304,7 @@ class OneOfValidatorTest {
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData,
                 SchemaValidatorsConfig.builder().discriminatorKeywordEnabled(true).build());
         String inputData = "{}";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(3, messages.size());
     }
 
@@ -363,7 +362,7 @@ class OneOfValidatorTest {
                 + "  \"type\": \"number\",\r\n"
                 + "  \"value\": 1\r\n"
                 + "}";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(0, messages.size());
 
         // Invalid only 1 message returned for number
@@ -371,13 +370,13 @@ class OneOfValidatorTest {
                 + "  \"type\": \"number\",\r\n"
                 + "  \"value\": {}\r\n"
                 + "}";
-        Set<ValidationMessage> messages2 = schema.validate(inputData2, InputFormat.JSON);
+        List<ValidationMessage> messages2 = schema.validate(inputData2, InputFormat.JSON);
         assertEquals(2, messages2.size());
 
         // Invalid both messages for string and object returned
         JsonSchema schema2 = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData,
                 SchemaValidatorsConfig.builder().discriminatorKeywordEnabled(false).build());
-        Set<ValidationMessage> messages3 = schema2.validate(inputData2, InputFormat.JSON);
+        List<ValidationMessage> messages3 = schema2.validate(inputData2, InputFormat.JSON);
         assertEquals(3, messages3.size());
     }
 
@@ -451,7 +450,7 @@ class OneOfValidatorTest {
                 + "  \"type\": \"number\",\r\n"
                 + "  \"value\": 1\r\n"
                 + "}";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(0, messages.size());
 
         // Invalid only 1 message returned for number
@@ -459,13 +458,13 @@ class OneOfValidatorTest {
                 + "  \"type\": \"number\",\r\n"
                 + "  \"value\": {}\r\n"
                 + "}";
-        Set<ValidationMessage> messages2 = schema.validate(inputData2, InputFormat.JSON);
+        List<ValidationMessage> messages2 = schema.validate(inputData2, InputFormat.JSON);
         assertEquals(2, messages2.size());
 
         // Invalid both messages for string and object returned
         JsonSchema schema2 = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData,
                 SchemaValidatorsConfig.builder().discriminatorKeywordEnabled(false).build());
-        Set<ValidationMessage> messages3 = schema2.validate(inputData2, InputFormat.JSON);
+        List<ValidationMessage> messages3 = schema2.validate(inputData2, InputFormat.JSON);
         assertEquals(3, messages3.size());
     }
 

--- a/src/test/java/com/networknt/schema/OutputFormatTest.java
+++ b/src/test/java/com/networknt/schema/OutputFormatTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.InputStream;
-import java.util.LinkedHashSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -38,7 +38,7 @@ class OutputFormatTest {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = factory.getSchema(schemaInputStream, config);
         JsonNode node = getJsonNodeFromJsonData("/data/output-format-input.json");
-        Set<ValidationMessage> errors = schema.validate(node);
+        List<ValidationMessage> errors = schema.validate(node);
         Assertions.assertEquals(3, errors.size());
 
         Set<String[]> messages = errors.stream().map(m -> new String[] { m.getEvaluationPath().toString(),
@@ -53,7 +53,7 @@ class OutputFormatTest {
                         new String[] { "/items/$ref/required", "https://example.com/polygon#/$defs/point/required", "/1", "/1: required property 'y' not found"}));
     }
 
-    public static class Detailed implements OutputFormat<Set<ValidationMessage>> {
+    public static class Detailed implements OutputFormat<List<ValidationMessage>> {
         private ValidationMessage format(ValidationMessage message) {
             Supplier<String> messageSupplier = () -> {
                 StringBuilder builder = new StringBuilder();
@@ -84,13 +84,13 @@ class OutputFormatTest {
         }
 
         @Override
-        public Set<ValidationMessage> format(JsonSchema jsonSchema, Set<ValidationMessage> validationMessages,
+        public java.util.List<ValidationMessage> format(JsonSchema jsonSchema,
                 ExecutionContext executionContext, ValidationContext validationContext) {
-            return validationMessages.stream().map(this::format).collect(Collectors.toCollection(LinkedHashSet::new));
+            return executionContext.getErrors().stream().map(this::format).collect(Collectors.toCollection(ArrayList::new));
         }
     }
 
-    public static final OutputFormat<Set<ValidationMessage>> DETAILED = new Detailed();
+    public static final OutputFormat<List<ValidationMessage>> DETAILED = new Detailed();
 
     @Test
     void customFormat() {

--- a/src/test/java/com/networknt/schema/OverrideValidatorTest.java
+++ b/src/test/java/com/networknt/schema/OverrideValidatorTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Set;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -56,7 +56,7 @@ class OverrideValidatorTest {
         final JsonSchemaFactory validatorFactory = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909)).metaSchema(validatorMetaSchema).build();
         final JsonSchema validatorSchema = validatorFactory.getSchema(schema);
 
-        Set<ValidationMessage> messages = validatorSchema.validate(targetNode, OutputFormat.DEFAULT, (executionContext, validationContext) -> {
+        List<ValidationMessage> messages = validatorSchema.validate(targetNode, OutputFormat.DEFAULT, (executionContext, validationContext) -> {
             executionContext.getExecutionConfig().setFormatAssertionsEnabled(true);
         });
 

--- a/src/test/java/com/networknt/schema/OverwritingCustomMessageBugTest.java
+++ b/src/test/java/com/networknt/schema/OverwritingCustomMessageBugTest.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.SpecVersion.VersionFlag;
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -23,7 +23,7 @@ class OverwritingCustomMessageBugTest {
 
   @Test
   void customMessageIsNotOverwritten() throws Exception {
-    Set<ValidationMessage> errors = validate();
+    List<ValidationMessage> errors = validate();
     Map<String, String> errorMsgMap = transferErrorMsg(errors);
     Assertions.assertTrue(errorMsgMap.containsKey("$.toplevel[1].foos"), "error message must contains key: $.foos");
     Assertions.assertTrue(errorMsgMap.containsKey("$.toplevel[1].bars"), "error message must contains key: $.bars");
@@ -32,7 +32,7 @@ class OverwritingCustomMessageBugTest {
   }
 
 
-  private Set<ValidationMessage> validate() throws Exception {
+  private List<ValidationMessage> validate() throws Exception {
     String schemaPath = "/schema/OverwritingCustomMessageBug.json";
     String dataPath = "/data/OverwritingCustomMessageBug.json";
     InputStream schemaInputStream = OverwritingCustomMessageBugTest.class.getResourceAsStream(schemaPath);
@@ -42,7 +42,7 @@ class OverwritingCustomMessageBugTest {
     return schema.validate(node);
   }
 
-  private Map<String, String> transferErrorMsg(Set<ValidationMessage> validationMessages) {
+  private Map<String, String> transferErrorMsg(List<ValidationMessage> validationMessages) {
     Map<String, String> pathToMessage = new HashMap<>();
     validationMessages.forEach(msg -> {
       pathToMessage.put(msg.getInstanceLocation().toString(), msg.getMessage());

--- a/src/test/java/com/networknt/schema/PatternPropertiesValidatorTest.java
+++ b/src/test/java/com/networknt/schema/PatternPropertiesValidatorTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -44,7 +45,7 @@ class PatternPropertiesValidatorTest extends BaseJsonSchemaValidatorTest {
             JsonSchema schema = factory.getSchema("{\"patternProperties\":6}");
 
             JsonNode node = getJsonNodeFromStringContent("");
-            Set<ValidationMessage> errors = schema.validate(node);
+            List<ValidationMessage> errors = schema.validate(node);
             Assertions.assertEquals(errors.size(), 0);
         });
     }
@@ -59,7 +60,7 @@ class PatternPropertiesValidatorTest extends BaseJsonSchemaValidatorTest {
             JsonSchema schema = factory.getSchema("{\"patternProperties\":6}", config);
 
             JsonNode node = getJsonNodeFromStringContent("");
-            Set<ValidationMessage> errors = schema.validate(node);
+            List<ValidationMessage> errors = schema.validate(node);
             Assertions.assertEquals(errors.size(), 0);
         });
     }
@@ -86,7 +87,7 @@ class PatternPropertiesValidatorTest extends BaseJsonSchemaValidatorTest {
                 + "  \"valid_string\": \"string_value\",\n"
                 + "  \"valid_key\": 5\n"
                 + "}";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertFalse(messages.isEmpty());
         ValidationMessage message = messages.iterator().next();
         assertEquals("/patternProperties/^valid_/type", message.getEvaluationPath().toString());

--- a/src/test/java/com/networknt/schema/PrefixItemsValidatorTest.java
+++ b/src/test/java/com/networknt/schema/PrefixItemsValidatorTest.java
@@ -14,7 +14,6 @@ import com.networknt.schema.walk.WalkFlow;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,7 +57,7 @@ class PrefixItemsValidatorTest extends AbstractJsonSchemaTestSuite {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = factory.getSchema(schemaData, config);
         String inputData = "[1, \"x\"]";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertFalse(messages.isEmpty());
         ValidationMessage message = messages.iterator().next();
         assertEquals("/prefixItems/0/type", message.getEvaluationPath().toString());
@@ -84,7 +83,7 @@ class PrefixItemsValidatorTest extends AbstractJsonSchemaTestSuite {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = factory.getSchema(schemaData, config);
         String inputData = "[\"x\", 1, 1]";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 
@@ -103,7 +102,7 @@ class PrefixItemsValidatorTest extends AbstractJsonSchemaTestSuite {
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = factory.getSchema(schemaData, config);
         String inputData = "[\"x\", 1, 1, 2]";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertFalse(messages.isEmpty());
         ValidationMessage message = messages.iterator().next();
         assertEquals("/items", message.getEvaluationPath().toString());
@@ -138,7 +137,7 @@ class PrefixItemsValidatorTest extends AbstractJsonSchemaTestSuite {
             }
 
             @Override
-            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+            public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                 @SuppressWarnings("unchecked")
                 List<WalkEvent> items = (List<WalkEvent>) walkEvent.getExecutionContext()
                         .getCollectorContext()
@@ -194,7 +193,7 @@ class PrefixItemsValidatorTest extends AbstractJsonSchemaTestSuite {
                     }
 
                     @Override
-                    public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+                    public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                         @SuppressWarnings("unchecked")
                         List<WalkEvent> items = (List<WalkEvent>) walkEvent.getExecutionContext()
                                 .getCollectorContext()

--- a/src/test/java/com/networknt/schema/PropertyNamesValidatorTest.java
+++ b/src/test/java/com/networknt/schema/PropertyNamesValidatorTest.java
@@ -18,7 +18,7 @@ package com.networknt.schema;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -45,7 +45,7 @@ class PropertyNamesValidatorTest {
                 + "  \"foo\": {},\r\n"
                 + "  \"foobar\": {}\r\n"
                 + "}";
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertFalse(messages.isEmpty());
         ValidationMessage message = messages.iterator().next();
         assertEquals("/propertyNames", message.getEvaluationPath().toString());

--- a/src/test/java/com/networknt/schema/ReadOnlyValidatorTest.java
+++ b/src/test/java/com/networknt/schema/ReadOnlyValidatorTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -19,14 +19,14 @@ class ReadOnlyValidatorTest {
 	@Test
 	void givenConfigWriteFalseWhenReadOnlyTrueThenAllows() throws IOException {
 		ObjectNode node = getJsonNode();
-		Set<ValidationMessage> errors = loadJsonSchema(false).validate(node);
+		List<ValidationMessage> errors = loadJsonSchema(false).validate(node);
 		assertTrue(errors.isEmpty());
 	}
 
 	@Test
 	void givenConfigWriteTrueWhenReadOnlyTrueThenDenies() throws IOException {
 		ObjectNode node = getJsonNode();
-		Set<ValidationMessage> errors = loadJsonSchema(true).validate(node);
+		List<ValidationMessage> errors = loadJsonSchema(true).validate(node);
 		assertFalse(errors.isEmpty());
 		assertEquals("/firstName: is a readonly field, it cannot be changed",
 				errors.stream().map(e -> e.getMessage()).collect(Collectors.toList()).get(0));

--- a/src/test/java/com/networknt/schema/RefTest.java
+++ b/src/test/java/com/networknt/schema/RefTest.java
@@ -2,7 +2,7 @@ package com.networknt.schema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,7 +26,7 @@ class RefTest {
                 + "  }\r\n"
                 + "}";
         assertEquals(SchemaId.V4, schema.getValidationContext().getMetaSchema().getIri());
-        Set<ValidationMessage> errors = schema.validate(OBJECT_MAPPER.readTree(input));
+        List<ValidationMessage> errors = schema.validate(OBJECT_MAPPER.readTree(input));
         assertEquals(1, errors.size());
         ValidationMessage error = errors.iterator().next();
         assertEquals("classpath:///schema/ref-ref.json#/definitions/DriverProperties/required",
@@ -49,7 +49,7 @@ class RefTest {
                 + "  }\r\n"
                 + "}";
         assertEquals(SchemaId.V4, schema.getValidationContext().getMetaSchema().getIri());
-        Set<ValidationMessage> errors = schema.validate(OBJECT_MAPPER.readTree(input));
+        List<ValidationMessage> errors = schema.validate(OBJECT_MAPPER.readTree(input));
         assertEquals(1, errors.size());
         ValidationMessage error = errors.iterator().next();
         assertEquals("https://www.example.org/common#/definitions/DriverProperties/required",

--- a/src/test/java/com/networknt/schema/RefValidatorTest.java
+++ b/src/test/java/com/networknt/schema/RefValidatorTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +44,7 @@ class RefValidatorTest {
                 builder -> builder.schemaLoaders(schemaLoaders -> schemaLoaders.schemas(
                         Collections.singletonMap("https://www.example.com/schema/integer.json", otherSchema))));
         JsonSchema jsonSchema = factory.getSchema(mainSchema);
-        Set<ValidationMessage> messages = jsonSchema.validate("\"string\"", InputFormat.JSON);
+        List<ValidationMessage> messages = jsonSchema.validate("\"string\"", InputFormat.JSON);
         assertEquals(1, messages.size());
     }
 
@@ -63,7 +63,7 @@ class RefValidatorTest {
                 builder -> builder.schemaLoaders(schemaLoaders -> schemaLoaders.schemas(
                         Collections.singletonMap("https://www.example.com/schema/integer.json", otherSchema))));
         JsonSchema jsonSchema = factory.getSchema(mainSchema);
-        Set<ValidationMessage> messages = jsonSchema.validate("\"string\"", InputFormat.JSON);
+        List<ValidationMessage> messages = jsonSchema.validate("\"string\"", InputFormat.JSON);
         assertEquals(1, messages.size());
     }
 
@@ -82,7 +82,7 @@ class RefValidatorTest {
                 builder -> builder.schemaLoaders(schemaLoaders -> schemaLoaders.schemas(
                         Collections.singletonMap("https://www.example.com/integer.json", otherSchema))));
         JsonSchema jsonSchema = factory.getSchema(mainSchema);
-        Set<ValidationMessage> messages = jsonSchema.validate("\"string\"", InputFormat.JSON);
+        List<ValidationMessage> messages = jsonSchema.validate("\"string\"", InputFormat.JSON);
         assertEquals(1, messages.size());
     }
 
@@ -101,7 +101,7 @@ class RefValidatorTest {
                 builder -> builder.schemaLoaders(schemaLoaders -> schemaLoaders.schemas(
                         Collections.singletonMap("https://www.example.com/schema/hello/integer.json", otherSchema))));
         JsonSchema jsonSchema = factory.getSchema(mainSchema);
-        Set<ValidationMessage> messages = jsonSchema.validate("\"string\"", InputFormat.JSON);
+        List<ValidationMessage> messages = jsonSchema.validate("\"string\"", InputFormat.JSON);
         assertEquals(1, messages.size());
     }
 

--- a/src/test/java/com/networknt/schema/SampleTest.java
+++ b/src/test/java/com/networknt/schema/SampleTest.java
@@ -3,7 +3,7 @@ package com.networknt.schema;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +31,7 @@ class SampleTest {
          * initializeValidators()
          */
         schemaFromSchemaLocation.initializeValidators();
-        Set<ValidationMessage> errors = schemaFromSchemaLocation.validate("{\"id\": \"2\"}", InputFormat.JSON,
+        List<ValidationMessage> errors = schemaFromSchemaLocation.validate("{\"id\": \"2\"}", InputFormat.JSON,
                 executionContext -> executionContext.getExecutionConfig().setFormatAssertionsEnabled(true));
         assertEquals(1, errors.size());
     }
@@ -54,7 +54,7 @@ class SampleTest {
          * initializeValidators()
          */
         schemaFromSchemaLocation.initializeValidators();
-        Set<ValidationMessage> errors = schemaFromSchemaLocation.validate("{\"id\": \"2\"}", InputFormat.JSON,
+        List<ValidationMessage> errors = schemaFromSchemaLocation.validate("{\"id\": \"2\"}", InputFormat.JSON,
                 executionContext -> executionContext.getExecutionConfig().setFormatAssertionsEnabled(true));
         assertEquals(1, errors.size());
     }
@@ -75,7 +75,7 @@ class SampleTest {
          * initializeValidators()
          */
         schemaFromClasspath.initializeValidators();
-        Set<ValidationMessage> errors = schemaFromClasspath.validate("{\"id\": \"2\"}", InputFormat.JSON,
+        List<ValidationMessage> errors = schemaFromClasspath.validate("{\"id\": \"2\"}", InputFormat.JSON,
                 executionContext -> executionContext.getExecutionConfig().setFormatAssertionsEnabled(true));
         assertEquals(1, errors.size());
     }
@@ -91,7 +91,7 @@ class SampleTest {
          */
         JsonSchema schemaFromString = factory
                 .getSchema("{\"enum\":[1, 2, 3, 4]}");
-        Set<ValidationMessage> errors = schemaFromString.validate("7", InputFormat.JSON,
+        List<ValidationMessage> errors = schemaFromString.validate("7", InputFormat.JSON,
                 executionContext -> executionContext.getExecutionConfig().setFormatAssertionsEnabled(true));
         assertEquals(1, errors.size());
     }
@@ -117,7 +117,7 @@ class SampleTest {
          * initializeValidators()
          */
         schemaFromNode.initializeValidators();
-        Set<ValidationMessage> errors = schemaFromNode.validate("{\"id\": \"2\"}", InputFormat.JSON,
+        List<ValidationMessage> errors = schemaFromNode.validate("{\"id\": \"2\"}", InputFormat.JSON,
                 executionContext -> executionContext.getExecutionConfig().setFormatAssertionsEnabled(true));
         assertEquals(1, errors.size());
     }

--- a/src/test/java/com/networknt/schema/SchemaLocationTest.java
+++ b/src/test/java/com/networknt/schema/SchemaLocationTest.java
@@ -17,7 +17,7 @@ package com.networknt.schema;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -220,7 +220,7 @@ class SchemaLocationTest {
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V202012);
         JsonSchema schema = factory.getSchema(SchemaLocation
                 .of("classpath:schema/example-escaped.yaml#/paths/~1users/post/requestBody/application~1json/schema"));
-        Set<ValidationMessage> result = schema.validate("1", InputFormat.JSON);
+        List<ValidationMessage> result = schema.validate("1", InputFormat.JSON);
         assertFalse(result.isEmpty());
         result = schema.validate("{}", InputFormat.JSON);
         assertTrue(result.isEmpty());

--- a/src/test/java/com/networknt/schema/SharedConfigTest.java
+++ b/src/test/java/com/networknt/schema/SharedConfigTest.java
@@ -1,6 +1,6 @@
 package com.networknt.schema;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -24,7 +24,7 @@ class SharedConfigTest {
         }
 
         @Override
-        public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+        public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
         }
     }
 

--- a/src/test/java/com/networknt/schema/TypeValidatorTest.java
+++ b/src/test/java/com/networknt/schema/TypeValidatorTest.java
@@ -18,7 +18,7 @@ package com.networknt.schema;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -68,7 +68,7 @@ class TypeValidatorTest {
                 + "  \"array_of_objects\": {}\r\n"
                 + "}";        
         // Without type loose this has 2 type errors
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(2, messages.size());
         assertEquals(2, messages.stream().filter(m -> "type".equals(m.getType())).count());
 
@@ -102,7 +102,7 @@ class TypeValidatorTest {
                 + "  \"type\": \"integer\"\r\n"
                 + "}";
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData);
-        Set<ValidationMessage> messages = schema.validate("1", InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate("1", InputFormat.JSON);
         assertEquals(0, messages.size());
         messages = schema.validate("2.0", InputFormat.JSON);
         assertEquals(0, messages.size());
@@ -131,7 +131,7 @@ class TypeValidatorTest {
                 + "  \"type\": \"integer\"\r\n"
                 + "}";
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V4).getSchema(schemaData);
-        Set<ValidationMessage> messages = schema.validate("1", InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate("1", InputFormat.JSON);
         assertEquals(0, messages.size());
         // The logic in JsonNodeUtil specifically excludes V4 from this handling
         messages = schema.validate("2.0", InputFormat.JSON);
@@ -178,7 +178,7 @@ class TypeValidatorTest {
             .nullableKeywordEnabled(false)
             .build());
 
-        final Set<ValidationMessage> errors = validator.validate(inputData, InputFormat.JSON);
+        final List<ValidationMessage> errors = validator.validate(inputData, InputFormat.JSON);
         assertEquals(1, errors.size());
     }
 }

--- a/src/test/java/com/networknt/schema/UnevaluatedItemsValidatorTest.java
+++ b/src/test/java/com/networknt/schema/UnevaluatedItemsValidatorTest.java
@@ -19,7 +19,6 @@ package com.networknt.schema;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -45,7 +44,7 @@ class UnevaluatedItemsValidatorTest {
                 + "}";
         String inputData = "[1,2,3]";
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData);
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(2, messages.size());
         List<ValidationMessage> assertions = messages.stream().collect(Collectors.toList());
         assertEquals("unevaluatedItems", assertions.get(0).getType());
@@ -71,7 +70,7 @@ class UnevaluatedItemsValidatorTest {
                 + "}";
         String inputData = "[1,2,3]";
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData);
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(2, messages.size());
         List<ValidationMessage> assertions = messages.stream().collect(Collectors.toList());
         assertEquals("type", assertions.get(0).getType());

--- a/src/test/java/com/networknt/schema/UnevaluatedPropertiesValidatorTest.java
+++ b/src/test/java/com/networknt/schema/UnevaluatedPropertiesValidatorTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -63,7 +62,7 @@ class UnevaluatedPropertiesValidatorTest {
                 + "    \"key4\": \"value4\"\r\n"
                 + "}";
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData);
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(2, messages.size());
         List<ValidationMessage> assertions = messages.stream().collect(Collectors.toList());
         assertEquals("required", assertions.get(0).getType());
@@ -118,7 +117,7 @@ class UnevaluatedPropertiesValidatorTest {
                 + "  }\r\n"
                 + "}";
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V201909).getSchema(schemaData);
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(1, messages.size());
         List<ValidationMessage> assertions = messages.stream().collect(Collectors.toList());
         assertEquals("additionalProperties", assertions.get(0).getType());
@@ -146,7 +145,7 @@ class UnevaluatedPropertiesValidatorTest {
                 + "  }\r\n"
                 + "}";
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V201909).getSchema(schemaData);
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(1, messages.size());
         List<ValidationMessage> assertions = messages.stream().collect(Collectors.toList());
         assertEquals("type", assertions.get(0).getType());
@@ -191,7 +190,7 @@ class UnevaluatedPropertiesValidatorTest {
                 + "}";
         String inputData = "{ \"pontoons\": {}, \"wheels\": {}, \"surfboard\": \"2\" }";
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V201909).getSchema(schemaData);
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals(0, messages.size());
     }
 

--- a/src/test/java/com/networknt/schema/UnknownMetaSchemaTest.java
+++ b/src/test/java/com/networknt/schema/UnknownMetaSchemaTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Set;
+import java.util.List;
 
 class UnknownMetaSchemaTest {
 
@@ -24,7 +24,7 @@ class UnknownMetaSchemaTest {
         JsonSchemaFactory factory = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7)).build();
         JsonSchema jsonSchema = factory.getSchema(schema1);
 
-        Set<ValidationMessage> errors = jsonSchema.validate(jsonNode);
+        List<ValidationMessage> errors = jsonSchema.validate(jsonNode);
         for(ValidationMessage error:errors) {
             System.out.println(error.getMessage());
         }
@@ -38,7 +38,7 @@ class UnknownMetaSchemaTest {
         JsonSchemaFactory factory = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7)).build();
         JsonSchema jsonSchema = factory.getSchema(schema2);
 
-        Set<ValidationMessage> errors = jsonSchema.validate(jsonNode);
+        List<ValidationMessage> errors = jsonSchema.validate(jsonNode);
         for(ValidationMessage error:errors) {
             System.out.println(error.getMessage());
         }
@@ -51,7 +51,7 @@ class UnknownMetaSchemaTest {
         JsonSchemaFactory factory = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7)).build();
         JsonSchema jsonSchema = factory.getSchema(schema3);
 
-        Set<ValidationMessage> errors = jsonSchema.validate(jsonNode);
+        List<ValidationMessage> errors = jsonSchema.validate(jsonNode);
         for(ValidationMessage error:errors) {
             System.out.println(error.getMessage());
         }

--- a/src/test/java/com/networknt/schema/V4JsonSchemaTest.java
+++ b/src/test/java/com/networknt/schema/V4JsonSchemaTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -47,7 +48,7 @@ class V4JsonSchemaTest {
      */
     @Test
     void testFailFast_AllErrors() throws IOException {
-        Set<ValidationMessage> messages = validateFailingFastSchemaFor("extra/product/product.schema.json",
+        List<ValidationMessage> messages = validateFailingFastSchemaFor("extra/product/product.schema.json",
                 "extra/product/product-all-errors-data.json");
         assertEquals(1, messages.size());
     }
@@ -57,7 +58,7 @@ class V4JsonSchemaTest {
      */
     @Test
     void testFailFast_OneErrors() throws IOException {
-        Set<ValidationMessage> messages = validateFailingFastSchemaFor("extra/product/product.schema.json",
+        List<ValidationMessage> messages = validateFailingFastSchemaFor("extra/product/product.schema.json",
                 "extra/product/product-one-error-data.json");
         assertEquals(1, messages.size());
     }
@@ -67,7 +68,7 @@ class V4JsonSchemaTest {
      */
     @Test
     void testFailFast_TwoErrors() throws IOException {
-        Set<ValidationMessage> messages = validateFailingFastSchemaFor("extra/product/product.schema.json",
+        List<ValidationMessage> messages = validateFailingFastSchemaFor("extra/product/product.schema.json",
                 "extra/product/product-two-errors-data.json");
         assertEquals(1, messages.size());
     }
@@ -78,12 +79,12 @@ class V4JsonSchemaTest {
      */
     @Test
     void testFailFast_NoErrors() throws IOException {
-        final Set<ValidationMessage> messages = validateFailingFastSchemaFor("extra/product/product.schema.json",
+        final List<ValidationMessage> messages = validateFailingFastSchemaFor("extra/product/product.schema.json",
                 "extra/product/product-no-errors-data.json");
         assertTrue(messages.isEmpty());
     }
 
-    private Set<ValidationMessage> validateFailingFastSchemaFor(final String schemaFileName, final String dataFileName) throws IOException {
+    private List<ValidationMessage> validateFailingFastSchemaFor(final String schemaFileName, final String dataFileName) throws IOException {
         final ObjectMapper objectMapper = new ObjectMapper();
         final JsonNode schema = getJsonNodeFromResource(objectMapper, schemaFileName);
         final JsonNode dataFile = getJsonNodeFromResource(objectMapper, dataFileName);

--- a/src/test/java/com/networknt/schema/VocabularyTest.java
+++ b/src/test/java/com/networknt/schema/VocabularyTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -68,7 +68,7 @@ class VocabularyTest {
                 + "  \"numberProperty\": 1\r\n"
                 + "}";
 
-        Set<ValidationMessage> messages = schema.validate(inputDataNoValidation, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputDataNoValidation, InputFormat.JSON);
         assertEquals(0, messages.size());
 
         // Set validation vocab
@@ -120,7 +120,7 @@ class VocabularyTest {
                 + "  \"dateProperty\": \"hello\"\r\n"
                 + "}";
 
-        Set<ValidationMessage> messages = schema.validate(inputDataNoValidation, InputFormat.JSON,
+        List<ValidationMessage> messages = schema.validate(inputDataNoValidation, InputFormat.JSON,
                 executionContext -> executionContext.getExecutionConfig().setFormatAssertionsEnabled(true));
         assertEquals(0, messages.size());
 

--- a/src/test/java/com/networknt/schema/format/IriFormatTest.java
+++ b/src/test/java/com/networknt/schema/format/IriFormatTest.java
@@ -18,7 +18,7 @@ package com.networknt.schema.format;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +38,7 @@ class IriFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf\"",
+        List<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf\"",
                 InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
@@ -51,7 +51,7 @@ class IriFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter[test]=1\"",
+        List<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter[test]=1\"",
                 InputFormat.JSON);
         assertFalse(messages.isEmpty());
     }
@@ -64,7 +64,7 @@ class IriFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter%5Btest%5D=1\"",
+        List<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter%5Btest%5D=1\"",
                 InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
@@ -77,7 +77,7 @@ class IriFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/produktdatenblätter.pdf\"",
+        List<ValidationMessage> messages = schema.validate("\"https://test.com/assets/produktdatenblätter.pdf\"",
                 InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
@@ -90,7 +90,7 @@ class IriFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"http://\"", InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate("\"http://\"", InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 
@@ -102,7 +102,7 @@ class IriFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"//\"", InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate("\"//\"", InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 
@@ -114,7 +114,7 @@ class IriFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"about:\"", InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate("\"about:\"", InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 }

--- a/src/test/java/com/networknt/schema/format/IriReferenceFormatTest.java
+++ b/src/test/java/com/networknt/schema/format/IriReferenceFormatTest.java
@@ -18,7 +18,7 @@ package com.networknt.schema.format;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +38,7 @@ class IriReferenceFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf\"",
+        List<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf\"",
                 InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
@@ -51,7 +51,7 @@ class IriReferenceFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter[test]=1\"",
+        List<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter[test]=1\"",
                 InputFormat.JSON);
         assertFalse(messages.isEmpty());
     }
@@ -64,7 +64,7 @@ class IriReferenceFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter%5Btest%5D=1\"",
+        List<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter%5Btest%5D=1\"",
                 InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
@@ -77,7 +77,7 @@ class IriReferenceFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/produktdatenblätter.pdf\"",
+        List<ValidationMessage> messages = schema.validate("\"https://test.com/assets/produktdatenblätter.pdf\"",
                 InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
@@ -90,7 +90,7 @@ class IriReferenceFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"http://\"", InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate("\"http://\"", InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 
@@ -102,7 +102,7 @@ class IriReferenceFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"//\"", InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate("\"//\"", InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 
@@ -114,7 +114,7 @@ class IriReferenceFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"about:\"", InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate("\"about:\"", InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 

--- a/src/test/java/com/networknt/schema/format/TimeFormatTest.java
+++ b/src/test/java/com/networknt/schema/format/TimeFormatTest.java
@@ -18,7 +18,7 @@ package com.networknt.schema.format;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -61,7 +61,7 @@ class TimeFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 
@@ -90,7 +90,7 @@ class TimeFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON);
         assertFalse(messages.isEmpty());
     }
 }

--- a/src/test/java/com/networknt/schema/format/UriFormatTest.java
+++ b/src/test/java/com/networknt/schema/format/UriFormatTest.java
@@ -18,7 +18,7 @@ package com.networknt.schema.format;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +38,7 @@ class UriFormatTest {
         
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf\"",
+        List<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf\"",
                 InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
@@ -51,7 +51,7 @@ class UriFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter[test]=1\"",
+        List<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter[test]=1\"",
                 InputFormat.JSON);
         assertFalse(messages.isEmpty());
     }
@@ -64,7 +64,7 @@ class UriFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter%5Btest%5D=1\"",
+        List<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter%5Btest%5D=1\"",
                 InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
@@ -77,7 +77,7 @@ class UriFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/produktdatenblätter.pdf\"",
+        List<ValidationMessage> messages = schema.validate("\"https://test.com/assets/produktdatenblätter.pdf\"",
                 InputFormat.JSON);
         assertFalse(messages.isEmpty());
     }
@@ -90,7 +90,7 @@ class UriFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"http://\"", InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate("\"http://\"", InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 
@@ -102,7 +102,7 @@ class UriFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"//\"", InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate("\"//\"", InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 
@@ -114,7 +114,7 @@ class UriFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"about:\"", InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate("\"about:\"", InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 }

--- a/src/test/java/com/networknt/schema/format/UriReferenceFormatTest.java
+++ b/src/test/java/com/networknt/schema/format/UriReferenceFormatTest.java
@@ -18,7 +18,7 @@ package com.networknt.schema.format;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +38,7 @@ class UriReferenceFormatTest {
         
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf\"",
+        List<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf\"",
                 InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
@@ -51,7 +51,7 @@ class UriReferenceFormatTest {
         
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter[test]=1\"",
+        List<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter[test]=1\"",
                 InputFormat.JSON);
         assertFalse(messages.isEmpty());
     }
@@ -64,7 +64,7 @@ class UriReferenceFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter%5Btest%5D=1\"",
+        List<ValidationMessage> messages = schema.validate("\"https://test.com/assets/product.pdf?filter%5Btest%5D=1\"",
                 InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
@@ -77,7 +77,7 @@ class UriReferenceFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"https://test.com/assets/produktdatenblätter.pdf\"",
+        List<ValidationMessage> messages = schema.validate("\"https://test.com/assets/produktdatenblätter.pdf\"",
                 InputFormat.JSON);
         assertFalse(messages.isEmpty());
     }
@@ -90,7 +90,7 @@ class UriReferenceFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"http://\"", InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate("\"http://\"", InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 
@@ -102,7 +102,7 @@ class UriReferenceFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"//\"", InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate("\"//\"", InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 
@@ -114,7 +114,7 @@ class UriReferenceFormatTest {
 
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().formatAssertionsEnabled(true).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V202012).getSchema(schemaData, config);
-        Set<ValidationMessage> messages = schema.validate("\"about:\"", InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate("\"about:\"", InputFormat.JSON);
         assertTrue(messages.isEmpty());
     }
 }

--- a/src/test/java/com/networknt/schema/oas/OpenApi30Test.java
+++ b/src/test/java/com/networknt/schema/oas/OpenApi30Test.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -55,7 +54,7 @@ class OpenApi30Test {
                 + "  \"petType\": \"dog\",\r\n"
                 + "  \"bark\": \"woof\"\r\n"
                 + "}";
-        Set<ValidationMessage> messages = schema.validate(input, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(input, InputFormat.JSON);
         assertEquals(0, messages.size());
 
         String invalid = "{\r\n"

--- a/src/test/java/com/networknt/schema/oas/OpenApi31Test.java
+++ b/src/test/java/com/networknt/schema/oas/OpenApi31Test.java
@@ -18,7 +18,6 @@ package com.networknt.schema.oas;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -49,7 +48,7 @@ class OpenApi31Test {
                 + "  \"petType\": \"dog\",\r\n"
                 + "  \"bark\": \"woof\"\r\n"
                 + "}";
-        Set<ValidationMessage> messages = schema.validate(input, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(input, InputFormat.JSON);
         assertEquals(0, messages.size());
 
         String invalid = "{\r\n"
@@ -78,7 +77,7 @@ class OpenApi31Test {
                 + "  \"petType\": \"dog\",\r\n"
                 + "  \"bark\": \"woof\"\r\n"
                 + "}";
-        Set<ValidationMessage> messages = schema.validate(input, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(input, InputFormat.JSON);
         assertEquals(0, messages.size());
 
         String invalid = "{\r\n"
@@ -109,7 +108,7 @@ class OpenApi31Test {
                 + "  \"bark\": \"woof\",\r\n"
                 + "  \"lovesRocks\": true\r\n"
                 + "}";
-        Set<ValidationMessage> messages = schema.validate(input, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(input, InputFormat.JSON);
         List<ValidationMessage> list = messages.stream().collect(Collectors.toList());
         assertEquals("oneOf", list.get(0).getType());
     }
@@ -128,7 +127,7 @@ class OpenApi31Test {
                 + "  \"petType\": \"lizard\",\r\n"
                 + "  \"none\": true\r\n"
                 + "}";
-        Set<ValidationMessage> messages = schema.validate(input, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(input, InputFormat.JSON);
         List<ValidationMessage> list = messages.stream().collect(Collectors.toList());
         assertEquals("oneOf", list.get(0).getType());
         assertEquals("required", list.get(1).getType());
@@ -150,7 +149,7 @@ class OpenApi31Test {
                 + "  \"petType\": \"dog\",\r\n"
                 + "  \"lovesRocks\": true\r\n"
                 + "}";
-        Set<ValidationMessage> messages = schema.validate(input, InputFormat.JSON);
+        List<ValidationMessage> messages = schema.validate(input, InputFormat.JSON);
         assertEquals(0, messages.size());
     }
 

--- a/src/test/java/com/networknt/schema/regex/AllowRegularExpressionFactoryTest.java
+++ b/src/test/java/com/networknt/schema/regex/AllowRegularExpressionFactoryTest.java
@@ -38,7 +38,7 @@ class AllowRegularExpressionFactoryTest {
         String allowed = "testing";
         RegularExpressionFactory factory = new AllowRegularExpressionFactory(delegate, allowed::equals);
         InvalidSchemaException exception = assertThrows(InvalidSchemaException.class, () -> factory.getRegularExpression("hello"));
-        assertEquals("hello", exception.getValidationMessage().getArguments()[0]);
+        assertEquals("hello", exception.getError().getArguments()[0]);
         
         assertDoesNotThrow(() -> factory.getRegularExpression(allowed));
         assertTrue(called[0]);

--- a/src/test/java/com/networknt/schema/resource/AllowSchemaLoaderTest.java
+++ b/src/test/java/com/networknt/schema/resource/AllowSchemaLoaderTest.java
@@ -40,7 +40,7 @@ class AllowSchemaLoaderTest {
         InvalidSchemaException invalidSchemaException = assertThrows(InvalidSchemaException.class,
                 () -> factory.getSchema(SchemaLocation.of("http://www.example.org/schema")));
         assertEquals("http://www.example.org/schema",
-                invalidSchemaException.getValidationMessage().getArguments()[0].toString());
+                invalidSchemaException.getError().getArguments()[0].toString());
         JsonSchema schema = factory.getSchema(SchemaLocation.of("classpath:schema/example-main.json"));
         assertNotNull(schema);
     }

--- a/src/test/java/com/networknt/schema/resource/DisallowSchemaLoaderTest.java
+++ b/src/test/java/com/networknt/schema/resource/DisallowSchemaLoaderTest.java
@@ -37,7 +37,7 @@ class DisallowSchemaLoaderTest {
         InvalidSchemaException invalidSchemaException = assertThrows(InvalidSchemaException.class,
                 () -> factory.getSchema(SchemaLocation.of("classpath:schema/example-main.json")));
         assertEquals("classpath:schema/example-main.json",
-                invalidSchemaException.getValidationMessage().getArguments()[0].toString());
+                invalidSchemaException.getError().getArguments()[0].toString());
     }
 
 }

--- a/src/test/java/com/networknt/schema/utils/JsonNodesTest.java
+++ b/src/test/java/com/networknt/schema/utils/JsonNodesTest.java
@@ -22,7 +22,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -92,7 +91,7 @@ class JsonNodesTest {
                 builder -> builder.jsonNodeReader(JsonNodeReader.builder().locationAware().build()));
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = factory.getSchema(schemaData, InputFormat.JSON, config);
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON, executionContext -> {
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.JSON, executionContext -> {
             executionContext.getExecutionConfig().setFormatAssertionsEnabled(true);
         });
         List<ValidationMessage> list = messages.stream().collect(Collectors.toList());
@@ -138,7 +137,7 @@ class JsonNodesTest {
                 builder -> builder.jsonNodeReader(JsonNodeReader.builder().locationAware().build()));
         SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().build();
         JsonSchema schema = factory.getSchema(schemaData, InputFormat.YAML, config);
-        Set<ValidationMessage> messages = schema.validate(inputData, InputFormat.YAML, executionContext -> {
+        List<ValidationMessage> messages = schema.validate(inputData, InputFormat.YAML, executionContext -> {
             executionContext.getExecutionConfig().setFormatAssertionsEnabled(true);
         });
         List<ValidationMessage> list = messages.stream().collect(Collectors.toList());

--- a/src/test/java/com/networknt/schema/walk/JsonSchemaWalkListenerTest.java
+++ b/src/test/java/com/networknt/schema/walk/JsonSchemaWalkListenerTest.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
@@ -101,7 +100,7 @@ class JsonSchemaWalkListenerTest {
                     }
 
                     @Override
-                    public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+                    public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                     }
                 })
                 .build();
@@ -181,7 +180,7 @@ class JsonSchemaWalkListenerTest {
                     }
 
                     @Override
-                    public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+                    public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                     }
                 })
                 .build();
@@ -267,7 +266,7 @@ class JsonSchemaWalkListenerTest {
             }
 
             @Override
-            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+            public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
             }
         }).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V7).getSchema(schemaData, config);
@@ -340,7 +339,7 @@ class JsonSchemaWalkListenerTest {
             }
 
             @Override
-            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+            public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
             }
         }).build();
         JsonSchema schema = JsonSchemaFactory.getInstance(VersionFlag.V7).getSchema(schemaData, config);
@@ -388,7 +387,7 @@ class JsonSchemaWalkListenerTest {
                     }
 
                     @Override
-                    public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+                    public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                     }
                 })
                 .build();
@@ -608,7 +607,7 @@ class JsonSchemaWalkListenerTest {
                     }
 
                     @Override
-                    public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+                    public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                     }
                 })
                 .build();
@@ -665,7 +664,7 @@ class JsonSchemaWalkListenerTest {
                     }
 
                     @Override
-                    public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+                    public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                     }
                 })
                 .build();
@@ -733,7 +732,7 @@ class JsonSchemaWalkListenerTest {
                     }
 
                     @Override
-                    public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+                    public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                     }
                 })
                 .build();
@@ -803,7 +802,7 @@ class JsonSchemaWalkListenerTest {
                     }
 
                     @Override
-                    public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+                    public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                     }
                 })
                 .build();
@@ -846,7 +845,7 @@ class JsonSchemaWalkListenerTest {
             }
 
             @Override
-            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+            public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                 @SuppressWarnings("unchecked")
                 List<WalkEvent> items = (List<WalkEvent>) walkEvent.getExecutionContext()
                         .getCollectorContext()
@@ -909,7 +908,7 @@ class JsonSchemaWalkListenerTest {
             }
 
             @Override
-            public void onWalkEnd(WalkEvent walkEvent, Set<ValidationMessage> validationMessages) {
+            public void onWalkEnd(WalkEvent walkEvent, List<ValidationMessage> validationMessages) {
                 @SuppressWarnings("unchecked")
                 List<WalkEvent> items = (List<WalkEvent>) walkEvent.getExecutionContext()
                         .getCollectorContext()


### PR DESCRIPTION
This refactors the return result from a set to a list.

Instead of returning the result for validation/walk, the errors are instead aggregated in a list in the execution context. Clients calling validate from JsonSchema will get a `List` instead of a `Set.

This should result in better performance when there are a lot of errors in the run as it's a single arraylist that aggregates results and gets resized, and as hashCode is no longer needed to be called on all the messages as it is no longer a set.

This also changes the version in the pom to be 2.0.0-SNAPSHOT to make it clear that this is a major breaking change.