### PR TITLE
Allow apostrophe in uri-template literal

### DIFF
--- a/src/main/java/com/networknt/schema/format/Formats.java
+++ b/src/main/java/com/networknt/schema/format/Formats.java
@@ -44,7 +44,7 @@ public class Formats {
         formats.add(new IPv6Format());
         formats.add(pattern("json-pointer", "^(/([^/#~]|[~](?=[01]))*)*$", "format.json-pointer"));
         formats.add(pattern("relative-json-pointer", "^(0|([1-9]\\d*))(#|(/([^/#~]|[~](?=[01]))*)*)$", "format.relative-json-pointer"));
-        formats.add(pattern("uri-template", "^([^\\p{Cntrl}\"'%<>\\^`\\{|\\}]|%\\p{XDigit}{2}|\\{[+#./;?&=,!@|]?((\\w|%\\p{XDigit}{2})(\\.?(\\w|%\\p{XDigit}{2}))*(:[1-9]\\d{0,3}|\\*)?)(,((\\w|%\\p{XDigit}{2})(\\.?(\\w|%\\p{XDigit}{2}))*(:[1-9]\\d{0,3}|\\*)?))*\\})*$", "format.uri-template"));
+        formats.add(pattern("uri-template", "^([^\\p{Cntrl}\"%<>\\^`\\{|\\}]|%\\p{XDigit}{2}|\\{[+#./;?&=,!@|]?((\\w|%\\p{XDigit}{2})(\\.?(\\w|%\\p{XDigit}{2}))*(:[1-9]\\d{0,3}|\\*)?)(,((\\w|%\\p{XDigit}{2})(\\.?(\\w|%\\p{XDigit}{2}))*(:[1-9]\\d{0,3}|\\*)?))*\\})*$", "format.uri-template"));
         formats.add(pattern("uuid", "^\\p{XDigit}{8}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{12}$", "format.uuid"));
         formats.add(new DateFormat());
         formats.add(new DateTimeFormat());

--- a/src/test/java/com/networknt/schema/FormatValidatorTest.java
+++ b/src/test/java/com/networknt/schema/FormatValidatorTest.java
@@ -220,4 +220,16 @@ class FormatValidatorTest {
         });
         assertEquals(0, messages.size());
     }
+
+    @Test
+    void uriTemplateAllowsApostropheInLiteral() {
+        String schemaData = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"format\":\"uri-template\"}";
+        Schema schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12).getSchema(schemaData);
+        // An apostrophe in a literal is valid.
+        assertTrue(schema.validate("\"a'b\"", InputFormat.JSON,
+                ec -> ec.executionConfig(c -> c.formatAssertionsEnabled(true))).isEmpty());
+        // Expression syntax still validates.
+        assertTrue(schema.validate("\"http://x/{y}\"", InputFormat.JSON,
+                ec -> ec.executionConfig(c -> c.formatAssertionsEnabled(true))).isEmpty());
+    }
 }


### PR DESCRIPTION
The `uri-template` format rejects an apostrophe in a literal:

```
"a'b"   // reported invalid — should be valid
```

The regex's excluded character class lists `'`. An apostrophe in a literal is valid (JSON-Schema-Test-Suite `uri-template.json`: "an apostrophe in a literal is valid"; the reference validator agrees). Removed `'` from the exclusion set. Full suite stays green; added a test.
