### PR TITLE
Honor PathType when formatting SchemaException locations

### DIFF
--- a/src/main/java/com/networknt/schema/SchemaLocation.java
+++ b/src/main/java/com/networknt/schema/SchemaLocation.java
@@ -392,6 +392,39 @@ public class SchemaLocation {
 
     }
 
+    /**
+     * Formats this location using the requested path type for the fragment.
+     * <p>
+     * Schema locations are stored as JSON Pointer fragments. Validation messages
+     * can request a different representation through {@link SchemaRegistryConfig}.
+     *
+     * @param pathType the path type to use for the fragment
+     * @return the formatted location
+     */
+    public String toString(PathType pathType) {
+        if (pathType == null || this.fragment == null || pathType == this.fragment.getPathType()) {
+            return toString();
+        }
+        NodePath converted = new NodePath(pathType);
+        int count = this.fragment.getNameCount();
+        for (int i = 0; i < count; i++) {
+            Object element = this.fragment.getElement(i);
+            if (element instanceof Number) {
+                converted = converted.append(((Number) element).intValue());
+            } else if (element != null) {
+                converted = converted.append(element.toString());
+            }
+        }
+        String fragmentText = converted.toString();
+        if (this.absoluteIri == null) {
+            return fragmentText;
+        }
+        if (fragmentText.startsWith("$")) {
+            return this.absoluteIri + fragmentText;
+        }
+        return this.absoluteIri + "#" + fragmentText;
+    }
+
     @Override
     public String toString() {
         if (this.value == null) {

--- a/src/main/java/com/networknt/schema/SchemaLocation.java
+++ b/src/main/java/com/networknt/schema/SchemaLocation.java
@@ -405,17 +405,11 @@ public class SchemaLocation {
         if (pathType == null || this.fragment == null || pathType == this.fragment.getPathType()) {
             return toString();
         }
-        NodePath converted = new NodePath(pathType);
-        int count = this.fragment.getNameCount();
-        for (int i = 0; i < count; i++) {
-            Object element = this.fragment.getElement(i);
-            if (element instanceof Number) {
-                converted = converted.append(((Number) element).intValue());
-            } else if (element != null) {
-                converted = converted.append(element.toString());
-            }
+        // Anchors keep their URI-reference identity. Only JSON Pointer fragments convert.
+        if (PathType.URI_REFERENCE.equals(this.fragment.getPathType())) {
+            return toString();
         }
-        String fragmentText = converted.toString();
+        String fragmentText = formatFragment(pathType);
         if (this.absoluteIri == null) {
             return fragmentText;
         }
@@ -423,6 +417,25 @@ public class SchemaLocation {
             return this.absoluteIri + fragmentText;
         }
         return this.absoluteIri + "#" + fragmentText;
+    }
+
+    private String formatFragment(PathType pathType) {
+        StringBuilder currentPath = new StringBuilder(pathType.getRoot());
+        int count = this.fragment.getNameCount();
+        for (int i = 0; i < count; i++) {
+            Object element = this.fragment.getElement(i);
+            if (element instanceof Number) {
+                pathType.append(currentPath, ((Number) element).intValue());
+            } else {
+                String token = element == null ? "" : element.toString();
+                if (token.isEmpty() && pathType == PathType.JSON_PATH) {
+                    currentPath.append("['']");
+                } else {
+                    pathType.append(currentPath, token);
+                }
+            }
+        }
+        return currentPath.toString();
     }
 
     @Override

--- a/src/main/java/com/networknt/schema/SchemaRegistry.java
+++ b/src/main/java/com/networknt/schema/SchemaRegistry.java
@@ -22,6 +22,7 @@ import com.networknt.schema.dialect.DefaultDialectRegistry;
 import com.networknt.schema.dialect.Dialect;
 import com.networknt.schema.dialect.DialectId;
 import com.networknt.schema.dialect.DialectRegistry;
+import com.networknt.schema.path.PathType;
 import com.networknt.schema.resource.InputStreamSource;
 import com.networknt.schema.resource.ResourceLoaders;
 import com.networknt.schema.resource.SchemaIdResolvers;
@@ -525,7 +526,7 @@ public class SchemaRegistry {
 
     private void validateSchemaNodeNotNull(SchemaLocation schemaLocation, JsonNode schemaNode) {
         if (schemaNode == null) {
-            throw new SchemaException("Schema at " + schemaLocation + " must not be null");
+            throw new SchemaException("Schema at " + formatSchemaLocation(schemaLocation) + " must not be null");
         }
     }
 
@@ -538,8 +539,13 @@ public class SchemaRegistry {
             return;
         }
         String expected = supportsBooleanSchema(schemaContext) ? "object or boolean" : "object";
-        throw new SchemaException("Schema at " + schemaLocation + " must be " + expected + " but was "
-                + schemaNode.getNodeType());
+        throw new SchemaException("Schema at " + formatSchemaLocation(schemaLocation) + " must be " + expected
+                + " but was " + schemaNode.getNodeType());
+    }
+
+    private String formatSchemaLocation(SchemaLocation schemaLocation) {
+        PathType pathType = this.schemaRegistryConfig != null ? this.schemaRegistryConfig.getPathType() : null;
+        return schemaLocation.toString(pathType);
     }
 
     private boolean supportsBooleanSchema(SchemaContext schemaContext) {

--- a/src/test/java/com/networknt/schema/Issue1270Test.java
+++ b/src/test/java/com/networknt/schema/Issue1270Test.java
@@ -52,4 +52,19 @@ class Issue1270Test {
         assertTrue(exception.getMessage().contains("must be object or boolean"), exception.getMessage());
         assertTrue(exception.getMessage().contains("#/properties/required"), exception.getMessage());
     }
+
+    @Test
+    void schemaExceptionShouldKeepDiagnosticForEmptyPropertyName() {
+        SchemaRegistryConfig config = SchemaRegistryConfig.builder().pathType(PathType.JSON_PATH).build();
+        SchemaRegistry registry = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_7,
+                builder -> builder.schemaRegistryConfig(config));
+
+        SchemaException exception = assertThrows(SchemaException.class,
+                () -> registry.getSchema("{\"type\":\"object\",\"properties\":{\"\":[]}}"));
+
+        assertTrue(exception.getMessage().contains("must be object or boolean"), exception.getMessage());
+        assertTrue(exception.getMessage().contains("ARRAY"), exception.getMessage());
+        assertTrue(exception.getMessage().contains("$.properties['']"), exception.getMessage());
+        assertFalse(exception.getMessage().contains("JSONPath selector cannot be empty"), exception.getMessage());
+    }
 }

--- a/src/test/java/com/networknt/schema/Issue1270Test.java
+++ b/src/test/java/com/networknt/schema/Issue1270Test.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.networknt.schema;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.networknt.schema.path.PathType;
+
+class Issue1270Test {
+
+    private static final String INVALID_PROPERTY_SCHEMA = "{\"type\":\"object\",\"properties\":{\"required\":[]}}";
+
+    @Test
+    void schemaExceptionShouldHonorJsonPathLocationFormatting() {
+        SchemaRegistryConfig config = SchemaRegistryConfig.builder().pathType(PathType.JSON_PATH).build();
+        SchemaRegistry registry = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_7,
+                builder -> builder.schemaRegistryConfig(config));
+
+        SchemaException exception = assertThrows(SchemaException.class,
+                () -> registry.getSchema(INVALID_PROPERTY_SCHEMA));
+
+        assertTrue(exception.getMessage().contains("must be object or boolean"), exception.getMessage());
+        assertTrue(exception.getMessage().contains("ARRAY"), exception.getMessage());
+        assertTrue(exception.getMessage().contains("$.properties.required"), exception.getMessage());
+        assertFalse(exception.getMessage().contains("#/properties/required"), exception.getMessage());
+    }
+
+    @Test
+    void schemaExceptionShouldKeepJsonPointerByDefault() {
+        SchemaRegistry registry = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_7);
+
+        SchemaException exception = assertThrows(SchemaException.class,
+                () -> registry.getSchema(INVALID_PROPERTY_SCHEMA));
+
+        assertTrue(exception.getMessage().contains("must be object or boolean"), exception.getMessage());
+        assertTrue(exception.getMessage().contains("#/properties/required"), exception.getMessage());
+    }
+}

