### PR TITLE
Fix matching of $ when there are trailing newlines

### DIFF
--- a/src/main/java/com/networknt/schema/regex/JDKRegularExpression.java
+++ b/src/main/java/com/networknt/schema/regex/JDKRegularExpression.java
@@ -9,7 +9,8 @@ class JDKRegularExpression implements RegularExpression {
     private final Pattern pattern;
 
     JDKRegularExpression(String regex) {
-        this.pattern = Pattern.compile(regex);
+        this.pattern = Pattern.compile(RegularExpressions
+                .replaceLongformCharacterProperties(RegularExpressions.replaceDollarAnchors(regex)));
     }
 
     @Override

--- a/src/main/java/com/networknt/schema/regex/JoniRegularExpression.java
+++ b/src/main/java/com/networknt/schema/regex/JoniRegularExpression.java
@@ -50,6 +50,7 @@ class JoniRegularExpression implements RegularExpression {
 
     JoniRegularExpression(String regex, Syntax syntax) {
         validate(regex);
+        regex = RegularExpressions.replaceDollarAnchors(regex);
         byte[] bytes = regex.getBytes(StandardCharsets.UTF_8);
         this.pattern = new Regex(bytes, 0, bytes.length, Option.SINGLELINE, ECMAScriptUTF8Encoding.INSTANCE, syntax);
     }

--- a/src/main/java/com/networknt/schema/regex/RegularExpressions.java
+++ b/src/main/java/com/networknt/schema/regex/RegularExpressions.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.regex;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility methods for Regular Expressions.
+ */
+public class RegularExpressions {
+    private RegularExpressions() {
+    }
+
+    /**
+     * The meaning of $ in ecmascript does not allow newlines while for other
+     * languages it is typically allowed. The closest to the meaning in ecmascript
+     * is \z.
+     * 
+     * @param regex the regex
+     * @return the replacement
+     */
+    public static String replaceDollarAnchors(String regex) {
+        if (regex.indexOf('$') == -1) {
+            return regex;
+        }
+        /*
+         * Note that for joni there's no option for this and this occurs in the Lexer
+         * when the regex is compiled. If single line $ is AnchorType.SEMI_END_BUF and
+         * if multiline is AnchorType.END_LINE. However what is required is
+         * AnchorType.END_BUF.
+         */
+        StringBuilder result = new StringBuilder();
+        boolean inCharacterClass = false;
+        boolean inLiteralSection = false; // This isn't supported by ECMA but by Java
+        for (int i = 0; i < regex.length(); i++) {
+            char ch = regex.charAt(i);
+            // Literal Section (not supported by ECMA)
+            if (inLiteralSection) {
+                if (ch == '\\' && i + 1 < regex.length() && regex.charAt(i + 1) == 'E') {
+                    result.append("\\E");
+                    inLiteralSection = false;
+                    i++;
+                } else {
+                    // Everything else is treated as a literal character
+                    result.append(ch);
+                }
+                continue;
+            }
+            // Escaped
+            if (ch == '\\') {
+                result.append(ch);
+                if (i + 1 < regex.length()) {
+                    char escapedChar = regex.charAt(i + 1); 
+                    result.append(escapedChar);
+                    if (escapedChar == 'Q') {
+                        inLiteralSection = true;
+                    }
+                    i++;
+                }
+                continue;
+            }
+            // Character Class
+            if (ch == '[') {
+                inCharacterClass = true;
+                result.append(ch);
+                continue;
+            } else if (ch == ']') {
+                inCharacterClass = false;
+                result.append(ch);
+                continue;
+            }
+
+            if (ch == '$') {
+                if (inCharacterClass) {
+                    result.append(ch);
+                } else {
+                    result.append("\\z");
+                }
+            } else {
+                result.append(ch);
+            }
+        }
+        return result.toString();
+    }
+    
+    private static final Map<String, String> LONGFORM_CHARACTER_PROPERTIES;
+    
+    static {
+        LONGFORM_CHARACTER_PROPERTIES = new HashMap<>();
+        LONGFORM_CHARACTER_PROPERTIES.put("Letter", "L");
+        LONGFORM_CHARACTER_PROPERTIES.put("Lowercase_Letter", "Ll");
+        LONGFORM_CHARACTER_PROPERTIES.put("Uppercase_Letter", "Lu");
+        LONGFORM_CHARACTER_PROPERTIES.put("Titlecase_Letter", "Lt");
+        LONGFORM_CHARACTER_PROPERTIES.put("Cased_Letter", "L&");
+        LONGFORM_CHARACTER_PROPERTIES.put("Modifier_Letter", "Lm");
+        LONGFORM_CHARACTER_PROPERTIES.put("Other_Letter", "Lo");
+        LONGFORM_CHARACTER_PROPERTIES.put("Mark", "M");
+        LONGFORM_CHARACTER_PROPERTIES.put("Non_Spacing_Mark", "Mn");
+        LONGFORM_CHARACTER_PROPERTIES.put("Spacing_Combining_Mark", "Mc");
+        LONGFORM_CHARACTER_PROPERTIES.put("Enclosing_Mark", "Me");
+        LONGFORM_CHARACTER_PROPERTIES.put("Separator", "Z");
+        LONGFORM_CHARACTER_PROPERTIES.put("Space_Separator", "Zs");
+        LONGFORM_CHARACTER_PROPERTIES.put("Line_Separator", "Zl");
+        LONGFORM_CHARACTER_PROPERTIES.put("Paragraph_Separator", "Zp");
+        LONGFORM_CHARACTER_PROPERTIES.put("Symbol", "S");
+        LONGFORM_CHARACTER_PROPERTIES.put("Math_Symbol", "Sm");
+        LONGFORM_CHARACTER_PROPERTIES.put("Currency_Symbol", "Sc");
+        LONGFORM_CHARACTER_PROPERTIES.put("Modifier_Symbol", "Sk");
+        LONGFORM_CHARACTER_PROPERTIES.put("Other_Symbol", "So");
+        LONGFORM_CHARACTER_PROPERTIES.put("Number", "N");
+        LONGFORM_CHARACTER_PROPERTIES.put("Decimal_Digit_Number", "Nd");
+        LONGFORM_CHARACTER_PROPERTIES.put("Letter_Number", "Nl");
+        LONGFORM_CHARACTER_PROPERTIES.put("Other_Number", "No");
+        LONGFORM_CHARACTER_PROPERTIES.put("Punctuation", "P");
+        LONGFORM_CHARACTER_PROPERTIES.put("Dash_Punctuation", "Pd");
+        LONGFORM_CHARACTER_PROPERTIES.put("Open_Punctuation", "Ps");
+        LONGFORM_CHARACTER_PROPERTIES.put("Close_Punctuation", "Pe");
+        LONGFORM_CHARACTER_PROPERTIES.put("Initial_Punctuation", "Pi");
+        LONGFORM_CHARACTER_PROPERTIES.put("Final_Punctuation", "Pf");
+        LONGFORM_CHARACTER_PROPERTIES.put("Connector_Punctuation", "Pc");
+        LONGFORM_CHARACTER_PROPERTIES.put("Other_Punctuation", "Po");
+        LONGFORM_CHARACTER_PROPERTIES.put("Other", "C");
+        LONGFORM_CHARACTER_PROPERTIES.put("Control", "Cc");
+        LONGFORM_CHARACTER_PROPERTIES.put("Format", "Cf");
+        LONGFORM_CHARACTER_PROPERTIES.put("Private_Use", "Co");
+        LONGFORM_CHARACTER_PROPERTIES.put("Surrogate", "Cs");
+        LONGFORM_CHARACTER_PROPERTIES.put("Unassigned", "Cn");
+        LONGFORM_CHARACTER_PROPERTIES.put("digit", "Nd");
+    }
+
+    /**
+     * Replaces the longform character properties with the shortform character
+     * propertise.
+     * 
+     * @param regex the regex
+     * @return the replacement
+     */
+    public static String replaceLongformCharacterProperties(String regex) {
+        return replaceCharacterProperties(regex, LONGFORM_CHARACTER_PROPERTIES);
+    }
+
+    /**
+     * The character properties in JDK is different from ECMA.
+     * 
+     * @param regex the regex
+     * @return the replacement
+     */
+    public static String replaceCharacterProperties(String regex, Map<String, String> replacements) {
+        if (regex.indexOf("\\p{") == -1) {
+            return regex;
+        }
+        StringBuilder result = new StringBuilder();
+        boolean inCharacterClass = false;
+        boolean inLiteralSection = false; // This isn't supported by ECMA but by Java
+        for (int i = 0; i < regex.length(); i++) {
+            char ch = regex.charAt(i);
+            // Literal Section (not supported by ECMA)
+            if (inLiteralSection) {
+                if (ch == '\\' && i + 1 < regex.length() && regex.charAt(i + 1) == 'E') {
+                    result.append("\\E");
+                    inLiteralSection = false;
+                    i++;
+                } else {
+                    // Everything else is treated as a literal character
+                    result.append(ch);
+                }
+                continue;
+            }
+            if (!inCharacterClass && regex.length() >= i + 3 && regex.startsWith("\\p{", i)) {
+                
+                // Find the matching closing brace '}'
+                int end = findClosingBrace(regex, i + 3);
+
+                if (end != -1) {
+                    // Found valid \p{...} outside character class and literal block
+                    result.append("\\p{");
+                    String characterClass = regex.substring(i + 3, end);
+                    String replacement = replacements.get(characterClass);
+                    if (replacement == null) {
+                        result.append(characterClass);
+                    } else {
+                        result.append(replacement);
+                    }
+                    result.append("}");
+                    i = end; // Skip the entire \p{...} sequence
+                    continue;
+                }
+                // If the closing brace isn't found, fall through and treat as literals
+            }            
+            // Escaped
+            if (ch == '\\') {
+                result.append(ch);
+                if (i + 1 < regex.length()) {
+                    char escapedChar = regex.charAt(i + 1); 
+                    result.append(escapedChar);
+                    if (escapedChar == 'Q') {
+                        inLiteralSection = true;
+                    }
+                    i++;
+                }
+                continue;
+            }
+            // Character Class
+            if (ch == '[') {
+                inCharacterClass = true;
+                result.append(ch);
+                continue;
+            } else if (ch == ']') {
+                inCharacterClass = false;
+                result.append(ch);
+                continue;
+            }
+            result.append(ch);
+        }
+        return result.toString();
+    }
+
+    private static int findClosingBrace(String regex, int start) {
+        int i = start;
+        while (i < regex.length()) {
+            if (regex.charAt(i) == '}') {
+                return i;
+            }
+            if (regex.charAt(i) == '\\' && i + 1 < regex.length()) {
+                i++;
+            }
+            i++;
+        }
+        return -1;
+    }
+}

--- a/src/test/java/com/networknt/schema/regex/RegularExpressionsTest.java
+++ b/src/test/java/com/networknt/schema/regex/RegularExpressionsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.regex;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class RegularExpressionsTest {
+    enum DollarAnchorInput {
+        ANCHOR("testing$", "testing\\z"),
+        COMPLEX_ANCHOR("(hello$|world$|today$)", "(hello\\z|world\\z|today\\z)"),
+        CHARACTER_CLASS("[a-Z$]", "[a-Z$]"),
+        QUOTED_LITERAL_SECTION("\\Q$\\E", "\\Q$\\E"),
+        ESCAPED("\\$", "\\$"),
+        ;
+
+        String regex;
+        String result;
+
+        DollarAnchorInput(String regex, String result) {
+            this.regex = regex;
+            this.result = result;
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(DollarAnchorInput.class)
+    void dollarAnchor(DollarAnchorInput input) {
+        String result = RegularExpressions.replaceDollarAnchors(input.regex);
+        assertEquals(input.result, result);
+    }
+
+    private static final Map<String, String> CHARACTER_CLASSES;
+    static {
+        CHARACTER_CLASSES = new HashMap<>();
+        CHARACTER_CLASSES.put("Letter", "L");
+    }
+
+    enum CharacterClassInput {
+        LETTER("abc\\p{Letter}abc", "abc\\p{L}abc"),
+        NO_BRACE("abc\\p{Letterabc", "abc\\p{Letterabc"),
+        ;
+
+        String regex;
+        String result;
+
+        CharacterClassInput(String regex, String result) {
+            this.regex = regex;
+            this.result = result;
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(CharacterClassInput.class)
+    void characterClass(CharacterClassInput input) {
+        String result = RegularExpressions.replaceCharacterProperties(input.regex, CHARACTER_CLASSES);
+        assertEquals(input.result, result);
+    }
+}


### PR DESCRIPTION
Closes #495 

This updates the Joni and JDK RegularExpression to treat the `$` anchor in the same way as ECMAScript.

This needed to update the pattern itself, namely replacing the `$` anchor for `\z` The underlying issue being that the semantic meaning of `$` for Joni and JDK is different from ECMAScript in that it allows trailing newlines. The meaning of `\z` is closer to what `$` means for ECMAScript.

It's not possible for Joni to support this without changes to their code, this is actually determined in their Lexer. What is needed is `AnchorType.END_BUF` but for `$` whether it's singleline or multiline only toggles between `AnchorType.SEMI_END_BUF` and `AnchorType.END_LINE`.

* https://github.com/jruby/joni/blob/65b181b42b8d3737ecf55be0d84f3bf46e76b129/src/org/joni/Lexer.java#L1117-L1119
```java
               case 'z':
                    if (syntax.opEscAZBufAnchor()) fetchTokenFor_anchor(AnchorType.END_BUF);
                    break;
```

* https://github.com/jruby/joni/blob/65b181b42b8d3737ecf55be0d84f3bf46e76b129/src/org/joni/Lexer.java#L1244-L1246
```java
                case '$':
                    if (syntax.opLineAnchor()) fetchTokenFor_anchor(isSingleline(env.option) ? AnchorType.SEMI_END_BUF : AnchorType.END_LINE);
                    break;
```

This also updates JDK RegularExpression to be able to accept the long form Unicode Character properties that ECMAScript also accepts.