### PR TITLE
Bump jackson to 3.1.4 to fix CVE-2026-54512 and CVE-2026-54513

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.itu>1.14.0</version.itu>
-    <version.jackson>3.1.1</version.jackson>
+    <version.jackson>3.1.4</version.jackson>
     <version.joni>2.2.6</version.joni>
     <version.logback>1.5.22</version.logback>
     <version.slf4j>2.0.17</version.slf4j>


### PR DESCRIPTION
Bumps `version.jackson` 3.1.1 → 3.1.4, fixing two high-severity jackson-databind PolymorphicTypeValidator bypasses:

- CVE-2026-54512 (GHSA-j3rv-43j4-c7qm)
- CVE-2026-54513 (GHSA-rmj7-2vxq-3g9f)

Patch bump within Jackson 3; no API changes. Closes #1262.