### PR TITLE
Fix #1239: Add support for non-finite values in schema and data

### DIFF
--- a/.env.cmd
+++ b/.env.cmd
@@ -1,2 +1,0 @@
-@rem set PATH=%PATH%;C:\Tools\apache-maven-4.0.0-rc-5\bin
-set PATH=%PATH%;C:\Tools\apache-maven-3.9.14\bin

--- a/.env.cmd
+++ b/.env.cmd
@@ -1,0 +1,2 @@
+@rem set PATH=%PATH%;C:\Tools\apache-maven-4.0.0-rc-5\bin
+set PATH=%PATH%;C:\Tools\apache-maven-3.9.14\bin

--- a/src/main/java/com/networknt/schema/keyword/ConstValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/ConstValidator.java
@@ -16,6 +16,8 @@
 package com.networknt.schema.keyword;
 
 import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.NumericNode;
+
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.Schema;
 import com.networknt.schema.SchemaLocation;
@@ -33,7 +35,26 @@ public class ConstValidator extends BaseKeywordValidator implements KeywordValid
 
     public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, NodePath instanceLocation) {
         if (schemaNode.isNumber() && node.isNumber()) {
-            if (schemaNode.decimalValue().compareTo(node.decimalValue()) != 0) {
+            if (((NumericNode) schemaNode).isNaN() || ((NumericNode) node).isNaN()) {
+                // At least one of the nodes is a non-finite floating-point number and therefore not representable as BigDecimal.
+                if (Double.isNaN(schemaNode.doubleValue())) {
+                    // Treat `const: .nan` in schema as meaning "isNaN()"
+                    // because NaN != anything (including itself) per IEEE 754.
+                    if (!Double.isNaN(node.doubleValue())) {
+                        executionContext.addError(error().instanceNode(node).instanceLocation(instanceLocation)
+                            .evaluationPath(executionContext.getEvaluationPath())
+                            .locale(executionContext.getExecutionConfig().getLocale())
+                            .arguments(schemaNode.asString(schemaNode.toString()), node.asString(node.toString())).build());
+                    }
+                }
+                else if (schemaNode.doubleValue() != node.doubleValue()) {
+                    executionContext.addError(error().instanceNode(node).instanceLocation(instanceLocation)
+                        .evaluationPath(executionContext.getEvaluationPath())
+                        .locale(executionContext.getExecutionConfig().getLocale())
+                        .arguments(schemaNode.asString(schemaNode.toString()), node.asString(node.toString())).build());
+                }
+            }
+            else if (schemaNode.decimalValue().compareTo(node.decimalValue()) != 0) {
                 executionContext.addError(error().instanceNode(node).instanceLocation(instanceLocation)
                         .evaluationPath(executionContext.getEvaluationPath()).locale(executionContext.getExecutionConfig().getLocale())
                         .arguments(schemaNode.asString(schemaNode.toString()), node.asString())

--- a/src/main/java/com/networknt/schema/keyword/EnumValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/EnumValidator.java
@@ -19,7 +19,9 @@ package com.networknt.schema.keyword;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.DecimalNode;
+import tools.jackson.databind.node.DoubleNode;
 import tools.jackson.databind.node.NullNode;
+
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.Schema;
 import com.networknt.schema.SchemaLocation;
@@ -129,6 +131,9 @@ public class EnumValidator extends BaseKeywordValidator implements KeywordValida
      * @return the node
      */
     protected JsonNode processNumberNode(JsonNode n) {
+        if (n.isFloatingPointNumber() && !Double.isFinite(n.doubleValue())) {
+            return DoubleNode.valueOf(n.doubleValue());
+        }
         return DecimalNode.valueOf(n.decimalValue().stripTrailingZeros());
     }
 

--- a/src/main/java/com/networknt/schema/keyword/ExclusiveMaximumValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/ExclusiveMaximumValidator.java
@@ -83,6 +83,9 @@ public class ExclusiveMaximumValidator extends BaseKeywordValidator {
                     if (node.isDouble() && node.doubleValue() == Double.POSITIVE_INFINITY) {
                         return true;
                     }
+                    if (node.isDouble() && Double.isNaN(node.doubleValue())) {
+                        return true;
+                    }
                     final BigDecimal max = new BigDecimal(maximumText);
                     BigDecimal value = new BigDecimal(node.asString());
                     int compare = value.compareTo(max);

--- a/src/main/java/com/networknt/schema/keyword/ExclusiveMinimumValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/ExclusiveMinimumValidator.java
@@ -90,6 +90,9 @@ public class ExclusiveMinimumValidator extends BaseKeywordValidator {
                     if (node.isDouble() && node.doubleValue() == Double.POSITIVE_INFINITY) {
                         return false;
                     }
+                    if (node.isDouble() && Double.isNaN(node.doubleValue())) {
+                        return true;
+                    }
                     final BigDecimal min = new BigDecimal(minimumText);
                     BigDecimal value = new BigDecimal(node.asString());
                     int compare = value.compareTo(min);

--- a/src/main/java/com/networknt/schema/keyword/MaximumValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/MaximumValidator.java
@@ -96,6 +96,9 @@ public class MaximumValidator extends BaseKeywordValidator {
                     if (node.isDouble() && node.doubleValue() == Double.POSITIVE_INFINITY) {
                         return true;
                     }
+                    if (node.isDouble() && Double.isNaN(node.doubleValue())) {
+                        return true;
+                    }
                     final BigDecimal max = new BigDecimal(maximumText);
                     BigDecimal value = new BigDecimal(node.asString());
                     int compare = value.compareTo(max);

--- a/src/main/java/com/networknt/schema/keyword/MinimumValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/MinimumValidator.java
@@ -103,6 +103,9 @@ public class MinimumValidator extends BaseKeywordValidator {
                     if (node.isDouble() && node.doubleValue() == Double.POSITIVE_INFINITY) {
                         return false;
                     }
+                    if (node.isDouble() && Double.isNaN(node.doubleValue())) {
+                        return true;
+                    }
                     final BigDecimal min = new BigDecimal(minimumText);
                     BigDecimal value = new BigDecimal(node.asString());
                     int compare = value.compareTo(min);

--- a/src/main/java/com/networknt/schema/keyword/MultipleOfValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/MultipleOfValidator.java
@@ -42,6 +42,14 @@ public class MultipleOfValidator extends BaseKeywordValidator implements Keyword
             NodePath instanceLocation) {
         
         if (this.divisor != null) {
+            if (node.isFloatingPointNumber() && !Double.isFinite(node.doubleValue())) {
+                executionContext.addError(error().instanceNode(node).instanceLocation(instanceLocation)
+                        .evaluationPath(executionContext.getEvaluationPath()).locale(executionContext.getExecutionConfig().getLocale())
+                        .arguments(this.divisor.toString()) // String is used as the MessageFormat NumberFormat considers 3 fractional digits by default
+                        .build());
+                return;
+            }
+
             BigDecimal dividend = getDividend(node);
             if (dividend != null) {
                 if (dividend.divideAndRemainder(this.divisor)[1].abs().compareTo(BigDecimal.ZERO) > 0) {

--- a/src/test/java/com/networknt/schema/NonFiniteTest.java
+++ b/src/test/java/com/networknt/schema/NonFiniteTest.java
@@ -1,0 +1,110 @@
+package com.networknt.schema;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.networknt.schema.dialect.Dialects;
+
+/**
+ * Test support for non-finite values (Infinity, -Infinity, and NaN) in numeric validations.
+ */
+public class NonFiniteTest {
+    private final static SchemaRegistry REGISTRY = SchemaRegistry.withDialect(Dialects.getDraft202012());
+    private final static String YAML_STRING =
+    """
+    ---
+    - 10.0
+    - 50.0
+    - .inf
+    - -.inf
+    - .nan
+    """;
+
+    @Test
+    public void nonFiniteConst() {
+        final String schemaString =
+        """
+        $schema: https://json-schema.org/draft/2020-12/schema
+        type: array
+        items:
+            type: number
+            not:
+                anyOf:
+                    - { const:  .inf }
+                    - { const: -.inf }
+                    - { const:  .nan }
+        """;
+        Schema      schema = REGISTRY.getSchema(schemaString, InputFormat.YAML);
+        List<Error> errors = schema.validate(YAML_STRING, InputFormat.YAML);
+        assertEquals(3, errors.size());
+    }
+
+    @Test
+    public void nonFiniteEnum() {
+        final String schemaString =
+        """
+        $schema: https://json-schema.org/draft/2020-12/schema
+        type: array
+        items:
+            type: number
+            not:
+                enum:
+                    -  .inf
+                    - -.inf
+                    -  .nan
+        """;
+        Schema      schema = REGISTRY.getSchema(schemaString, InputFormat.YAML);
+        List<Error> errors = schema.validate(YAML_STRING, InputFormat.YAML);
+        assertEquals(3, errors.size());
+    }
+
+    @Test
+    public void nonFiniteDataMinMax() {
+        final String schemaString =
+        """
+        $schema: https://json-schema.org/draft/2020-12/schema
+        type: array
+        items:
+            type: number
+            minimum: 0
+            maximum: 100
+        """;
+        Schema      schema = REGISTRY.getSchema(schemaString, InputFormat.YAML);
+        List<Error> errors = schema.validate(YAML_STRING, InputFormat.YAML);
+        assertEquals(4, errors.size());
+    }
+
+    @Test
+    public void nonFiniteDataExclusiveMinMax() {
+        final String schemaString =
+        """
+        $schema: https://json-schema.org/draft/2020-12/schema
+        type: array
+        items:
+            type: number
+            exclusiveMinimum: 0
+            exclusiveMaximum: 100
+        """;
+        Schema      schema = REGISTRY.getSchema(schemaString, InputFormat.YAML);
+        List<Error> errors = schema.validate(YAML_STRING, InputFormat.YAML);
+        assertEquals(4, errors.size());
+    }
+
+    @Test
+    public void nonFiniteDataMultipleOf() {
+        final String schemaString =
+        """
+        $schema: https://json-schema.org/draft/2020-12/schema
+        type: array
+        items:
+            type: number
+            multipleOf: 10.0
+        """;
+        Schema      schema = REGISTRY.getSchema(schemaString, InputFormat.YAML);
+        List<Error> errors = schema.validate(YAML_STRING, InputFormat.YAML);
+        assertEquals(3, errors.size());
+    }
+}


### PR DESCRIPTION
Modifies numeric validators to add checks for non-finite values and process them as Double instead of BigDecimal (which would trigger an exception).

Implements #1239

Note: In order to run the test for these changes, you'll need `jackson-dataformats-yaml` v3.2 (currently pre-release). In particular, you need the changes in https://github.com/FasterXML/jackson-dataformats-text/pull/627, which added support for properly parsing `.inf`, `-.inf`, and `.nan` in YAML files.