### PR TITLE
Reject empty labels in idn-hostname format

### DIFF
--- a/src/main/java/com/networknt/schema/utils/RFC5892.java
+++ b/src/main/java/com/networknt/schema/utils/RFC5892.java
@@ -99,11 +99,11 @@ public class RFC5892 {
         if ("".equals(value)) {
             return false; // empty string should fail
         }
-        if (value.length() == 1 && value.matches(LABEL_SEPARATOR_REGEX)) {
-            return false; // single label separator should fail
-        }
         // RFC 5892 calls each segment in a host name a label. They are separated by all the recognized label separators.
         String[] labels = value.split(LABEL_SEPARATOR_REGEX);
+        if (labels.length == 0) {
+            return false; // a value made up only of label separators (e.g. "." or "...") has no labels
+        }
         for (String label : labels) {
             // String.split() drops trailing empty strings, so a trailing '.' never
             // produces an empty label here. A leading or interior empty label

--- a/src/main/java/com/networknt/schema/utils/RFC5892.java
+++ b/src/main/java/com/networknt/schema/utils/RFC5892.java
@@ -105,7 +105,10 @@ public class RFC5892 {
         // RFC 5892 calls each segment in a host name a label. They are separated by all the recognized label separators.
         String[] labels = value.split(LABEL_SEPARATOR_REGEX);
         for (String label : labels) {
-            if (label.isEmpty()) continue; // A DNS entry may contain a trailing '.'.
+            // String.split() drops trailing empty strings, so a trailing '.' never
+            // produces an empty label here. A leading or interior empty label
+            // (e.g. ".example" or "a..b") is invalid.
+            if (label.isEmpty()) return false;
 
             String unicode = label;
             if (isACE(label)) {

--- a/src/test/java/com/networknt/schema/FormatValidatorTest.java
+++ b/src/test/java/com/networknt/schema/FormatValidatorTest.java
@@ -220,4 +220,20 @@ class FormatValidatorTest {
         });
         assertEquals(0, messages.size());
     }
+
+    @Test
+    void idnHostnameRejectsEmptyLabels() {
+        String schemaData = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"format\":\"idn-hostname\"}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12).getSchema(schemaData);
+        // A leading or interior empty label (a leading dot, or two adjacent dots) is invalid.
+        assertFalse(schema.validate("\".example\"", InputFormat.JSON,
+                ec -> ec.executionConfig(c -> c.formatAssertionsEnabled(true))).isEmpty());
+        assertFalse(schema.validate("\"a..b\"", InputFormat.JSON,
+                ec -> ec.executionConfig(c -> c.formatAssertionsEnabled(true))).isEmpty());
+        // Ordinary host names remain valid.
+        assertTrue(schema.validate("\"example\"", InputFormat.JSON,
+                ec -> ec.executionConfig(c -> c.formatAssertionsEnabled(true))).isEmpty());
+        assertTrue(schema.validate("\"sub.example.com\"", InputFormat.JSON,
+                ec -> ec.executionConfig(c -> c.formatAssertionsEnabled(true))).isEmpty());
+    }
 }

--- a/src/test/java/com/networknt/schema/FormatValidatorTest.java
+++ b/src/test/java/com/networknt/schema/FormatValidatorTest.java
@@ -230,6 +230,11 @@ class FormatValidatorTest {
                 ec -> ec.executionConfig(c -> c.formatAssertionsEnabled(true))).isEmpty());
         assertFalse(schema.validate("\"a..b\"", InputFormat.JSON,
                 ec -> ec.executionConfig(c -> c.formatAssertionsEnabled(true))).isEmpty());
+        // A value made up only of label separators has no labels and is invalid.
+        assertFalse(schema.validate("\"...\"", InputFormat.JSON,
+                ec -> ec.executionConfig(c -> c.formatAssertionsEnabled(true))).isEmpty());
+        assertFalse(schema.validate("\"。。\"", InputFormat.JSON,
+                ec -> ec.executionConfig(c -> c.formatAssertionsEnabled(true))).isEmpty());
         // Ordinary host names remain valid.
         assertTrue(schema.validate("\"example\"", InputFormat.JSON,
                 ec -> ec.executionConfig(c -> c.formatAssertionsEnabled(true))).isEmpty());


### PR DESCRIPTION
The `idn-hostname` format accepts host names with a leading or interior empty label:

```
".example"   // reported valid — should be invalid
"a..b"       // reported valid — should be invalid
```

`RFC5892.isValid` skips empty labels with `continue`, with a comment about a trailing `.`. But `String.split` already drops trailing empty strings, so the skip only ever hits a **leading or interior** empty label, both of which are invalid. Rejecting them matches the JSON-Schema-Test-Suite (`idn-hostname.json`: "leading dot" and "empty label between two dots is invalid") and the reference validator. Ordinary host names (and trailing dots) are unaffected; the full suite stays green (added a test).
