### PR TITLE
simplify additionalItems validation flow

### DIFF
--- a/src/main/java/com/networknt/schema/keyword/ItemsLegacyValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/ItemsLegacyValidator.java
@@ -186,9 +186,7 @@ public class ItemsLegacyValidator extends BaseKeywordValidator {
                         executionContext.evaluationPathAddLast("items");
                     }
                 } else if (this.additionalItems != null) {
-                    if (this.additionalItems) {
-//                        evaluatedItems.add(path);
-                    } else {
+                    if (!this.additionalItems) {
                         // no additional item allowed, return error
                         executionContext.evaluationPathRemoveLast(); // remove items
                         executionContext.evaluationPathAddLast("additionalItems");


### PR DESCRIPTION
  ## Summary
  Simplifies the `additionalItems` handling in `ItemsLegacyValidator` by removing an empty branch that contained
  only commented-out code.

  ## Rationale
  PMD reported an `EmptyControlStatement` in this area. The previous `if (this.additionalItems)` branch had no
  active behavior, while the `else` branch handled the validation error case. This change checks `if (!
  this.additionalItems)` directly and preserves the existing behavior.

  Related issue: #ISSUE_NUMBER

  ## Validation
  - PMD quickstart: selected `EmptyControlStatement` finding is removed
  - `mvn test`
  - `mvn verify`