### PR TITLE
Support handling of non-finite numbers if present

### DIFF
--- a/src/main/java/com/networknt/schema/keyword/ConstValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/ConstValidator.java
@@ -20,6 +20,7 @@ import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.Schema;
 import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.path.NodePath;
+import com.networknt.schema.utils.JsonNodeTypes;
 import com.networknt.schema.SchemaContext;
 
 /**
@@ -33,11 +34,22 @@ public class ConstValidator extends BaseKeywordValidator implements KeywordValid
 
     public void validate(ExecutionContext executionContext, JsonNode node, JsonNode rootNode, NodePath instanceLocation) {
         if (schemaNode.isNumber() && node.isNumber()) {
-            if (schemaNode.decimalValue().compareTo(node.decimalValue()) != 0) {
+            boolean schemaIsNonFinite = JsonNodeTypes.isNonFiniteNumber(schemaNode);
+            boolean nodeIsNonFinite = JsonNodeTypes.isNonFiniteNumber(node);
+            if (schemaIsNonFinite || nodeIsNonFinite) {
+                // Handle the NaN, Infinity and -Infinity cases
+                // Note that Double.compare(NaN, NaN) == 0 as this is comparing constants and not the numeric operation 
+                if (Double.compare(schemaNode.doubleValue(), node.doubleValue()) != 0) {
+                    executionContext.addError(error().instanceNode(node).instanceLocation(instanceLocation)
+                            .evaluationPath(executionContext.getEvaluationPath())
+                            .locale(executionContext.getExecutionConfig().getLocale())
+                            .arguments(schemaNode.asString(schemaNode.toString()), node.asString()).build());
+                }
+            } else if (schemaNode.decimalValue().compareTo(node.decimalValue()) != 0) {
                 executionContext.addError(error().instanceNode(node).instanceLocation(instanceLocation)
-                        .evaluationPath(executionContext.getEvaluationPath()).locale(executionContext.getExecutionConfig().getLocale())
-                        .arguments(schemaNode.asString(schemaNode.toString()), node.asString())
-                        .build());
+                        .evaluationPath(executionContext.getEvaluationPath())
+                        .locale(executionContext.getExecutionConfig().getLocale())
+                        .arguments(schemaNode.asString(schemaNode.toString()), node.asString()).build());
             }
         } else if (!schemaNode.equals(node)) {
             executionContext.addError(error().instanceNode(node).instanceLocation(instanceLocation)

--- a/src/main/java/com/networknt/schema/keyword/ConstValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/ConstValidator.java
@@ -36,7 +36,12 @@ public class ConstValidator extends BaseKeywordValidator implements KeywordValid
         if (schemaNode.isNumber() && node.isNumber()) {
             boolean schemaIsNonFinite = JsonNodeTypes.isNonFiniteNumber(schemaNode);
             boolean nodeIsNonFinite = JsonNodeTypes.isNonFiniteNumber(node);
-            if (schemaIsNonFinite || nodeIsNonFinite) {
+            if (schemaIsNonFinite != nodeIsNonFinite) {
+                executionContext.addError(error().instanceNode(node).instanceLocation(instanceLocation)
+                        .evaluationPath(executionContext.getEvaluationPath())
+                        .locale(executionContext.getExecutionConfig().getLocale())
+                        .arguments(schemaNode.asString(schemaNode.toString()), node.asString()).build());                
+            } else if (schemaIsNonFinite || nodeIsNonFinite) {
                 // Handle the NaN, Infinity and -Infinity cases
                 // Note that Double.compare(NaN, NaN) == 0 as this is comparing constants and not the numeric operation 
                 if (Double.compare(schemaNode.doubleValue(), node.doubleValue()) != 0) {

--- a/src/main/java/com/networknt/schema/keyword/EnumValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/EnumValidator.java
@@ -19,11 +19,13 @@ package com.networknt.schema.keyword;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.DecimalNode;
+import tools.jackson.databind.node.DoubleNode;
 import tools.jackson.databind.node.NullNode;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.Schema;
 import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.path.NodePath;
+import com.networknt.schema.utils.JsonNodeTypes;
 import com.networknt.schema.utils.JsonType;
 import com.networknt.schema.utils.TypeFactory;
 import com.networknt.schema.SchemaContext;
@@ -129,6 +131,12 @@ public class EnumValidator extends BaseKeywordValidator implements KeywordValida
      * @return the node
      */
     protected JsonNode processNumberNode(JsonNode n) {
+        if (JsonNodeTypes.isNonFiniteNumber(n)) {
+            if (n.isDouble()) { // If it is already a DoubleNode don't create another one
+                return n;
+            }
+            return DoubleNode.valueOf(n.doubleValue());
+        }
         return DecimalNode.valueOf(n.decimalValue().stripTrailingZeros());
     }
 

