### PR TITLE
Cleanup of IOException leftovers after update to jackson3

### DIFF
--- a/src/main/java/com/networknt/schema/Schema.java
+++ b/src/main/java/com/networknt/schema/Schema.java
@@ -32,6 +32,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.function.Consumer;
 
+import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import com.networknt.schema.keyword.KeywordValidator;
 import com.networknt.schema.keyword.TypeValidator;
@@ -1190,8 +1191,8 @@ public class Schema implements Validator {
     private JsonNode deserialize(String input, InputFormat inputFormat) {
         try {
             return this.getSchemaContext().getSchemaRegistry().readTree(input, inputFormat);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Invalid input", e);
+        } catch (JacksonException e) {
+            throw new UncheckedIOException(new IOException("Invalid input", e));
         }
     }
 
@@ -1213,6 +1214,8 @@ public class Schema implements Validator {
             }
         } catch (IOException e) {
             throw new UncheckedIOException("Invalid input", e);
+        } catch (JacksonException e) {
+            throw new UncheckedIOException(new IOException("Invalid input", e));
         }
     }
 

--- a/src/main/java/com/networknt/schema/Schema.java
+++ b/src/main/java/com/networknt/schema/Schema.java
@@ -32,7 +32,6 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.function.Consumer;
 
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import com.networknt.schema.keyword.KeywordValidator;
 import com.networknt.schema.keyword.TypeValidator;
