### PR TITLE
fix: uniqueItems compares numbers by value, not by node type

### DIFF
--- a/src/main/java/com/networknt/schema/keyword/UniqueItemsValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/UniqueItemsValidator.java
@@ -23,7 +23,11 @@ import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.path.NodePath;
 import com.networknt.schema.SchemaContext;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -45,15 +49,52 @@ public class UniqueItemsValidator extends BaseKeywordValidator implements Keywor
         
 
         if (unique) {
-            Set<JsonNode> set = new HashSet<>();
+            Set<Object> set = new HashSet<>();
             for (JsonNode n : node) {
-                if (!set.add(n)) {
+                if (!set.add(comparisonKey(n))) {
                     executionContext.addError(error().instanceNode(node).instanceLocation(instanceLocation)
                             .evaluationPath(executionContext.getEvaluationPath()).locale(executionContext.getExecutionConfig().getLocale())
                             .build());
                 }
             }
         }
+    }
+
+    /**
+     * Builds the value this keyword compares items by.
+     *
+     * uniqueItems treats two numbers as the same item when they are
+     * mathematically equal, so 1, 1.0 and 1.00 are one value. JsonNode equality
+     * is type-sensitive -- IntNode(1) does not equal DoubleNode(1.0) -- so
+     * comparing the nodes themselves let that duplicate through. Numbers are
+     * therefore reduced to a scale-independent BigDecimal.
+     *
+     * Only numbers are folded together. A number and a boolean stay distinct,
+     * as do a number and its string form, which the suite requires: nested [1]
+     * and [true], and [0] and [false], are unique arrays. Objects and arrays are
+     * walked so the rule holds wherever the number sits.
+     */
+    private static Object comparisonKey(JsonNode node) {
+        if (node.isNumber()) {
+            return node.decimalValue().stripTrailingZeros();
+        }
+        if (node.isArray()) {
+            List<Object> items = new ArrayList<>(node.size());
+            for (JsonNode item : node) {
+                items.add(comparisonKey(item));
+            }
+            return items;
+        }
+        if (node.isObject()) {
+            // Map equality ignores insertion order, which is what JSON objects want.
+            Map<String, Object> properties = new LinkedHashMap<>();
+            for (Map.Entry<String, JsonNode> property : node.properties()) {
+                properties.put(property.getKey(), comparisonKey(property.getValue()));
+            }
+            return properties;
+        }
+        // Strings, booleans and null compare as themselves; a node is its own key.
+        return node;
     }
 
 }

--- a/src/main/java/com/networknt/schema/keyword/UniqueItemsValidator.java
+++ b/src/main/java/com/networknt/schema/keyword/UniqueItemsValidator.java
@@ -22,6 +22,7 @@ import com.networknt.schema.Schema;
 import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.path.NodePath;
 import com.networknt.schema.SchemaContext;
+import com.networknt.schema.utils.JsonNodeTypes;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -69,13 +70,16 @@ public class UniqueItemsValidator extends BaseKeywordValidator implements Keywor
      * comparing the nodes themselves let that duplicate through. Numbers are
      * therefore reduced to a scale-independent BigDecimal.
      *