--- a/src/main/java/com/networknt/schema/keyword/MultipleOfValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/MultipleOfValidator.java
@@ -80,6 +80,11 @@ public class MultipleOfValidator extends BaseKeywordValidator implements Keyword
      */
     protected BigDecimal getDividend(JsonNode node) {
         if (node.isNumber()) {
+            // Handle NaN, Infinity and -Infinity
+            if (JsonNodeTypes.isNonFiniteNumber(node)) {
+                // Incorrect type as NaN, Infinity and -Infinity are not valid JSON numbers so return null
+                return null;
+            }
             // convert to BigDecimal since double type is not accurate enough to do the
             // division and multiple
             return node.isBigDecimal() ? node.decimalValue() : BigDecimal.valueOf(node.doubleValue());

--- a/src/main/java/com/networknt/schema/keyword/MultipleOfValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/MultipleOfValidator.java
@@ -63,7 +63,7 @@ public class MultipleOfValidator extends BaseKeywordValidator implements Keyword
     protected BigDecimal getDivisor(JsonNode schemaNode) {
         if (schemaNode.isNumber()) {
             double divisor = schemaNode.doubleValue();
-            if (divisor != 0) {
+            if (divisor != 0 && Double.isFinite(divisor)) {
                 // convert to BigDecimal since double type is not accurate enough to do the
                 // division and multiple
                 return schemaNode.isBigDecimal() ? schemaNode.decimalValue().stripTrailingZeros() : BigDecimal.valueOf(divisor).stripTrailingZeros();

--- a/src/main/java/com/networknt/schema/utils/JsonNodeTypes.java
+++ b/src/main/java/com/networknt/schema/utils/JsonNodeTypes.java
@@ -89,11 +89,28 @@ public class JsonNodeTypes {
      */
     public static boolean isNumber(JsonNode node, SchemaRegistryConfig config) {
         if (node.isNumber()) {
+            if (isNonFiniteNumber(node)) {
+                return false;
+            }
             return true;
         } else if (config.isTypeLoose()) {
             if (TypeFactory.getValueNodeType(node, config) == JsonType.STRING) {
                 return Strings.isNumeric(node.asString());
             }
+        }
+        return false;
+    }
+
+    /**
+     * Check if the node is a number and is one of NaN, Infinity or -Infinity
+     * 
+     * @param node to check
+     * @return true if it is NaN, Infinity or -Infinity
+     */
+    public static boolean isNonFiniteNumber(JsonNode node) {
+        if (node.isFloatingPointNumber() && !node.isBigDecimal() && !node.isBigInteger()
+                && !Double.isFinite(node.doubleValue())) {
+            return true;
         }
         return false;
     }

--- a/src/main/java/com/networknt/schema/utils/TypeFactory.java
+++ b/src/main/java/com/networknt/schema/utils/TypeFactory.java
@@ -102,6 +102,10 @@ public class TypeFactory {
             } else if (config != null && config.isLosslessNarrowing() && node.canConvertToExactIntegral()) {
                 return JsonType.INTEGER;
             } else {
+                // Handle NaN, Infinity and -Infinity
+                if (JsonNodeTypes.isNonFiniteNumber(node)) {
+                    return JsonType.UNKNOWN;
+                }
                 return JsonType.NUMBER;
             }
         case BOOLEAN:

--- a/src/test/java/com/networknt/schema/ConstValidatorTest.java
+++ b/src/test/java/com/networknt/schema/ConstValidatorTest.java
@@ -24,6 +24,10 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import com.networknt.schema.i18n.ResourceBundleMessageSource;
+import com.networknt.schema.serialization.NodeReader;
+
+import tools.jackson.core.json.JsonReadFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Test for ConstValidator.
@@ -92,4 +96,70 @@ class ConstValidatorTest {
         assertFalse(messages.isEmpty());
     }
 
+    @Test
+    void nan() {
+        String schemaData = "{\r\n"
+                + "  \"const\": NaN\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12,
+                builder -> builder.nodeReader(NodeReader.builder()
+                        .jsonMapper(JsonMapper.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                        .build()))
+                .getSchema(schemaData);
+        String inputData = "NaN";
+        List<Error> messages = schema.validate(inputData, InputFormat.JSON);
+        assertTrue(messages.isEmpty()); // Note that Double.compare(NaN, NaN) == 0 as this is comparing constants and
+                                        // not the numeric operation
+    }
+
+    @Test
+    void infinity() {
+        String schemaData = "{\r\n"
+                + "  \"const\": Infinity\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12,
+                builder -> builder.nodeReader(NodeReader.builder()
+                        .jsonMapper(JsonMapper.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                        .build()))
+                .getSchema(schemaData);
+        String inputData = "Infinity";
+        List<Error> messages = schema.validate(inputData, InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
+
+    @Test
+    void negativeInfinity() {
+        String schemaData = "{\r\n"
+                + "  \"const\": -Infinity\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12,
+                builder -> builder.nodeReader(NodeReader.builder()
+                        .jsonMapper(JsonMapper.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                        .build()))
+                .getSchema(schemaData);
+        String inputData = "-Infinity";
+        List<Error> messages = schema.validate(inputData, InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
+
+    @Test
+    void nonFinite() {
+        String schemaData = "{\r\n"
+                + "  \"const\": 10\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12,
+                builder -> builder.nodeReader(NodeReader.builder()
+                        .jsonMapper(JsonMapper.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                        .build()))
+                .getSchema(schemaData);
+        String inputData = "-Infinity";
+        List<Error> messages = schema.validate(inputData, InputFormat.JSON);
+        assertFalse(messages.isEmpty());
+        inputData = "Infinity";
+        messages = schema.validate(inputData, InputFormat.JSON);
+        assertFalse(messages.isEmpty());
+        inputData = "NaN";
+        messages = schema.validate(inputData, InputFormat.JSON);
+        assertFalse(messages.isEmpty());
+    }
 }

--- a/src/test/java/com/networknt/schema/EnumValidatorTest.java
+++ b/src/test/java/com/networknt/schema/EnumValidatorTest.java
@@ -22,6 +22,11 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import com.networknt.schema.serialization.NodeReader;
+
+import tools.jackson.core.json.JsonReadFeature;
+import tools.jackson.databind.json.JsonMapper;
+
 /**
  * EnumValidator test. 
  */
@@ -107,5 +112,72 @@ class EnumValidatorTest {
         assertEquals(1, messages.size());
         Error message = messages.get(0);
         assertEquals(": does not have a value in the enumeration [6, \"foo\", [], true, {\"foo\":12}]", message.toString());
+    }
+
+    @Test
+    void nan() {
+        String schemaData = "{\r\n"
+                + "  \"enum\": [NaN]\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12,
+                builder -> builder.nodeReader(NodeReader.builder()
+                        .jsonMapper(JsonMapper.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                        .build()))
+                .getSchema(schemaData);
+        String inputData = "NaN";
+        List<Error> messages = schema.validate(inputData, InputFormat.JSON);
+        assertTrue(messages.isEmpty()); // Note that Double.compare(NaN, NaN) == 0 as this is comparing constants and
+                                        // not the numeric operation
+    }
+
+    @Test
+    void infinity() {
+        String schemaData = "{\r\n"
+                + "  \"enum\": [Infinity]\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12,
+                builder -> builder.nodeReader(NodeReader.builder()
+                        .jsonMapper(JsonMapper.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                        .build()))
+                .getSchema(schemaData);
+        String inputData = "Infinity";
+        List<Error> messages = schema.validate(inputData, InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
+
+    @Test
+    void negativeInfinity() {
+        String schemaData = "{\r\n"
+                + "  \"enum\": [-Infinity]\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12,
+                builder -> builder.nodeReader(NodeReader.builder()
+                        .jsonMapper(JsonMapper.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                        .build()))
+                .getSchema(schemaData);
+        String inputData = "-Infinity";
+        List<Error> messages = schema.validate(inputData, InputFormat.JSON);
+        assertTrue(messages.isEmpty());
+    }
+
+    @Test
+    void nonFinite() {
+        String schemaData = "{\r\n"
+                + "  \"enum\": [10]\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12,
+                builder -> builder.nodeReader(NodeReader.builder()
+                        .jsonMapper(JsonMapper.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                        .build()))
+                .getSchema(schemaData);
+        String inputData = "-Infinity";
+        List<Error> messages = schema.validate(inputData, InputFormat.JSON);
+        assertFalse(messages.isEmpty());
+        inputData = "Infinity";
+        messages = schema.validate(inputData, InputFormat.JSON);
+        assertFalse(messages.isEmpty());
+        inputData = "NaN";
+        messages = schema.validate(inputData, InputFormat.JSON);
+        assertFalse(messages.isEmpty());
     }
 }

--- a/src/test/java/com/networknt/schema/ExclusiveMaximumValidatorTest.java
+++ b/src/test/java/com/networknt/schema/ExclusiveMaximumValidatorTest.java
@@ -17,9 +17,15 @@ package com.networknt.schema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import com.networknt.schema.dialect.Dialects;
+import com.networknt.schema.serialization.NodeReader;
+
+import tools.jackson.core.json.JsonReadFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Test ExclusiveMaximumValidator validator.
@@ -36,5 +42,23 @@ class ExclusiveMaximumValidatorTest {
         """;
         final SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(Dialects.getDraft7());
         assertEquals(1, schemaRegistry.getSchema(schemaString).validate("10", InputFormat.JSON).size());
+    }
+
+    @Test
+    void nonFinite() {
+        String schemaData = "{\r\n"
+                + "  \"exclusiveMaximum\": 10\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_4,
+                builder -> builder.nodeReader(NodeReader.builder()
+                        .jsonMapper(JsonMapper.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                        .build()))
+                .getSchema(schemaData);
+        List<Error> errors = schema.validate("NaN", InputFormat.JSON);
+        assertEquals(0, errors.size());
+        errors = schema.validate("Infinity", InputFormat.JSON);
+        assertEquals(0, errors.size());
+        errors = schema.validate("-Infinity", InputFormat.JSON);
+        assertEquals(0, errors.size());
     }
 }

--- a/src/test/java/com/networknt/schema/ExclusiveMinimumValidatorTest.java
+++ b/src/test/java/com/networknt/schema/ExclusiveMinimumValidatorTest.java
@@ -25,6 +25,10 @@ import org.junit.jupiter.api.Test;
 import com.networknt.schema.dialect.Dialect;
 import com.networknt.schema.dialect.Dialects;
 import com.networknt.schema.keyword.DisallowUnknownKeywordFactory;
+import com.networknt.schema.serialization.NodeReader;
+
+import tools.jackson.core.json.JsonReadFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Test ExclusiveMinimumValidator validator.
@@ -104,5 +108,23 @@ class ExclusiveMinimumValidatorTest {
         """;
         final SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(Dialects.getDraft7());
         assertEquals(1, schemaRegistry.getSchema(schemaString).validate("10", InputFormat.JSON).size());
+    }
+
+    @Test
+    void nonFinite() {
+        String schemaData = "{\r\n"
+                + "  \"exclusiveMinimum\": 10\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_4,
+                builder -> builder.nodeReader(NodeReader.builder()
+                        .jsonMapper(JsonMapper.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                        .build()))
+                .getSchema(schemaData);
+        List<Error> errors = schema.validate("NaN", InputFormat.JSON);
+        assertEquals(0, errors.size());
+        errors = schema.validate("Infinity", InputFormat.JSON);
+        assertEquals(0, errors.size());
+        errors = schema.validate("-Infinity", InputFormat.JSON);
+        assertEquals(0, errors.size());
     }
 }

--- a/src/test/java/com/networknt/schema/MaximumValidatorTest.java
+++ b/src/test/java/com/networknt/schema/MaximumValidatorTest.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
     private static final String INTEGER = "{ \"$schema\":\"http://json-schema.org/draft-04/schema#\", \"type\": \"integer\", \"maximum\": %s }";
     private static final String NUMBER = "{ \"$schema\":\"http://json-schema.org/draft-04/schema#\", \"type\": \"number\", \"maximum\": %s }";
+    private static final String MAXIMUM = "{ \"$schema\":\"http://json-schema.org/draft-04/schema#\", \"maximum\": %s }";
     private static final String EXCLUSIVE_INTEGER = "{ \"$schema\":\"http://json-schema.org/draft-04/schema#\", \"type\": \"integer\", \"maximum\": %s, \"exclusiveMaximum\": true}";
 
     private static final SchemaRegistry factory = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_4);
@@ -194,18 +195,18 @@ class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
         for (String[] aTestCycle : values) {
             String maximum = aTestCycle[0];
             String value = aTestCycle[1];
-            String schema = format(NUMBER, maximum);
+            String schema = format(MAXIMUM, maximum);
 
             // Schema and document parsed with just double
             Schema v = factory.getSchema(mapper.readTree(schema));
             JsonNode doc = mapper.readTree(value);
-            List<Error> messages = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();
+            List<Error> messages = v.validate(doc);
             assertTrue(messages.isEmpty(), format("Maximum %s and value %s are interpreted as Infinity, thus no schema violation should be reported", maximum, value));
 
             // document parsed with BigDecimal
 
             doc = bigDecimalMapper.readTree(value);
-            List<Error> messages2 = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();
+            List<Error> messages2 = v.validate(doc);
             if (Double.valueOf(maximum).equals(Double.POSITIVE_INFINITY)) {
                 assertTrue(messages2.isEmpty(), format("Maximum %s and value %s are equal, thus no schema violation should be reported", maximum, value));
             } else {
@@ -215,7 +216,7 @@ class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
 
             // schema and document parsed with BigDecimal
             v = factory.getSchema(bigDecimalMapper.readTree(schema));
-            List<Error> messages3 = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();
+            List<Error> messages3 = v.validate(doc);
             //when the schema and value are both using BigDecimal, the value should be parsed in same mechanism.
             String theValue = value.toLowerCase().replace("\"", "");
             if (maximum.toLowerCase().equals(theValue)) {
@@ -264,13 +265,13 @@ class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
      */
     @Test
     void doubleValueCoarsingExceedRange() throws IOException {
-        String schema = "{ \"$schema\":\"http://json-schema.org/draft-04/schema#\", \"type\": \"number\", \"maximum\": 1.7976931348623159e+308 }";
+        String schema = "{ \"$schema\":\"http://json-schema.org/draft-04/schema#\", \"maximum\": 1.7976931348623159e+308 }";
         String content = "1.7976931348623160e+308";
 
         JsonNode doc = mapper.readTree(content);
         Schema v = factory.getSchema(mapper.readTree(schema));
 
-        List<Error> messages = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
+        List<Error> messages = v.validate(doc);
         assertTrue(messages.isEmpty(), "Validation should succeed as by default double values are used by mapper");
 
         doc = bigDecimalMapper.readTree(content);
@@ -287,7 +288,7 @@ class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
          *       seems infeasible.
          */
         v = factory.getSchema(bigDecimalMapper.readTree(schema));
-        messages = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
+        messages = v.validate(doc);
         // Before 2.16.0 messages will be empty due to bug https://github.com/FasterXML/jackson-databind/issues/1770
         // assertTrue(messages.isEmpty(), "Validation should success because the bug of bigDecimalMapper, it will treat 1.7976931348623159e+308 as INFINITY");
         assertFalse(messages.isEmpty(), "Validation should fail as Incorrect deserialization for BigDecimal numbers is fixed in 2.16.0");

--- a/src/test/java/com/networknt/schema/MaximumValidatorTest.java
+++ b/src/test/java/com/networknt/schema/MaximumValidatorTest.java
@@ -16,12 +16,16 @@
 
 package com.networknt.schema;
 
+import tools.jackson.core.json.JsonReadFeature;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
 import org.junit.jupiter.api.Test;
 
 import com.networknt.schema.dialect.Dialects;
+import com.networknt.schema.serialization.NodeReader;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -195,13 +199,13 @@ class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
             // Schema and document parsed with just double
             Schema v = factory.getSchema(mapper.readTree(schema));
             JsonNode doc = mapper.readTree(value);
-            List<Error> messages = v.validate(doc);
+            List<Error> messages = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();
             assertTrue(messages.isEmpty(), format("Maximum %s and value %s are interpreted as Infinity, thus no schema violation should be reported", maximum, value));
 
             // document parsed with BigDecimal
 
             doc = bigDecimalMapper.readTree(value);
-            List<Error> messages2 = v.validate(doc);
+            List<Error> messages2 = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();
             if (Double.valueOf(maximum).equals(Double.POSITIVE_INFINITY)) {
                 assertTrue(messages2.isEmpty(), format("Maximum %s and value %s are equal, thus no schema violation should be reported", maximum, value));
             } else {
@@ -211,7 +215,7 @@ class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
 
             // schema and document parsed with BigDecimal
             v = factory.getSchema(bigDecimalMapper.readTree(schema));
-            List<Error> messages3 = v.validate(doc);
+            List<Error> messages3 = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();
             //when the schema and value are both using BigDecimal, the value should be parsed in same mechanism.
             String theValue = value.toLowerCase().replace("\"", "");
             if (maximum.toLowerCase().equals(theValue)) {
@@ -266,11 +270,11 @@ class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
         JsonNode doc = mapper.readTree(content);
         Schema v = factory.getSchema(mapper.readTree(schema));
 
-        List<Error> messages = v.validate(doc);
+        List<Error> messages = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
         assertTrue(messages.isEmpty(), "Validation should succeed as by default double values are used by mapper");
 
         doc = bigDecimalMapper.readTree(content);
-        messages = v.validate(doc);
+        messages = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
         // "1.7976931348623158e+308" == "1.7976931348623157e+308" == Double.MAX_VALUE
         // new BigDecimal("1.7976931348623158e+308").compareTo(new BigDecimal("1.7976931348623157e+308")) > 0
         assertTrue(messages.isEmpty(), "Validation should success because the bug of bigDecimalMapper, it will treat 1.7976931348623159e+308 as INFINITY");
@@ -283,7 +287,7 @@ class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
          *       seems infeasible.
          */
         v = factory.getSchema(bigDecimalMapper.readTree(schema));
-        messages = v.validate(doc);
+        messages = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
         // Before 2.16.0 messages will be empty due to bug https://github.com/FasterXML/jackson-databind/issues/1770
         // assertTrue(messages.isEmpty(), "Validation should success because the bug of bigDecimalMapper, it will treat 1.7976931348623159e+308 as INFINITY");
         assertFalse(messages.isEmpty(), "Validation should fail as Incorrect deserialization for BigDecimal numbers is fixed in 2.16.0");
@@ -341,6 +345,24 @@ class MaximumValidatorTest extends BaseJsonSchemaValidatorTest {
         """;
         final SchemaRegistry schemaRegistry = SchemaRegistry.withDialect(Dialects.getDraft7());
         assertEquals(1, schemaRegistry.getSchema(schemaString).validate("11", InputFormat.JSON).size());
+    }
+
+    @Test
+    void nonFinite() {
+        String schemaData = "{\r\n"
+                + "  \"maximum\": 10\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_4,
+                builder -> builder.nodeReader(NodeReader.builder()
+                        .jsonMapper(JsonMapper.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                        .build()))
+                .getSchema(schemaData);
+        List<Error> errors = schema.validate("NaN", InputFormat.JSON);
+        assertEquals(0, errors.size());
+        errors = schema.validate("Infinity", InputFormat.JSON);
+        assertEquals(0, errors.size());
+        errors = schema.validate("-Infinity", InputFormat.JSON);
+        assertEquals(0, errors.size());
     }
 }
 

--- a/src/test/java/com/networknt/schema/MinimumValidatorTest.java
+++ b/src/test/java/com/networknt/schema/MinimumValidatorTest.java
@@ -40,6 +40,7 @@ import tools.jackson.databind.json.JsonMapper;
 
 class MinimumValidatorTest {
     private static final String NUMBER = "{ \"$schema\":\"http://json-schema.org/draft-04/schema#\", \"type\": \"number\", \"minimum\": %s }";
+    private static final String MINIMUM = "{ \"$schema\":\"http://json-schema.org/draft-04/schema#\", \"minimum\": %s }";
     private static final String EXCLUSIVE_INTEGER = "{ \"$schema\":\"http://json-schema.org/draft-04/schema#\", \"type\": \"integer\", \"minimum\": %s, \"exclusiveMinimum\": true}";
     private static final String INTEGER = "{ \"$schema\":\"http://json-schema.org/draft-04/schema#\", \"type\": \"integer\", \"minimum\": %s }";
     private static final String NEGATIVE_MESSAGE_TEMPLATE = "Expecting validation errors, value %s is smaller than minimum %s";
@@ -177,19 +178,19 @@ class MinimumValidatorTest {
         for (String[] aTestCycle : values) {
             String minimum = aTestCycle[0];
             String value = aTestCycle[1];
-            String schema = format(NUMBER, minimum);
+            String schema = format(MINIMUM, minimum);
             SchemaRegistryConfig config = SchemaRegistryConfig.builder().typeLoose(true).build();
             SchemaRegistry factory = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_4, builder -> builder.schemaRegistryConfig(config));
 
             // Schema and document parsed with just double
             Schema v = factory.getSchema(mapper.readTree(schema));
             JsonNode doc = mapper.readTree(value);
-            List<Error> messages = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
+            List<Error> messages = v.validate(doc);
             assertTrue(messages.isEmpty(), format("Minimum %s and value %s are interpreted as Infinity, thus no schema violation should be reported", minimum, value));
 
             // document parsed with BigDecimal
             doc = bigDecimalMapper.readTree(value);
-            List<Error> messages2 = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
+            List<Error> messages2 = v.validate(doc);
 
             //when the schema and value are both using BigDecimal, the value should be parsed in same mechanism.
             if (Double.valueOf(minimum).equals(Double.NEGATIVE_INFINITY)) {
@@ -205,7 +206,7 @@ class MinimumValidatorTest {
             // schema and document parsed with BigDecimal
             
             v = factory.getSchema(bigDecimalMapper.readTree(schema));
-            List<Error> messages3 = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
+            List<Error> messages3 = v.validate(doc);
             //when the schema and value are both using BigDecimal, the value should be parsed in same mechanism.
             String theValue = value.toLowerCase().replace("\"", "");
             if (minimum.toLowerCase().equals(theValue)) {
@@ -252,21 +253,21 @@ class MinimumValidatorTest {
      */
     @Test
     void doubleValueCoarsingExceedRange() throws IOException {
-        String schema = "{ \"$schema\":\"http://json-schema.org/draft-04/schema#\", \"type\": \"number\", \"minimum\": -1.7976931348623159e+308 }";
+        String schema = "{ \"$schema\":\"http://json-schema.org/draft-04/schema#\", \"minimum\": -1.7976931348623159e+308 }";
         String content = "-1.7976931348623160e+308";
 
         JsonNode doc = mapper.readTree(content);
         Schema v = factory.getSchema(mapper.readTree(schema));
 
-        List<Error> messages = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
+        List<Error> messages = v.validate(doc);
         assertTrue(messages.isEmpty(), "Validation should succeed as by default double values are used by mapper");
 
         doc = bigDecimalMapper.readTree(content);
-        messages = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
+        messages = v.validate(doc);
         assertTrue(messages.isEmpty(), "Validation should succeed due to the bug of BigDecimal option of mapper");
 
         v = factory.getSchema(bigDecimalMapper.readTree(schema));
-        messages = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
+        messages = v.validate(doc);
         // Before 2.16.0 messages will be empty due to bug https://github.com/FasterXML/jackson-databind/issues/1770
         //assertTrue(messages.isEmpty(), "Validation should succeed due to the bug of BigDecimal option of mapper");
         assertFalse(messages.isEmpty(), "Validation should fail as Incorrect deserialization for BigDecimal numbers is fixed in 2.16.0");

--- a/src/test/java/com/networknt/schema/MinimumValidatorTest.java
+++ b/src/test/java/com/networknt/schema/MinimumValidatorTest.java
@@ -30,10 +30,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.networknt.schema.dialect.Dialects;
+import com.networknt.schema.serialization.NodeReader;
 
+import tools.jackson.core.json.JsonReadFeature;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 class MinimumValidatorTest {
     private static final String NUMBER = "{ \"$schema\":\"http://json-schema.org/draft-04/schema#\", \"type\": \"number\", \"minimum\": %s }";
@@ -181,12 +184,12 @@ class MinimumValidatorTest {
             // Schema and document parsed with just double
             Schema v = factory.getSchema(mapper.readTree(schema));
             JsonNode doc = mapper.readTree(value);
-            List<Error> messages = v.validate(doc);
+            List<Error> messages = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
             assertTrue(messages.isEmpty(), format("Minimum %s and value %s are interpreted as Infinity, thus no schema violation should be reported", minimum, value));
 
             // document parsed with BigDecimal
             doc = bigDecimalMapper.readTree(value);
-            List<Error> messages2 = v.validate(doc);
+            List<Error> messages2 = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
 
             //when the schema and value are both using BigDecimal, the value should be parsed in same mechanism.
             if (Double.valueOf(minimum).equals(Double.NEGATIVE_INFINITY)) {
@@ -202,7 +205,7 @@ class MinimumValidatorTest {
             // schema and document parsed with BigDecimal
             
             v = factory.getSchema(bigDecimalMapper.readTree(schema));
-            List<Error> messages3 = v.validate(doc);
+            List<Error> messages3 = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
             //when the schema and value are both using BigDecimal, the value should be parsed in same mechanism.
             String theValue = value.toLowerCase().replace("\"", "");
             if (minimum.toLowerCase().equals(theValue)) {
@@ -255,15 +258,15 @@ class MinimumValidatorTest {
         JsonNode doc = mapper.readTree(content);
         Schema v = factory.getSchema(mapper.readTree(schema));
 
-        List<Error> messages = v.validate(doc);
+        List<Error> messages = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
         assertTrue(messages.isEmpty(), "Validation should succeed as by default double values are used by mapper");
 
         doc = bigDecimalMapper.readTree(content);
-        messages = v.validate(doc);
+        messages = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
         assertTrue(messages.isEmpty(), "Validation should succeed due to the bug of BigDecimal option of mapper");
 
         v = factory.getSchema(bigDecimalMapper.readTree(schema));
-        messages = v.validate(doc);
+        messages = v.validate(doc).stream().filter(e -> !e.getKeyword().equals("type")).toList();;
         // Before 2.16.0 messages will be empty due to bug https://github.com/FasterXML/jackson-databind/issues/1770
         //assertTrue(messages.isEmpty(), "Validation should succeed due to the bug of BigDecimal option of mapper");
         assertFalse(messages.isEmpty(), "Validation should fail as Incorrect deserialization for BigDecimal numbers is fixed in 2.16.0");
@@ -315,6 +318,23 @@ class MinimumValidatorTest {
         assertEquals(1, schemaRegistry.getSchema(schemaString).validate("9", InputFormat.JSON).size());
     }
 
+    @Test
+    void nonFinite() {
+        String schemaData = "{\r\n"
+                + "  \"minimum\": 10\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_4,
+                builder -> builder.nodeReader(NodeReader.builder()
+                        .jsonMapper(JsonMapper.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                        .build()))
+                .getSchema(schemaData);
+        List<Error> errors = schema.validate("NaN", InputFormat.JSON);
+        assertEquals(0, errors.size());
+        errors = schema.validate("Infinity", InputFormat.JSON);
+        assertEquals(0, errors.size());
+        errors = schema.validate("-Infinity", InputFormat.JSON);
+        assertEquals(0, errors.size());
+    }
 }
 
 

--- a/src/test/java/com/networknt/schema/MultipleOfValidatorTest.java
+++ b/src/test/java/com/networknt/schema/MultipleOfValidatorTest.java
@@ -123,4 +123,28 @@ class MultipleOfValidatorTest {
         errors = schema.validate("-Infinity", InputFormat.JSON);
         assertEquals(0, errors.size());
     }
+
+    @Test
+    void nonFiniteSchemaShouldBeIgnored() {
+        String schemaData = "{\r\n"
+                + "  \"multipleOf\": NaN\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_4,
+                builder -> builder.nodeReader(NodeReader.builder()
+                        .jsonMapper(JsonMapper.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                        .build()))
+                .getSchema(schemaData);
+        List<Error> errors = schema.validate("NaN", InputFormat.JSON);
+        assertEquals(0, errors.size());
+    }
+
+    @Test
+    void stringSchemaShouldBeIgnored() {
+        String schemaData = "{\r\n"
+                + "  \"multipleOf\": \"test\"\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_4).getSchema(schemaData);
+        List<Error> errors = schema.validate("10", InputFormat.JSON);
+        assertEquals(0, errors.size());
+    }
 }

--- a/src/test/java/com/networknt/schema/MultipleOfValidatorTest.java
+++ b/src/test/java/com/networknt/schema/MultipleOfValidatorTest.java
@@ -21,6 +21,11 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import com.networknt.schema.serialization.NodeReader;
+
+import tools.jackson.core.json.JsonReadFeature;
+import tools.jackson.databind.json.JsonMapper;
+
 /**
  * Test MultipleOfValidator validator.
  */
@@ -99,5 +104,23 @@ class MultipleOfValidatorTest {
 
         List<Error> messages = schema.validate(inputData, InputFormat.JSON);
         assertEquals("must be multiple of 0.00001", messages.get(0).getMessage());
+    }
+
+    @Test
+    void nonFinite() {
+        String schemaData = "{\r\n"
+                + "  \"multipleOf\": 10\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_4,
+                builder -> builder.nodeReader(NodeReader.builder()
+                        .jsonMapper(JsonMapper.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                        .build()))
+                .getSchema(schemaData);
+        List<Error> errors = schema.validate("NaN", InputFormat.JSON);
+        assertEquals(0, errors.size());
+        errors = schema.validate("Infinity", InputFormat.JSON);
+        assertEquals(0, errors.size());
+        errors = schema.validate("-Infinity", InputFormat.JSON);
+        assertEquals(0, errors.size());
     }
 }

--- a/src/test/java/com/networknt/schema/TypeValidatorTest.java
+++ b/src/test/java/com/networknt/schema/TypeValidatorTest.java
@@ -22,6 +22,11 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import com.networknt.schema.serialization.NodeReader;
+
+import tools.jackson.core.json.JsonReadFeature;
+import tools.jackson.databind.json.JsonMapper;
+
 /**
  * Test TypeValidator validator.
  */
@@ -177,6 +182,42 @@ class TypeValidatorTest {
         final Schema validator = factory.getSchema(schemaData);
 
         final List<Error> errors = validator.validate(inputData, InputFormat.JSON);
+        assertEquals(1, errors.size());
+    }
+
+    @Test
+    void integerNonFinite() {
+        String schemaData = "{\r\n"
+                + "  \"type\": \"integer\"\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_4,
+                builder -> builder.nodeReader(NodeReader.builder()
+                        .jsonMapper(JsonMapper.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                        .build()))
+                .getSchema(schemaData);
+        List<Error> errors = schema.validate("NaN", InputFormat.JSON);
+        assertEquals(1, errors.size());
+        errors = schema.validate("Infinity", InputFormat.JSON);
+        assertEquals(1, errors.size());
+        errors = schema.validate("-Infinity", InputFormat.JSON);
+        assertEquals(1, errors.size());
+    }
+
+    @Test
+    void numberNonFinite() {
+        String schemaData = "{\r\n"
+                + "  \"type\": \"number\"\r\n"
+                + "}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_4,
+                builder -> builder.nodeReader(NodeReader.builder()
+                        .jsonMapper(JsonMapper.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                        .build()))
+                .getSchema(schemaData);
+        List<Error> errors = schema.validate("NaN", InputFormat.JSON);
+        assertEquals(1, errors.size());
+        errors = schema.validate("Infinity", InputFormat.JSON);
+        assertEquals(1, errors.size());
+        errors = schema.validate("-Infinity", InputFormat.JSON);
         assertEquals(1, errors.size());
     }
 }


### PR DESCRIPTION
Closes #1239, Closes #1240

If `NaN`, `Infinity`, `-Infinity` values are present they are not treated as a JSON number type as it is not valid JSON.

When used in `const` and `enum` comparison is done by checking the values and not using numeric comparison. I.e. for `const` `NaN` the instance data `NaN` will pass validation.

When used in `type` such non-finite numbers are not considered `number`.

When used in `minimum`, `maximum`, `exclusiveMaximum`, `exclusiveMinimum` and `multipleOf` as these are not numbers no validation is performed similar to when the instance data is a `string`.