@@ -1189,11 +1188,7 @@ public class Schema implements Validator {
      * @return the JsonNode.
      */
     private JsonNode deserialize(String input, InputFormat inputFormat) {
-        try {
-            return this.getSchemaContext().getSchemaRegistry().readTree(input, inputFormat);
-        } catch (JacksonException e) {
-            throw new UncheckedIOException(new IOException("Invalid input", e));
-        }
+        return this.getSchemaContext().getSchemaRegistry().readTree(input, inputFormat);
     }
 
     /**
@@ -1214,8 +1209,6 @@ public class Schema implements Validator {
             }
         } catch (IOException e) {
             throw new UncheckedIOException("Invalid input", e);
-        } catch (JacksonException e) {
-            throw new UncheckedIOException(new IOException("Invalid input", e));
         }
     }
 

--- a/src/main/java/com/networknt/schema/SchemaRegistry.java
+++ b/src/main/java/com/networknt/schema/SchemaRegistry.java
@@ -16,7 +16,6 @@
 
 package com.networknt.schema;
 
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import com.networknt.schema.dialect.BasicDialectRegistry;
 import com.networknt.schema.dialect.DefaultDialectRegistry;
@@ -617,13 +616,8 @@ public class SchemaRegistry {
      * @return the schema
      */
     public Schema getSchema(final String schema, InputFormat inputFormat) {
-        try {
-            final JsonNode schemaNode = readTree(schema, inputFormat);
-            return newSchema(null, schemaNode);
-        } catch (JacksonException e) {
-            logger.error("Failed to load json schema!", e);
-            throw new SchemaException(e);
-        }
+        final JsonNode schemaNode = readTree(schema, inputFormat);
+        return newSchema(null, schemaNode);
     }
 
     /**
@@ -650,13 +644,8 @@ public class SchemaRegistry {
      * @return the schema
      */
     public Schema getSchema(final InputStream schemaStream, InputFormat inputFormat) {
-        try {
-            final JsonNode schemaNode = readTree(schemaStream, inputFormat);
-            return newSchema(null, schemaNode);
-        } catch (JacksonException e) {
-            logger.error("Failed to load json schema!", e);
-            throw new SchemaException(e);
-        }
+        final JsonNode schemaNode = readTree(schemaStream, inputFormat);
+        return newSchema(null, schemaNode);
     }
 
     /**
@@ -692,13 +681,8 @@ public class SchemaRegistry {
      * @return the schema
      */
     public Schema getSchema(final SchemaLocation schemaUri, final String schema, InputFormat inputFormat) {
-        try {
-            final JsonNode schemaNode = readTree(schema, inputFormat);
-            return newSchema(schemaUri, schemaNode);
-        } catch (JacksonException e) {
-            logger.error("Failed to load json schema!", e);
-            throw new SchemaException(e);
-        }
+        final JsonNode schemaNode = readTree(schema, inputFormat);
+        return newSchema(schemaUri, schemaNode);
     }
 
     /**
@@ -710,13 +694,8 @@ public class SchemaRegistry {
      * @return the schema
      */
     public Schema getSchema(final SchemaLocation schemaUri, final InputStream schemaStream, InputFormat inputFormat) {
-        try {
-            final JsonNode schemaNode = readTree(schemaStream, inputFormat);
-            return newSchema(schemaUri, schemaNode);
-        } catch (JacksonException e) {
-            logger.error("Failed to load json schema!", e);
-            throw new SchemaException(e);
-        }
+        final JsonNode schemaNode = readTree(schemaStream, inputFormat);
+        return newSchema(schemaUri, schemaNode);
     }
 
     /**

--- a/src/main/java/com/networknt/schema/SchemaRegistry.java
+++ b/src/main/java/com/networknt/schema/SchemaRegistry.java
@@ -16,6 +16,7 @@
 
 package com.networknt.schema;
 
+import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import com.networknt.schema.dialect.BasicDialectRegistry;
 import com.networknt.schema.dialect.DefaultDialectRegistry;
@@ -584,11 +585,11 @@ public class SchemaRegistry {
         return dialectRegistry.getDialect(key, this);
     }
 
-    JsonNode readTree(String content, InputFormat inputFormat) throws IOException {
+    JsonNode readTree(String content, InputFormat inputFormat) {
         return this.nodeReader.readTree(content, inputFormat);
     }
 
-    JsonNode readTree(InputStream content, InputFormat inputFormat) throws IOException {
+    JsonNode readTree(InputStream content, InputFormat inputFormat) {
         return this.nodeReader.readTree(content, inputFormat);
     }
 
@@ -619,9 +620,9 @@ public class SchemaRegistry {
         try {
             final JsonNode schemaNode = readTree(schema, inputFormat);
             return newSchema(null, schemaNode);
-        } catch (IOException ioe) {
-            logger.error("Failed to load json schema!", ioe);
-            throw new SchemaException(ioe);
+        } catch (JacksonException e) {
+            logger.error("Failed to load json schema!", e);
+            throw new SchemaException(e);
         }
     }
 
@@ -652,9 +653,9 @@ public class SchemaRegistry {
         try {
             final JsonNode schemaNode = readTree(schemaStream, inputFormat);
             return newSchema(null, schemaNode);
-        } catch (IOException ioe) {
-            logger.error("Failed to load json schema!", ioe);
-            throw new SchemaException(ioe);
+        } catch (JacksonException e) {
+            logger.error("Failed to load json schema!", e);
+            throw new SchemaException(e);
         }
     }
 
@@ -694,9 +695,9 @@ public class SchemaRegistry {
         try {
             final JsonNode schemaNode = readTree(schema, inputFormat);
             return newSchema(schemaUri, schemaNode);
-        } catch (IOException ioe) {
-            logger.error("Failed to load json schema!", ioe);
-            throw new SchemaException(ioe);
+        } catch (JacksonException e) {
+            logger.error("Failed to load json schema!", e);
+            throw new SchemaException(e);
         }
     }
 
@@ -712,9 +713,9 @@ public class SchemaRegistry {
         try {
             final JsonNode schemaNode = readTree(schemaStream, inputFormat);
             return newSchema(schemaUri, schemaNode);
-        } catch (IOException ioe) {
-            logger.error("Failed to load json schema!", ioe);
-            throw new SchemaException(ioe);
+        } catch (JacksonException e) {
+            logger.error("Failed to load json schema!", e);
+            throw new SchemaException(e);
         }
     }
 

--- a/src/main/java/com/networknt/schema/serialization/BasicNodeReader.java
+++ b/src/main/java/com/networknt/schema/serialization/BasicNodeReader.java
@@ -16,12 +16,11 @@
 
 package com.networknt.schema.serialization;
 
-import java.io.IOException;
-import java.io.InputStream;
-
+import com.networknt.schema.InputFormat;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
-import com.networknt.schema.InputFormat;
+
+import java.io.InputStream;
 
 /**
  * Basic implementation of {@link NodeReader}.
@@ -39,12 +38,12 @@ public class BasicNodeReader implements NodeReader {
     }
 
     @Override
-    public JsonNode readTree(String content, InputFormat inputFormat) throws IOException {
+    public JsonNode readTree(String content, InputFormat inputFormat) {
         return getObjectMapper(inputFormat).readTree(content);
     }
 
     @Override
-    public JsonNode readTree(InputStream content, InputFormat inputFormat) throws IOException {
+    public JsonNode readTree(InputStream content, InputFormat inputFormat) {
         return getObjectMapper(inputFormat).readTree(content);
     }
 

--- a/src/main/java/com/networknt/schema/serialization/DefaultNodeReader.java
+++ b/src/main/java/com/networknt/schema/serialization/DefaultNodeReader.java
@@ -1,6 +1,5 @@
 package com.networknt.schema.serialization;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 import tools.jackson.databind.JsonNode;
@@ -33,7 +32,7 @@ public class DefaultNodeReader implements NodeReader {
     }
 
     @Override
-    public JsonNode readTree(String content, InputFormat inputFormat) throws IOException {
+    public JsonNode readTree(String content, InputFormat inputFormat) {
         if (this.jsonNodeFactoryFactory == null) {
             return getObjectMapper(inputFormat).readTree(content);
         } else {
@@ -42,7 +41,7 @@ public class DefaultNodeReader implements NodeReader {
     }
 
     @Override
-    public JsonNode readTree(InputStream content, InputFormat inputFormat) throws IOException {
+    public JsonNode readTree(InputStream content, InputFormat inputFormat) {
         if (this.jsonNodeFactoryFactory == null) {
             return getObjectMapper(inputFormat).readTree(content);
         } else {

--- a/src/main/java/com/networknt/schema/serialization/NodeReader.java
+++ b/src/main/java/com/networknt/schema/serialization/NodeReader.java
@@ -15,7 +15,6 @@
  */
 package com.networknt.schema.serialization;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 import tools.jackson.databind.JsonNode;
@@ -32,9 +31,8 @@ public interface NodeReader {
      * @param content     the content
      * @param inputFormat the input format
      * @return the node
-     * @throws IOException IOException
      */
-    JsonNode readTree(String content, InputFormat inputFormat) throws IOException;
+    JsonNode readTree(String content, InputFormat inputFormat);
 
     /**
      * Deserialize content as a tree.
@@ -42,9 +40,8 @@ public interface NodeReader {
      * @param content input stream
      * @param inputFormat input format
      * @return the node
-     * @throws IOException IOException
      */
-    JsonNode readTree(InputStream content, InputFormat inputFormat) throws IOException;
+    JsonNode readTree(InputStream content, InputFormat inputFormat);
 
     /**
      * Creates a builder for {@link NodeReader}.

--- a/src/main/java/com/networknt/schema/utils/JsonNodes.java
+++ b/src/main/java/com/networknt/schema/utils/JsonNodes.java
@@ -17,7 +17,6 @@ package com.networknt.schema.utils;
 
 import java.io.InputStream;
 
-import tools.jackson.core.JacksonException;
 import tools.jackson.core.TokenStreamLocation;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.JsonNode;
@@ -89,8 +88,6 @@ public class JsonNodes {
             ObjectReader reader = objectMapper.reader(nodeFactory);
             JsonNode result = reader.readTree(parser);
             return (result != null) ? result : nodeFactory.missingNode();
-        } catch (JacksonException e) {
-            throw new IllegalArgumentException("Invalid input", e);
         }
     }
 
@@ -109,8 +106,6 @@ public class JsonNodes {
             ObjectReader reader = objectMapper.reader(nodeFactory);
             JsonNode result = reader.readTree(parser);
             return (result != null) ? result : nodeFactory.missingNode();
-        } catch (JacksonException e) {
-            throw new IllegalArgumentException("Invalid input", e);
         }
     }
 

--- a/src/test/java/com/networknt/schema/SchemaRegistryTest.java
+++ b/src/test/java/com/networknt/schema/SchemaRegistryTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import com.networknt.schema.dialect.BasicDialectRegistry;
 import com.networknt.schema.dialect.Dialect;
 import com.networknt.schema.dialect.Dialects;
+import tools.jackson.core.JacksonException;
 
 /**
  * Tests for JsonSchemaFactory.
@@ -158,5 +159,13 @@ class SchemaRegistryTest {
         result.validate(input, InputFormat.JSON);
         Schema nested = registry.getSchema(SchemaLocation.of("https://example.org/schema"));
         assertEquals(Dialects.getDraft4(), nested.getSchemaContext().getDialect());
+    }
+
+    @Test
+    void invalidJsonSchema() {
+        SchemaRegistry registry = SchemaRegistry.builder().build();
+        assertThrows(JacksonException.class, () -> {
+            registry.getSchema("INVALID_JSON");
+        });
     }
 }

--- a/src/test/java/com/networknt/schema/SchemaRegistryTest.java
+++ b/src/test/java/com/networknt/schema/SchemaRegistryTest.java
@@ -159,10 +159,4 @@ class SchemaRegistryTest {
         Schema nested = registry.getSchema(SchemaLocation.of("https://example.org/schema"));
         assertEquals(Dialects.getDraft4(), nested.getSchemaContext().getDialect());
     }
-
-    @Test
-    void invalidJsonSchema() {
-        SchemaRegistry registry = SchemaRegistry.builder().build();
-        assertThrows(SchemaException.class, () -> registry.getSchema("INVALID_JSON"));
-    }
 }

--- a/src/test/java/com/networknt/schema/SchemaRegistryTest.java
+++ b/src/test/java/com/networknt/schema/SchemaRegistryTest.java
@@ -159,4 +159,10 @@ class SchemaRegistryTest {
         Schema nested = registry.getSchema(SchemaLocation.of("https://example.org/schema"));
         assertEquals(Dialects.getDraft4(), nested.getSchemaContext().getDialect());
     }
+
+    @Test
+    void invalidJsonSchema() {
+        SchemaRegistry registry = SchemaRegistry.builder().build();
+        assertThrows(SchemaException.class, () -> registry.getSchema("INVALID_JSON"));
+    }
 }

--- a/src/test/java/com/networknt/schema/serialization/DefaultNodeReaderTest.java
+++ b/src/test/java/com/networknt/schema/serialization/DefaultNodeReaderTest.java
@@ -16,7 +16,6 @@
 package com.networknt.schema.serialization;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +29,7 @@ import com.networknt.schema.utils.JsonNodes;
  */
 class DefaultNodeReaderTest {
     @Test
-    void location() throws IOException {
+    void location() {
         String schemaData = "{\r\n"
                 + "  \"$id\": \"https://schema/myschema\",\r\n"
                 + "  \"properties\": {\r\n"
@@ -58,7 +57,7 @@ class DefaultNodeReaderTest {
     }
 
     @Test
-    void jsonLocation() throws IOException {
+    void jsonLocation() {
         String schemaData = "{\r\n"
                 + "  \"$id\": \"https://schema/myschema\",\r\n"
                 + "  \"properties\": {\r\n"
@@ -81,7 +80,7 @@ class DefaultNodeReaderTest {
     }
 
     @Test
-    void yamlLocation() throws IOException {
+    void yamlLocation() {
         String schemaData = "---\r\n"
                 + "\"$id\": 'https://schema/myschema'\r\n"
                 + "properties:\r\n"


### PR DESCRIPTION
To keep backward compatiblity with version 2.x catch JacksonException and rethrow as SchemaException

This is an proposition to fix #1243 