### PR TITLE
Fix multipleOf error message for fractional digits greater than 3

### DIFF
--- a/src/main/java/com/networknt/schema/keyword/MultipleOfValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/MultipleOfValidator.java
@@ -47,7 +47,7 @@ public class MultipleOfValidator extends BaseKeywordValidator implements Keyword
                 if (dividend.divideAndRemainder(this.divisor)[1].abs().compareTo(BigDecimal.ZERO) > 0) {
                     executionContext.addError(error().instanceNode(node).instanceLocation(instanceLocation)
                             .evaluationPath(executionContext.getEvaluationPath()).locale(executionContext.getExecutionConfig().getLocale())
-                            .arguments(this.divisor)
+                            .arguments(this.divisor.toString()) // String is used as the MessageFormat NumberFormat considers 3 fractional digits by default
                             .build());
                 }
             }
@@ -66,7 +66,7 @@ public class MultipleOfValidator extends BaseKeywordValidator implements Keyword
             if (divisor != 0) {
                 // convert to BigDecimal since double type is not accurate enough to do the
                 // division and multiple
-                return schemaNode.isBigDecimal() ? schemaNode.decimalValue() : BigDecimal.valueOf(divisor);
+                return schemaNode.isBigDecimal() ? schemaNode.decimalValue().stripTrailingZeros() : BigDecimal.valueOf(divisor).stripTrailingZeros();
             }
         }
         return null;

--- a/src/test/java/com/networknt/schema/MultipleOfValidatorTest.java
+++ b/src/test/java/com/networknt/schema/MultipleOfValidatorTest.java
@@ -89,4 +89,15 @@ class MultipleOfValidatorTest {
         messages = typeLoose.validate(validTypeLooseInputData, InputFormat.JSON);
         assertEquals(0, messages.size());
     }
+
+    @Test
+    void messageFormatPrecision() {
+        String schemaData = "{ \"type\": \"object\", \"properties\": { \"value1\": { \"type\": \"number\", \"multipleOf\": 0.00001 } } }";
+        SchemaRegistry factory = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12);
+        Schema schema = factory.getSchema(schemaData);
+        String inputData = "{\"value1\":123.000001}";
+
+        List<Error> messages = schema.validate(inputData, InputFormat.JSON);
+        assertEquals("must be multiple of 0.00001", messages.get(0).getMessage());
+    }
 }


### PR DESCRIPTION
Closes #1209

Fixes the issue where the message for multipleOf was incorrect due to the precision for the number