-     * Only numbers are folded together. A number and a boolean stay distinct,
+     * NaN, Infinity and -Infinity have no BigDecimal form, so they are left out
+ * of that and keep comparing as nodes, as every item did before.
+ *
+ * Only numbers are folded together. A number and a boolean stay distinct,
      * as do a number and its string form, which the suite requires: nested [1]
      * and [true], and [0] and [false], are unique arrays. Objects and arrays are
      * walked so the rule holds wherever the number sits.
      */
     private static Object comparisonKey(JsonNode node) {
-        if (node.isNumber()) {
+        if (node.isNumber() && !JsonNodeTypes.isNonFiniteNumber(node)) {
             return node.decimalValue().stripTrailingZeros();
         }
         if (node.isArray()) {

--- a/src/test/java/com/networknt/schema/UniqueItemsNumericEqualityTest.java
+++ b/src/test/java/com/networknt/schema/UniqueItemsNumericEqualityTest.java
@@ -1,0 +1,74 @@
+package com.networknt.schema;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * uniqueItems compares numbers by mathematical value, so 1 and 1.0 are the same
+ * item. Comparison went through JsonNode equality, which is type-sensitive:
+ * IntNode(1) does not equal DoubleNode(1.0), so the duplicate slipped through.
+ *
+ * The official suite's case for this is [1.0, 1.0, 1], which passes either way --
+ * the two identical decimals are caught before an integer is ever compared with a
+ * decimal. These cases put the integer next to the decimal directly.
+ */
+class UniqueItemsNumericEqualityTest {
+
+    private boolean valid(String instance) {
+        Schema schema = SchemaRegistry
+                .withDefaultDialect(SpecificationVersion.DRAFT_2020_12)
+                .getSchema("{\"type\":\"array\",\"uniqueItems\":true}");
+        return schema.validate(instance, InputFormat.JSON).isEmpty();
+    }
+
+    @Test
+    void integerAndDecimalWithTheSameValueAreDuplicates() {
+        assertFalse(valid("[1, 1.0]"), "1 and 1.0 are the same number");
+    }
+
+    @Test
+    void integerAndTrailingZeroDecimalAreDuplicates() {
+        assertFalse(valid("[1, 1.00]"), "1 and 1.00 are the same number");
+    }
+
+    @Test
+    void decimalsWithDifferentScaleAreDuplicates() {
+        assertFalse(valid("[1.0, 1.00]"), "1.0 and 1.00 are the same number");
+    }
+
+    @Test
+    void largeIntegerAndDecimalWithTheSameValueAreDuplicates() {
+        assertFalse(valid("[10000000000, 1.0e10]"), "10000000000 and 1.0e10 are the same number");
+    }
+
+    @Test
+    void mathematicallyDifferentNumbersStayUnique() {
+        assertTrue(valid("[1, 2]"));
+        assertTrue(valid("[1, 1.5]"));
+    }
+
+    // The suite requires these to stay distinct: a number must not collapse into
+    // a boolean of the same "truthiness".
+    @Test
+    void numbersAndBooleansAreNotInterchangeable() {
+        assertTrue(valid("[[[1], \"foo\"], [[true], \"foo\"]]"), "nested 1 and true are unique");
+        assertTrue(valid("[[[0], \"foo\"], [[false], \"foo\"]]"), "nested 0 and false are unique");
+        assertTrue(valid("[1, true]"));
+        assertTrue(valid("[0, false]"));
+    }
+
+    @Test
+    void numbersAndTheirStringFormAreNotInterchangeable() {
+        assertTrue(valid("[1, \"1\"]"));
+    }
+
+    // The rule applies wherever the number sits, not only at the top level.
+    @Test
+    void nestedNumbersFollowTheSameRule() {
+        assertFalse(valid("[{\"a\": 1}, {\"a\": 1.0}]"), "nested 1 and 1.0 are the same");
+        assertFalse(valid("[[1], [1.0]]"), "1 and 1.0 inside arrays are the same");
+        assertTrue(valid("[{\"a\": 1}, {\"a\": 2}]"));
+    }
+}

--- a/src/test/java/com/networknt/schema/UniqueItemsNumericEqualityTest.java
+++ b/src/test/java/com/networknt/schema/UniqueItemsNumericEqualityTest.java
@@ -5,6 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import com.networknt.schema.serialization.NodeReader;
+
+import tools.jackson.core.json.JsonReadFeature;
+import tools.jackson.databind.json.JsonMapper;
+
 /**
  * uniqueItems compares numbers by mathematical value, so 1 and 1.0 are the same
  * item. Comparison went through JsonNode equality, which is type-sensitive:
@@ -70,5 +75,30 @@ class UniqueItemsNumericEqualityTest {
         assertFalse(valid("[{\"a\": 1}, {\"a\": 1.0}]"), "nested 1 and 1.0 are the same");
         assertFalse(valid("[[1], [1.0]]"), "1 and 1.0 inside arrays are the same");
         assertTrue(valid("[{\"a\": 1}, {\"a\": 2}]"));
+    }
+
+    /**
+     * NaN, Infinity and -Infinity are not JSON numbers, but a mapper can be
+     * configured to read them. BigDecimal cannot represent them, so they have to
+     * stay out of the numeric comparison; they keep comparing as nodes, which is
+     * what every item did before numbers were folded by value.
+     */
+    @Test
+    void nonFiniteNumbersDoNotFailValidation() {
+        Schema schema = SchemaRegistry
+                .withDefaultDialect(SpecificationVersion.DRAFT_2020_12,
+                        builder -> builder.nodeReader(NodeReader.builder()
+                                .jsonMapper(JsonMapper.builder()
+                                        .enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).build())
+                                .build()))
+                .getSchema("{\"type\":\"array\",\"uniqueItems\":true}");
+
+        assertTrue(schema.validate("[NaN, 1]", InputFormat.JSON).isEmpty());
+        assertTrue(schema.validate("[Infinity, -Infinity]", InputFormat.JSON).isEmpty());
+        assertTrue(schema.validate("[NaN, 1.0, 2]", InputFormat.JSON).isEmpty());
+        assertFalse(schema.validate("[NaN, NaN]", InputFormat.JSON).isEmpty(),
+                "non-finite numbers still compare as nodes");
+        assertFalse(schema.validate("[Infinity, 1, 1.0]", InputFormat.JSON).isEmpty(),
+                "finite numbers next to a non-finite one are still folded by value");
     }
 }


### PR DESCRIPTION
## The bug

`UniqueItemsValidator` puts each item into a `HashSet<JsonNode>` and relies on `JsonNode` equality, which is type-sensitive — `IntNode(1)` does not equal `DoubleNode(1.0)`. Two mathematically equal numbers written differently are therefore accepted as distinct items.

```json
schema:   {"type": "array", "uniqueItems": true}
instance: [1, 1.0]          -> currently valid, should be invalid
instance: [1, 1.00]         -> currently valid, should be invalid
instance: [10000000000, 1.0e10] -> currently valid, should be invalid
```

The spec is explicit that numbers compare by mathematical value.

## Why the suite didn't catch it

The official case for this rule is:

```json
["[1.0, 1.0, 1]", "numbers are unique if mathematically unequal", valid: false]
```

That passes **either way**. The two identical decimals are caught first, so an integer is never actually compared against a decimal, and the gap stays hidden. The tests here put the integer next to the decimal directly.

## The change

Items are compared by a derived key rather than by node identity. Numbers reduce to a scale-independent `BigDecimal`, so `1`, `1.0` and `1.00` are one value.

**Only numbers are folded together**, which the suite constrains tightly:

- a number and a boolean stay distinct — `[[[1], "foo"], [[true], "foo"]]` and `[[[0], "foo"], [[false], "foo"]]` are both required to be unique
- a number and its string form stay distinct — `[1, "1"]` is unique

Objects and arrays are walked so the rule holds wherever the number sits (`[{"a":1},{"a":1.0}]` is a duplicate), and map equality ignores property order.

## Tests

`UniqueItemsNumericEqualityTest`, 8 cases: the integer/decimal pairs, differing scales, a large value in exponent form, nesting inside an object and an array, and the number-versus-boolean and number-versus-string cases that must remain unique.

**Four fail against the previous implementation**; the four asserting things stay distinct pass both before and after, so the tests pin the rule rather than the implementation.

Full suite after the change: **8487 tests, 0 failures** — including the complete vendored JSON-Schema-Test-Suite.

Built and tested with JDK 17 and Maven 3.9.9. The file uses CRLF endings and I kept them, so the diff is only the lines I touched.