### PR TITLE
Skip processing of properties keyword if not an object

### DIFF
--- a/src/main/java/com/networknt/schema/keyword/PropertiesValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/PropertiesValidator.java
@@ -57,13 +57,17 @@ public class PropertiesValidator extends BaseKeywordValidator {
     @Override
     public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             NodePath instanceLocation) {
+        if (!node.isObject()) {
+            // ignore if not object
+            return;
+        }
         validate(executionContext, node, rootNode, instanceLocation, false);
     }
 
     protected void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode,
             NodePath instanceLocation, boolean walk) {
         Set<String> matchedInstancePropertyNames = null;
-        boolean collectAnnotations =  hasUnevaluatedPropertiesInEvaluationPath(executionContext) || collectAnnotations(executionContext);
+        boolean collectAnnotations = hasUnevaluatedPropertiesInEvaluationPath(executionContext) || collectAnnotations(executionContext);
         for (Entry<String, Schema> entry : this.schemas.entrySet()) {
             JsonNode propertyNode = node.get(entry.getKey());
             if (propertyNode != null) {

--- a/src/test/java/com/networknt/schema/keyword/PropertiesValidatorTest.java
+++ b/src/test/java/com/networknt/schema/keyword/PropertiesValidatorTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.schema.BaseJsonSchemaValidatorTest;
 import com.networknt.schema.Error;
 import com.networknt.schema.InputFormat;
+import com.networknt.schema.OutputFormat;
 import com.networknt.schema.Result;
 import com.networknt.schema.Schema;
 import com.networknt.schema.SchemaRegistry;
@@ -119,5 +120,27 @@ class PropertiesValidatorTest extends BaseJsonSchemaValidatorTest {
         assertEquals("/additionalProperties/type", errors.get(1).getEvaluationPath().toString());
         assertEquals("#/additionalProperties/type", errors.get(1).getSchemaLocation().toString());
         assertEquals("type", errors.get(1).getKeyword());
+    }
+
+    @Test
+    void shouldNotProcessIfNotObject() {
+        SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(Dialects.getDraft202012());
+        String schemaData = "{\n"
+                + "  \"properties\": {\n"
+                + "    \"productId\": {\n"
+                + "      \"type\": \"integer\",\n"
+                + "      \"minimum\": 1\n"
+                + "    }\n"
+                + "  },\n"
+                + "  \"additionalProperties\": {\n"
+                + "    \"type\": \"integer\"\n"
+                + "  },\n"
+                + "  \"unevaluatedProperties\": false\n"
+                + "}";
+        String instanceData = "\"hello\"";
+        Schema schema = schemaRegistry.getSchema(schemaData, InputFormat.JSON);
+        Result result = schema.validate(instanceData, InputFormat.JSON, OutputFormat.RESULT);
+        assertEquals(true, result.getErrors().isEmpty());
+        assertEquals(0, result.getExecutionContext().getAnnotations().asMap().size());
     }
 }


### PR DESCRIPTION
Closes #1216 

Skips processing of the properties keyword if not an object, otherwise it will generate annotations it is not supposed to, which requires memory.