### PR TITLE
Allow for default dialect id not to be specified and throw an exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,16 @@ List<Error> errors = schema.validate(input, InputFormat.JSON, executionContext -
 });
 ```
 
+### Require schema dialect to be specified
+
+The specification allows for the `$schema` keyword not to be specified, in which case the schema will default to the default dialect specified.
+
+The following example creates a `SchemaRegistry` that does not specify a default dialect and will throw a `MissingSchemaKeywordException` if the schema does not specify a dialect using the `$schema` keyword.
+
+```java
+SchemaRegistry registry = SchemaRegistry.builder().dialectRegistry(new BasicDialectRegistry(Dialects.getDraft202012())).build();
+```
+
 ### Results and output formats
 
 #### Results

--- a/src/main/java/com/networknt/schema/MissingSchemaKeywordException.java
+++ b/src/main/java/com/networknt/schema/MissingSchemaKeywordException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.networknt.schema;
+
+/**
+ * Thrown when the $schema keyword is expected as no default dialect id was
+ * specified.
+ */
+public class MissingSchemaKeywordException extends SchemaException {
+    private static final long serialVersionUID = 1L;
+
+    public MissingSchemaKeywordException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/networknt/schema/SchemaRegistry.java
+++ b/src/main/java/com/networknt/schema/SchemaRegistry.java
@@ -218,9 +218,6 @@ public class SchemaRegistry {
 
     private SchemaRegistry(NodeReader nodeReader, String defaultDialectId, SchemaLoader schemaLoader,
             boolean schemaCacheEnabled, DialectRegistry dialectRegistry, SchemaRegistryConfig schemaRegistryConfig) {
-        if (defaultDialectId == null || defaultDialectId.trim().isEmpty()) {
-            throw new IllegalArgumentException("defaultDialectId must not be null or empty");
-        }
         this.nodeReader = nodeReader != null ? nodeReader : BasicNodeReader.getInstance();
         this.defaultDialectId = defaultDialectId;
         this.schemaLoader = schemaLoader != null ? schemaLoader : SchemaLoader.getDefault();
@@ -549,6 +546,10 @@ public class SchemaRegistry {
             throw new SchemaException("Unknown dialect: " + iriNode);
         }
         final String iri = iriNode == null || iriNode.isNull() ? defaultDialectId : iriNode.textValue();
+        if (iri == null) {
+            throw new MissingSchemaKeywordException(
+                    "The $schema keyword that indicates the schema dialect must be specified.");
+        }
         return getDialect(iri);
     }
 

--- a/src/test/java/com/networknt/schema/SchemaRegistryTest.java
+++ b/src/test/java/com/networknt/schema/SchemaRegistryTest.java
@@ -25,7 +25,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 
+import com.networknt.schema.dialect.BasicDialectRegistry;
 import com.networknt.schema.dialect.Dialect;
+import com.networknt.schema.dialect.Dialects;
 
 /**
  * Tests for JsonSchemaFactory.
@@ -86,5 +88,32 @@ class SchemaRegistryTest {
             }
         });
         assertFalse(failed.get());
+    }
+
+    @Test
+    void noDefaultDialect() {
+        SchemaRegistry registry = SchemaRegistry.builder()
+                .dialectRegistry(new BasicDialectRegistry(Dialects.getDraft202012())).build();
+        assertThrows(MissingSchemaKeywordException.class, () -> {
+            registry.getSchema("{\"type\":\"object\"}");
+        });
+    }
+
+    @Test
+    void noDefaultDialectButSchemaSpecified() {
+        SchemaRegistry registry = SchemaRegistry.builder()
+                .dialectRegistry(new BasicDialectRegistry(Dialects.getDraft202012())).build();
+        assertDoesNotThrow(() -> {
+            registry.getSchema("{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"type\":\"object\"}");
+        });
+    }
+
+    @Test
+    void noDefaultDialectButSchemaSpecifiedButNotInRegistry() {
+        SchemaRegistry registry = SchemaRegistry.builder()
+                .dialectRegistry(new BasicDialectRegistry(Dialects.getDraft201909())).build();
+        assertThrows(InvalidSchemaException.class, () -> {
+            registry.getSchema("{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"type\":\"object\"}");
+        });
     }
 }


### PR DESCRIPTION
Closes #1206

Allows for a default dialect not to be specified.