### PR TITLE
Fix nullable allOf ref type check

### DIFF
--- a/src/main/java/com/networknt/schema/utils/JsonNodeTypes.java
+++ b/src/main/java/com/networknt/schema/utils/JsonNodeTypes.java
@@ -1,5 +1,7 @@
 package com.networknt.schema.utils;
 
+import java.util.Iterator;
+
 import tools.jackson.databind.JsonNode;
 import com.networknt.schema.ExecutionContext;
 import com.networknt.schema.Schema;
@@ -36,12 +38,9 @@ public class JsonNodeTypes {
             }
 
             if (nodeType == JsonType.NULL) {
-                if (parentSchema != null && schemaContext.isNullableKeywordEnabled()) {
-                    Schema grandParentSchema = parentSchema.getParentSchema();
-                    if (grandParentSchema != null && JsonNodeTypes.isNodeNullable(grandParentSchema.getSchemaNode())
-                            || JsonNodeTypes.isNodeNullable(parentSchema.getSchemaNode())) {
-                        return true;
-                    }
+                if (parentSchema != null && schemaContext.isNullableKeywordEnabled()
+                        && isNullableAncestor(parentSchema, executionContext)) {
+                    return true;
                 }
             }
 
@@ -73,6 +72,64 @@ public class JsonNodeTypes {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Determines if the schema owning the failing {@code type} keyword is
+     * nullable, either directly, via its lexical parent, or via a schema that
+     * referenced it through {@code $ref}.
+     * <p>
+     * A schema resolved through {@code $ref} is cached and shared across every
+     * site that references it, so its lexical parent (obtained through
+     * {@link Schema#getParentSchema()}) reflects where it is declared in the
+     * document rather than where it was referenced from. To find a
+     * {@code nullable: true} declared on the referencing schema (for example a
+     * property composed using {@code allOf} containing only a {@code $ref}),
+     * this walks up the dynamic evaluation stack instead, following through any
+     * chain of {@code $ref} schemas.
+     *
+     * @param schema the schema owning the {@code type} keyword
+     * @param executionContext the execution context
+     * @return true if a nullable schema is found
+     */
+    private static boolean isNullableAncestor(Schema schema, ExecutionContext executionContext) {
+        Schema current = schema;
+        while (current != null) {
+            if (isNodeNullable(current.getSchemaNode())) {
+                return true;
+            }
+            Schema parentSchema = current.getParentSchema();
+            if (parentSchema != null && isNodeNullable(parentSchema.getSchemaNode())) {
+                return true;
+            }
+            current = findReferencingSchema(current, executionContext);
+        }
+        return false;
+    }
+
+    /**
+     * Finds the schema that referenced the given schema through {@code $ref}, if
+     * any, by looking at the schema evaluated immediately before it on the
+     * dynamic evaluation stack.
+     *
+     * @param schema the schema that may have been reached through {@code $ref}
+     * @param executionContext the execution context
+     * @return the referencing schema, or null if none is found
+     */
+    private static Schema findReferencingSchema(Schema schema, ExecutionContext executionContext) {
+        Iterator<Schema> ancestors = executionContext.getEvaluationSchema().descendingIterator();
+        while (ancestors.hasNext()) {
+            if (ancestors.next() == schema) {
+                if (ancestors.hasNext()) {
+                    Schema candidate = ancestors.next();
+                    if (candidate.getSchemaNode().get(REF) != null) {
+                        return candidate;
+                    }
+                }
+                return null;
+            }
+        }
+        return null;
     }
 
     private static long detectVersion(SchemaContext schemaContext) {

--- a/src/main/java/com/networknt/schema/utils/JsonNodeTypes.java
+++ b/src/main/java/com/networknt/schema/utils/JsonNodeTypes.java
@@ -87,6 +87,13 @@ public class JsonNodeTypes {
      * property composed using {@code allOf} containing only a {@code $ref}),
      * this walks up the dynamic evaluation stack instead, following through any
      * chain of {@code $ref} schemas.
+     * <p>
+     * A schema found this way is itself a Reference Object (its node contains
+     * {@code $ref}), and per the OpenAPI 3.0 specification any sibling
+     * properties on a Reference Object, including {@code nullable}, must be
+     * ignored. So its own node is never consulted for {@code nullable} — only
+     * its lexical parent, which is the schema actually composing it (for
+     * example the {@code allOf}-owning schema).
      *
      * @param schema the schema owning the {@code type} keyword
      * @param executionContext the execution context
@@ -94,8 +101,9 @@ public class JsonNodeTypes {
      */
     private static boolean isNullableAncestor(Schema schema, ExecutionContext executionContext) {
         Schema current = schema;
+        boolean isRefSchema = false;
         while (current != null) {
-            if (isNodeNullable(current.getSchemaNode())) {
+            if (!isRefSchema && isNodeNullable(current.getSchemaNode())) {
                 return true;
             }
             Schema parentSchema = current.getParentSchema();
@@ -103,6 +111,7 @@ public class JsonNodeTypes {
                 return true;
             }
             current = findReferencingSchema(current, executionContext);
+            isRefSchema = true;
         }
         return false;
     }

--- a/src/test/java/com/networknt/schema/TypeValidatorTest.java
+++ b/src/test/java/com/networknt/schema/TypeValidatorTest.java
@@ -186,6 +186,37 @@ class TypeValidatorTest {
     }
 
     @Test
+    void nullableAllOfRefIgnoredOutsideNullableDialect() {
+        String schemaData = """
+                {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "type": "object",
+                  "required": ["value"],
+                  "properties": {
+                    "value": {
+                      "allOf": [ { "$ref": "#/definitions/Money" } ],
+                      "nullable": true
+                    }
+                  },
+                  "definitions": {
+                    "Money": {
+                      "type": "object",
+                      "required": ["amount"],
+                      "properties": {
+                        "amount": { "type": "integer" }
+                      }
+                    }
+                  }
+                }
+                """;
+        final SchemaRegistry factory = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_7);
+        final Schema validator = factory.getSchema(schemaData);
+
+        final List<Error> errors = validator.validate("{ \"value\": null }", InputFormat.JSON);
+        assertEquals(1, errors.size());
+    }
+
+    @Test
     void integerNonFinite() {
         String schemaData = "{\r\n"
                 + "  \"type\": \"integer\"\r\n"

--- a/src/test/java/com/networknt/schema/oas/OpenApi30Test.java
+++ b/src/test/java/com/networknt/schema/oas/OpenApi30Test.java
@@ -111,4 +111,36 @@ class OpenApi30Test {
         Schema schema = factory.getSchema(schemaData);
         assertFalse(schema.validate("0", InputFormat.JSON, OutputFormat.BOOLEAN));
     }
+
+    @Test
+    void nullableAllOfRef() {
+        String schemaData = """
+                {
+                  "type": "object",
+                  "required": ["value"],
+                  "properties": {
+                    "value": {
+                      "allOf": [ { "$ref": "#/components/schemas/Money" } ],
+                      "nullable": true
+                    }
+                  },
+                  "components": {
+                    "schemas": {
+                      "Money": {
+                        "type": "object",
+                        "required": ["amount"],
+                        "properties": {
+                          "amount": { "type": "integer" }
+                        }
+                      }
+                    }
+                  }
+                }
+                """;
+        SchemaRegistry factory = SchemaRegistry.withDialect(Dialects.getOpenApi30());
+        Schema schema = factory.getSchema(schemaData);
+
+        List<Error> messages = schema.validate("{ \"value\": null }", InputFormat.JSON);
+        assertEquals(0, messages.size());
+    }
 }

--- a/src/test/java/com/networknt/schema/oas/OpenApi30Test.java
+++ b/src/test/java/com/networknt/schema/oas/OpenApi30Test.java
@@ -143,4 +143,44 @@ class OpenApi30Test {
         List<Error> messages = schema.validate("{ \"value\": null }", InputFormat.JSON);
         assertEquals(0, messages.size());
     }
+
+    /**
+     * A {@code nullable: true} declared directly alongside a {@code $ref} is a
+     * sibling property on a Reference Object, which the OpenAPI 3.0
+     * specification requires to be ignored. This must remain rejected even
+     * though {@link #nullableAllOfRef()} accepts the same {@code nullable}
+     * declared alongside an {@code allOf} that composes a {@code $ref}.
+     */
+    @Test
+    void nullableDirectRefSiblingIsIgnored() {
+        String schemaData = """
+                {
+                  "type": "object",
+                  "required": ["value"],
+                  "properties": {
+                    "value": {
+                      "$ref": "#/components/schemas/Money",
+                      "nullable": true
+                    }
+                  },
+                  "components": {
+                    "schemas": {
+                      "Money": {
+                        "type": "object",
+                        "required": ["amount"],
+                        "properties": {
+                          "amount": { "type": "integer" }
+                        }
+                      }
+                    }
+                  }
+                }
+                """;
+        SchemaRegistry factory = SchemaRegistry.withDialect(Dialects.getOpenApi30());
+        Schema schema = factory.getSchema(schemaData);
+
+        List<Error> messages = schema.validate("{ \"value\": null }", InputFormat.JSON);
+        assertEquals(1, messages.size());
+        assertEquals("type", messages.get(0).getKeyword());
+    }
 }


### PR DESCRIPTION
Fixes issue where a nullable (OpenAPI dialect) on an element containing `allOf` isn't honoured when a null value is passed.

Closes #1278 