### PR TITLE
Reject non-ASCII whitespace in email format

### DIFF
--- a/src/main/java/com/networknt/schema/format/EmailFormat.java
+++ b/src/main/java/com/networknt/schema/format/EmailFormat.java
@@ -35,7 +35,25 @@ public class EmailFormat implements Format {
 
     @Override
     public boolean matches(ExecutionContext executionContext, String value) {
+        if (containsNonAsciiWhitespace(value)) {
+            return false;
+        }
         return this.emailValidator.isValid(value);
+    }
+
+    /**
+     * Whether {@code value} contains a non-ASCII whitespace character such as
+     * {@code U+00A0} NON-BREAKING SPACE. The underlying validator only excludes
+     * ASCII whitespace, so such characters would otherwise be accepted in an
+     * email address. Note that {@link Character#isWhitespace(char)} deliberately
+     * excludes {@code U+00A0}, hence the additional
+     * {@link Character#isSpaceChar(char)} check.
+     */
+    private static boolean containsNonAsciiWhitespace(String value) {
+        if (value == null) {
+            return false;
+        }
+        return value.codePoints().anyMatch(ch -> ch > 0x7F && (Character.isWhitespace(ch) || Character.isSpaceChar(ch)));
     }
     
     @Override

--- a/src/test/java/com/networknt/schema/format/EmailFormatTest.java
+++ b/src/test/java/com/networknt/schema/format/EmailFormatTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema.format;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.networknt.schema.Error;
+import com.networknt.schema.InputFormat;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SpecificationVersion;
+
+class EmailFormatTest {
+
+    /** U+00A0 NON-BREAKING SPACE, built from its code point so no invisible character sits in the source. */
+    private static final String NBSP = new String(Character.toChars(0x00A0));
+
+    /**
+     * Validates {@code email} against a {@code {"format": "email"}} schema with
+     * format assertions turned on, and returns the validation errors.
+     */
+    private List<Error> validateEmail(String email) {
+        String schemaData = "{\r\n"
+                + "  \"format\": \"email\"\r\n"
+                + "}";
+        String inputData = "\"" + email + "\"";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12).getSchema(schemaData);
+        return schema.validate(inputData, InputFormat.JSON,
+                executionContext -> executionContext.executionConfig(executionConfig -> executionConfig.formatAssertionsEnabled(true)));
+    }
+
+    /** Sanity check that the test harness accepts a plainly valid email. */
+    @Test
+    void validEmailShouldPass() {
+        List<Error> messages = validateEmail("name@email.com");
+        assertTrue(messages.isEmpty(), "a plainly valid email should pass");
+    }
+
+    /**
+     * Reproduces issue #1164: a leading non-breaking space (U+00A0) should make
+     * the email invalid, just like a regular leading space does, but it is
+     * currently accepted because the validator only excludes ASCII whitespace.
+     */
+    @Test
+    void emailWithLeadingNbspShouldFail() {
+        List<Error> messages = validateEmail(NBSP + "name@email.com");
+        assertFalse(messages.isEmpty(), "email with a leading non-breaking space (U+00A0) should be invalid");
+    }
+}


### PR DESCRIPTION
## Problem

`{ "format": "email" }` accepts values containing a non-breaking space (U+00A0)
or other non-ASCII whitespace. For example, an email with a leading U+00A0 is
treated as valid, even though the same address with a regular leading space is
correctly rejected.

The underlying `EmailValidator` regex only excludes ASCII whitespace, so
non-ASCII whitespace slips through.

## Fix

`EmailFormat` now rejects any value containing a non-ASCII whitespace character
before delegating to the validator. `Character.isWhitespace` deliberately
excludes U+00A0, so `Character.isSpaceChar` is also checked.

The change only affects values that contain non-ASCII whitespace; all-ASCII
emails — including quoted local parts with spaces such as
`"joe bloggs"@example.com` — are unchanged.

Following the existing per-format test convention (`TimeFormatTest`,
`UriFormatTest`, …), this also adds `EmailFormatTest`.

## Note on idn-email

`IdnEmailFormat` (idn-email) shares the same delegation and therefore the same
behavior, but is intentionally left out of scope here since this issue concerns
`email`. Happy to address it in a follow-up if desired.

## Testing

- New `EmailFormatTest` covers a plainly valid email and the reported
  non-breaking space case.
- The full test suite passes locally, including the official JSON Schema Test
  Suite email cases (e.g. the valid quoted local part `"joe bloggs"@example.com`).

Closes #1164