--- a/src/test/java/com/networknt/schema/SchemaLocationTest.java
+++ b/src/test/java/com/networknt/schema/SchemaLocationTest.java
@@ -302,4 +302,19 @@ class SchemaLocationTest {
         assertEquals("$.properties.required", location.toString(PathType.JSON_PATH));
     }
 
+    @Test
+    void toStringKeepsAnchorFragments() {
+        SchemaLocation location = SchemaLocation.of("https://example.com/schema#anchor");
+        assertEquals("https://example.com/schema#anchor", location.toString());
+        assertEquals("https://example.com/schema#anchor", location.toString(PathType.JSON_PATH));
+        assertEquals("https://example.com/schema#anchor", location.toString(PathType.JSON_POINTER));
+    }
+
+    @Test
+    void toStringEscapesEmptyPropertyNamesForJsonPath() {
+        SchemaLocation location = SchemaLocation.of("#/properties/");
+        assertEquals("#/properties/", location.toString());
+        assertEquals("$.properties['']", location.toString(PathType.JSON_PATH));
+    }
+
 }

--- a/src/test/java/com/networknt/schema/SchemaLocationTest.java
+++ b/src/test/java/com/networknt/schema/SchemaLocationTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import com.networknt.schema.path.NodePath;
+import com.networknt.schema.path.PathType;
 
 class SchemaLocationTest {
 
@@ -291,6 +292,14 @@ class SchemaLocationTest {
     void equalsEqualsNoFragmentToString() {
         assertEquals(SchemaLocation.of("https://example.com/example.yaml#").toString(),
                 SchemaLocation.of("https://example.com/example.yaml").toString());
+    }
+
+    @Test
+    void toStringHonorsRequestedPathType() {
+        SchemaLocation location = SchemaLocation.of("#/properties/required");
+        assertEquals("#/properties/required", location.toString());
+        assertEquals("#/properties/required", location.toString(PathType.JSON_POINTER));
+        assertEquals("$.properties.required", location.toString(PathType.JSON_PATH));
     }
 
 }


### PR DESCRIPTION
## Summary
`SchemaRegistry` now formats `SchemaException` locations with the configured `PathType`. Creating a schema with `PathType.JSON_PATH` reports `$.properties.required` instead of always using the JSON Pointer `#/properties/required`.

Default `JSON_POINTER` messages are unchanged.

Fixes #1270

## Test Plan
- [x] `mvn -Dtest=Issue1270Test,Issue1174Test,SchemaLocationTest test` (Java 17)
- [x] `mvn test` (Java 17)