### PR TITLE
test: re-enable and strengthen recursive $ref SelfRefTest

### DIFF
--- a/src/test/java/com/networknt/schema/SelfRefTest.java
+++ b/src/test/java/com/networknt/schema/SelfRefTest.java
@@ -16,17 +16,49 @@
 
 package com.networknt.schema;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import tools.jackson.databind.JsonNode;
 
 /**
  * Created by stevehu on 2016-12-20.
+ *
+ * Regression coverage for a recursive {@code $ref} (a self-referential "tree"
+ * schema). This historically caused a {@code StackOverflowError} while loading
+ * the schema; the test guards against that and additionally verifies that
+ * validation actually recurses into nested branches.
  */
 class SelfRefTest extends BaseJsonSchemaValidatorTest {
-    @Disabled("This test currently is failing because of a StackOverflow caused by a recursive $ref.")
-    @Test()
-    void testSelfRef() throws Exception {
-        Schema node = getJsonSchemaFromClasspath("selfRef.json");
-        System.out.println("node = " + node);
+
+    @Test
+    void recursiveRefLoadsWithoutStackOverflow() {
+        Schema schema = getJsonSchemaFromClasspath("selfRef.json");
+        Assertions.assertNotNull(schema);
+    }
+
+    @Test
+    void recursiveRefValidatesNestedBranches() throws Exception {
+        Schema schema = getJsonSchemaFromClasspath("selfRef.json");
+
+        // A well-formed, deeply nested tree: every node carries the required
+        // "value", so recursing through "branches" should yield no errors.
+        JsonNode valid = getJsonNodeFromStringContent(
+                "{\"name\":\"root\",\"tree\":{\"value\":\"a\",\"branches\":["
+                + "{\"value\":\"b\",\"branches\":[{\"value\":\"c\"}]}]}}");
+        List<Error> validErrors = schema.validate(valid);
+        Assertions.assertTrue(validErrors.isEmpty(),
+                "valid recursive tree should not produce errors, got: " + validErrors);
+
+        // A nested branch missing the required "value" must be reported, which
+        // only happens if the validator follows the recursive $ref downward.
+        JsonNode invalid = getJsonNodeFromStringContent(
+                "{\"name\":\"root\",\"tree\":{\"value\":\"a\",\"branches\":["
+                + "{\"branches\":[{\"value\":\"c\"}]}]}}");
+        List<Error> invalidErrors = schema.validate(invalid);
+        Assertions.assertFalse(invalidErrors.isEmpty(),
+                "missing required 'value' in a nested branch should be reported");
     }
 }


### PR DESCRIPTION
SelfRefTest has been @Disabled since 2016 with the note that a recursive $ref caused a StackOverflowError. That has long since been fixed, but the test stayed disabled and only printed to stdout, so the recursive-$ref path had no coverage.

This re-enables it and replaces the println with real assertions: the self-referential "tree" schema loads without StackOverflow, a valid nested tree validates with no errors, and a nested branch missing the required "value" is reported (proving validation follows the recursive $ref). Verified locally with mvn -Dtest=SelfRefTest test.